### PR TITLE
Expose refObjects as a prop in Button components

### DIFF
--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -37,6 +37,8 @@ interface Props {
   type: ButtonType
   /** Test ID for Integration Tests */
   testID: string
+  /** React Ref object */
+  refObject?: RefObject<HTMLButtonElement>
 }
 
 export class ButtonBase extends Component<Props> {
@@ -50,10 +52,16 @@ export class ButtonBase extends Component<Props> {
     testID: ButtonType.Button,
   }
 
-  public ref: RefObject<HTMLButtonElement> = React.createRef()
-
   public render() {
-    const {onClick, titleText, tabIndex, type, testID, children} = this.props
+    const {
+      onClick,
+      titleText,
+      tabIndex,
+      type,
+      testID,
+      children,
+      refObject,
+    } = this.props
 
     return (
       <button
@@ -63,8 +71,8 @@ export class ButtonBase extends Component<Props> {
         title={titleText}
         tabIndex={!!tabIndex ? tabIndex : 0}
         type={type}
-        ref={this.ref}
         data-testid={testID}
+        ref={refObject}
       >
         {children}
       </button>

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -47,6 +47,8 @@ interface Props {
   testID: string
   /** Reverse ordering of text and icon */
   placeIconAfterText: boolean
+  /** React Ref object */
+  refObject?: RefObject<HTMLButtonElement>
 }
 
 export class Button extends Component<Props> {
@@ -61,12 +63,11 @@ export class Button extends Component<Props> {
     placeIconAfterText: false,
   }
 
-  public ref: RefObject<HTMLButtonElement> = React.createRef()
-
   public render() {
     const {
       className,
       titleText,
+      refObject,
       tabIndex,
       onClick,
       testID,
@@ -88,6 +89,7 @@ export class Button extends Component<Props> {
       <ButtonBase
         className={className}
         titleText={titleText || text}
+        refObject={refObject}
         tabIndex={!!tabIndex ? tabIndex : 0}
         onClick={onClick}
         testID={testID}

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -41,6 +41,8 @@ interface Props {
   type: ButtonType
   /** Test ID for Integration Tests */
   testID: string
+  /** React Ref object */
+  refObject?: RefObject<HTMLButtonElement>
 }
 
 export class SquareButton extends Component<Props> {
@@ -59,6 +61,7 @@ export class SquareButton extends Component<Props> {
     const {
       className,
       titleText,
+      refObject,
       tabIndex,
       onClick,
       testID,
@@ -73,6 +76,7 @@ export class SquareButton extends Component<Props> {
       <ButtonBase
         className={className}
         titleText={titleText}
+        refObject={refObject}
         tabIndex={!!tabIndex ? tabIndex : 0}
         onClick={onClick}
         testID={testID}


### PR DESCRIPTION
This was causing an error in InfluxDB. I think we could also extend this pattern and expose `refObject` prop in all components (#111)