### PR TITLE
Add display names to all components

### DIFF
--- a/src/Components/Alerts/Alert.tsx
+++ b/src/Components/Alerts/Alert.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class Alert extends Component<Props> {
+  public static readonly displayName = 'Alert'
+
   public static defaultProps = {
     testID: 'alert',
   }

--- a/src/Components/AppWrapper/AppWrapper.tsx
+++ b/src/Components/AppWrapper/AppWrapper.tsx
@@ -5,6 +5,8 @@ import React, {PureComponent} from 'react'
 import './AppWrapper.scss'
 
 export class AppWrapper extends PureComponent<{}> {
+  public static readonly displayName = 'AppWrapper'
+
   public render() {
     return <div className="clockface--app-wrapper">{this.props.children}</div>
   }

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -39,6 +39,8 @@ interface Props extends StandardProps {
 }
 
 export class ButtonBase extends Component<Props> {
+  public static readonly displayName = 'ButtonBase'
+
   public static defaultProps = {
     color: ComponentColor.Default,
     size: ComponentSize.Small,

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -49,6 +49,8 @@ interface Props extends StandardProps {
 }
 
 export class Button extends Component<Props> {
+  public static readonly displayName = 'Button'
+
   public static defaultProps = {
     color: ComponentColor.Default,
     size: ComponentSize.Small,

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -43,6 +43,8 @@ interface Props extends StandardProps {
 }
 
 export class SquareButton extends Component<Props> {
+  public static readonly displayName = 'SquareButton'
+
   public static defaultProps = {
     color: ComponentColor.Default,
     size: ComponentSize.Small,

--- a/src/Components/ClickOutside/ClickOutside.tsx
+++ b/src/Components/ClickOutside/ClickOutside.tsx
@@ -7,6 +7,8 @@ interface Props {
 }
 
 export class ClickOutside extends PureComponent<Props> {
+  public static readonly displayName = 'ClickOutside'
+
   public componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside, true)
   }

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -45,6 +45,8 @@ interface State {
 }
 
 export class ColorPicker extends Component<Props, State> {
+  public static readonly displayName = 'ColorPicker'
+
   public static defaultProps = {
     colors: influxColors,
     maintainInputFocus: false,

--- a/src/Components/ColorPicker/ColorPickerSwatch.tsx
+++ b/src/Components/ColorPicker/ColorPickerSwatch.tsx
@@ -21,6 +21,8 @@ interface Props extends StandardProps {
 }
 
 export class ColorPickerSwatch extends Component<Props> {
+  public static readonly displayName = 'ColorPicker.Swatch'
+
   public static defaultProps = {
     testID: 'color-picker',
   }

--- a/src/Components/ComponentSpacer/ComponentSpacer.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacer.tsx
@@ -32,6 +32,8 @@ interface Props extends StandardProps {
 }
 
 export class ComponentSpacer extends Component<Props> {
+  public static readonly displayName = 'ComponentSpacer'
+
   public static defaultProps = {
     justifyContent: JustifyContent.FlexStart,
     alignItems: AlignItems.Center,

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -40,6 +40,8 @@ interface Props extends StandardProps {
 }
 
 export class DapperScrollbars extends Component<Props> {
+  public static readonly displayName = 'DapperScrollbars'
+
   public static defaultProps = {
     removeTracksWhenNotUsed: true,
     removeTrackYWhenNotUsed: true,

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -34,6 +34,8 @@ interface State {
 }
 
 export class DraggableResizer extends Component<Props, State> {
+  public static readonly displayName = 'DraggableResizer'
+
   public static Panel = DraggableResizerPanel
 
   public static defaultProps = {

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -26,6 +26,8 @@ interface Props extends StandardProps {
 }
 
 export class DraggableResizerHandle extends PureComponent<Props> {
+  public static readonly displayName = 'DraggableResizer.Handle'
+
   public static defaultProps = {
     dragIndex: 9999,
     dragging: false,

--- a/src/Components/DraggableResizer/DraggableResizerPanel.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerPanel.tsx
@@ -14,6 +14,8 @@ interface Props extends StandardProps {
 }
 
 export class DraggableResizerPanel extends Component<Props> {
+  public static readonly displayName = 'DraggableResizer.Panel'
+
   public static defaultProps = {
     minSizePixels: 0,
     testID: 'draggable-resizer--panel',

--- a/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
@@ -48,6 +48,8 @@ interface Props extends StandardProps {
 }
 
 export class MultiSelectDropdown extends Component<Props> {
+  public static readonly displayName = 'MultiSelectDropdown'
+
   public static defaultProps = {
     emptyText: 'None selected',
     buttonStatus: ComponentStatus.Default,

--- a/src/Components/Dropdowns/Composed/SelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/SelectDropdown.tsx
@@ -46,6 +46,8 @@ interface Props extends StandardProps {
 }
 
 export class SelectDropdown extends Component<Props> {
+  public static readonly displayName = 'SelectDropdown'
+
   public static defaultProps = {
     buttonStatus: ComponentStatus.Default,
     buttonColor: ComponentColor.Default,

--- a/src/Components/Dropdowns/Family/Dropdown.tsx
+++ b/src/Components/Dropdowns/Family/Dropdown.tsx
@@ -35,6 +35,8 @@ interface State {
 }
 
 export class Dropdown extends Component<Props, State> {
+  public static readonly displayName = 'Dropdown'
+
   public static defaultProps = {
     testID: 'dropdown',
   }

--- a/src/Components/Dropdowns/Family/DropdownButton.tsx
+++ b/src/Components/Dropdowns/Family/DropdownButton.tsx
@@ -37,6 +37,8 @@ interface Props extends StandardProps {
 }
 
 export class DropdownButton extends Component<Props> {
+  public static readonly displayName = 'Dropdown.Button'
+
   public static defaultProps = {
     color: ComponentColor.Default,
     size: ComponentSize.Small,

--- a/src/Components/Dropdowns/Family/DropdownDivider.tsx
+++ b/src/Components/Dropdowns/Family/DropdownDivider.tsx
@@ -11,6 +11,8 @@ interface Props extends StandardProps {
 }
 
 export class DropdownDivider extends Component<Props> {
+  public static readonly displayName = 'Dropdown.Divider'
+
   public static defaultProps = {
     testID: 'dropdown-divider',
   }

--- a/src/Components/Dropdowns/Family/DropdownItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownItem.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class DropdownItem extends Component<Props> {
+  public static readonly displayName = 'Dropdown.Item'
+
   public static defaultProps = {
     checkbox: false,
     selected: false,

--- a/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
@@ -15,6 +15,8 @@ interface Props extends StandardProps {
 }
 
 export class DropdownLinkItem extends Component<Props> {
+  public static readonly displayName = 'Dropdown.LinkItem'
+
   public static defaultProps = {
     checkbox: false,
     selected: false,

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -24,6 +24,8 @@ interface Props extends StandardProps {
 }
 
 export class DropdownMenu extends Component<Props> {
+  public static readonly displayName = 'Dropdown.Menu'
+
   public static defaultProps = {
     theme: DropdownMenuTheme.Sapphire,
     testID: 'dropdown-menu',

--- a/src/Components/EmptyState/EmptyState.tsx
+++ b/src/Components/EmptyState/EmptyState.tsx
@@ -18,6 +18,8 @@ interface Props extends StandardProps {
 }
 
 export class EmptyState extends Component<Props> {
+  public static readonly displayName = 'EmptyState'
+
   public static defaultProps = {
     size: ComponentSize.Small,
     testID: 'empty-state',

--- a/src/Components/EmptyState/EmptyStateSubText.tsx
+++ b/src/Components/EmptyState/EmptyStateSubText.tsx
@@ -10,6 +10,8 @@ interface Props extends StandardProps {
 }
 
 export class EmptyStateSubText extends Component<Props> {
+  public static readonly displayName = 'EmptyState.SubText'
+
   public static defaultProps = {
     testID: 'empty-state--sub-text',
   }

--- a/src/Components/EmptyState/EmptyStateText.tsx
+++ b/src/Components/EmptyState/EmptyStateText.tsx
@@ -37,6 +37,8 @@ const highlighter = (
 }
 
 export class EmptyStateText extends Component<Props & StandardProps> {
+  public static readonly displayName = 'EmptyState.Text'
+
   public static defaultProps = {
     testID: 'empty-state--text',
   }

--- a/src/Components/FormLayout/Form.tsx
+++ b/src/Components/FormLayout/Form.tsx
@@ -24,6 +24,8 @@ interface Props extends StandardProps {
 }
 
 export class Form extends Component<Props> {
+  public static readonly displayName = 'Form'
+
   public static defaultProps = {
     testID: 'form-container',
   }

--- a/src/Components/FormLayout/FormBox.tsx
+++ b/src/Components/FormLayout/FormBox.tsx
@@ -7,6 +7,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class FormBox extends Component<Props> {
+  public static readonly displayName = 'Form.Box'
+
   public static defaultProps = {
     className: '',
     testID: 'form--box',

--- a/src/Components/FormLayout/FormDivider.tsx
+++ b/src/Components/FormLayout/FormDivider.tsx
@@ -11,6 +11,8 @@ interface Props extends StandardProps {
 }
 
 export class FormDivider extends Component<Props> {
+  public static readonly displayName = 'Form.Divider'
+
   public static defaultProps = {
     testID: 'form--divider',
   }

--- a/src/Components/FormLayout/FormElement.tsx
+++ b/src/Components/FormLayout/FormElement.tsx
@@ -24,6 +24,8 @@ interface Props extends StandardProps {
 }
 
 export class FormElement extends Component<Props> {
+  public static readonly displayName = 'Form.Element'
+
   public static defaultProps = {
     testID: 'form--element',
   }

--- a/src/Components/FormLayout/FormElementError.tsx
+++ b/src/Components/FormLayout/FormElementError.tsx
@@ -10,6 +10,8 @@ interface Props extends StandardProps {
 }
 
 export class FormElementError extends Component<Props> {
+  public static readonly displayName = 'FormElementError'
+
   public static defaultProps = {
     testID: 'form--element-error',
   }

--- a/src/Components/FormLayout/FormFooter.tsx
+++ b/src/Components/FormLayout/FormFooter.tsx
@@ -25,6 +25,8 @@ interface Props extends StandardProps {
 }
 
 export class FormFooter extends Component<Props> {
+  public static readonly displayName = 'Form.Footer'
+
   public static defaultProps = {
     testID: 'form--footer',
     widthXS: Columns.Twelve,

--- a/src/Components/FormLayout/FormHelpText.tsx
+++ b/src/Components/FormLayout/FormHelpText.tsx
@@ -10,6 +10,8 @@ interface Props extends StandardProps {
 }
 
 export class FormHelpText extends Component<Props> {
+  public static readonly displayName = 'FormHelpText'
+
   public static defaultProps = {
     testID: 'form--help-text',
   }

--- a/src/Components/FormLayout/FormLabel.tsx
+++ b/src/Components/FormLayout/FormLabel.tsx
@@ -12,6 +12,8 @@ interface Props extends StandardProps {
 }
 
 export class FormLabel extends Component<Props> {
+  public static readonly displayName = 'Form.Label'
+
   public static defaultProps = {
     testID: 'form--label',
   }

--- a/src/Components/FormLayout/FormValidationElement.tsx
+++ b/src/Components/FormLayout/FormValidationElement.tsx
@@ -39,6 +39,8 @@ interface State {
 }
 
 export class FormValidationElement extends Component<Props, State> {
+  public static readonly displayName = 'Form.ValidationElement'
+
   public static defaultProps = {
     testID: 'form--validation-element',
   }

--- a/src/Components/GridLayout/Grid.tsx
+++ b/src/Components/GridLayout/Grid.tsx
@@ -15,6 +15,8 @@ import './Grid.scss'
 interface Props extends StandardProps {}
 
 export class Grid extends Component<Props> {
+  public static readonly displayName = 'Grid'
+
   public static defaultProps = {
     testID: 'grid',
   }

--- a/src/Components/GridLayout/GridColumn.tsx
+++ b/src/Components/GridLayout/GridColumn.tsx
@@ -25,6 +25,8 @@ interface Props extends StandardProps {
 }
 
 export class GridColumn extends Component<Props> {
+  public static readonly displayName = 'Grid.Column'
+
   public static defaultProps = {
     testID: 'grid--column',
     widthXS: Columns.Twelve,

--- a/src/Components/GridLayout/GridRow.tsx
+++ b/src/Components/GridLayout/GridRow.tsx
@@ -8,6 +8,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class GridRow extends Component<Props> {
+  public static readonly displayName = 'Grid.Row'
+
   public static defaultProps = {
     testID: 'grid--row',
   }

--- a/src/Components/Icon/Icon.tsx
+++ b/src/Components/Icon/Icon.tsx
@@ -12,6 +12,8 @@ interface Props extends StandardProps {
 }
 
 export class Icon extends Component<Props> {
+  public static readonly displayName = 'Icon'
+
   public static defaultProps = {
     testID: 'icon',
   }

--- a/src/Components/IndexList/IndexList.tsx
+++ b/src/Components/IndexList/IndexList.tsx
@@ -17,6 +17,8 @@ import './IndexList.scss'
 interface Props extends StandardProps {}
 
 export class IndexList extends Component<Props> {
+  public static readonly displayName = 'IndexList'
+
   public static Body = IndexListBody
   public static Header = IndexListHeader
   public static HeaderCell = IndexListHeaderCell

--- a/src/Components/IndexList/IndexListBody.tsx
+++ b/src/Components/IndexList/IndexListBody.tsx
@@ -12,6 +12,8 @@ interface Props extends StandardProps {
 }
 
 export class IndexListBody extends Component<Props> {
+  public static readonly displayName = 'IndexList.Body'
+
   public static defaultProps = {
     testID: 'index-list--body',
   }

--- a/src/Components/IndexList/IndexListHeader.tsx
+++ b/src/Components/IndexList/IndexListHeader.tsx
@@ -7,6 +7,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class IndexListHeader extends Component<Props> {
+  public static readonly displayName = 'IndexList.Header'
+
   public static defaultProps = {
     testID: 'index-list--header',
   }

--- a/src/Components/IndexList/IndexListHeaderCell.tsx
+++ b/src/Components/IndexList/IndexListHeaderCell.tsx
@@ -23,6 +23,8 @@ export interface IndexHeaderCellProps {
 type Props = IndexHeaderCellProps & StandardProps
 
 export class IndexListHeaderCell extends Component<Props> {
+  public static readonly displayName = 'IndexList.HeaderCell'
+
   public static defaultProps = {
     columnName: '',
     alignment: Alignment.Left,

--- a/src/Components/IndexList/IndexListRow.tsx
+++ b/src/Components/IndexList/IndexListRow.tsx
@@ -11,6 +11,8 @@ interface Props extends StandardProps {
 }
 
 export class IndexListRow extends Component<Props> {
+  public static readonly displayName = 'IndexList.Row'
+
   public static defaultProps = {
     disabled: false,
     testID: 'table-row',

--- a/src/Components/IndexList/IndexListRowCell.tsx
+++ b/src/Components/IndexList/IndexListRowCell.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class IndexListRowCell extends Component<Props> {
+  public static readonly displayName = 'IndexList.Cell'
+
   public static defaultProps = {
     alignment: Alignment.Left,
     revealOnHover: false,

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -84,6 +84,8 @@ interface Props extends StandardProps {
 }
 
 export class Input extends Component<Props> {
+  public static readonly displayName = 'Input'
+
   public static defaultProps = {
     type: InputType.Text,
     name: '',

--- a/src/Components/Inputs/TextArea.tsx
+++ b/src/Components/Inputs/TextArea.tsx
@@ -74,6 +74,8 @@ interface Props extends StandardProps {
 }
 
 export class TextArea extends Component<Props> {
+  public static readonly displayName = 'TextArea'
+
   public static defaultProps = {
     autocomplete: AutoComplete.Off,
     autoFocus: false,

--- a/src/Components/Label/Label.tsx
+++ b/src/Components/Label/Label.tsx
@@ -35,6 +35,8 @@ interface State {
 }
 
 export class Label extends Component<Props, State> {
+  public static readonly displayName = 'Label'
+
   public static defaultProps = {
     size: ComponentSize.ExtraSmall,
     testID: 'label--pill',

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class NavMenu extends PureComponent<Props> {
+  public static readonly displayName = 'NavMenu'
+
   public static defaultProps = {
     testID: 'nav-menu',
   }

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -15,6 +15,8 @@ interface Props extends StandardProps {
 }
 
 export class NavMenuItem extends PureComponent<Props> {
+  public static readonly displayName = 'NavMenu.Item'
+
   public static defaultProps = {
     testID: 'nav-menu--item',
   }

--- a/src/Components/NavMenu/NavMenuSubItem.tsx
+++ b/src/Components/NavMenu/NavMenuSubItem.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class NavMenuSubItem extends PureComponent<Props> {
+  public static readonly displayName = 'NavMenu.SubItem'
+
   public static defaultProps = {
     testID: 'nav-menu--link-item',
   }

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -32,6 +32,8 @@ interface State {
 }
 
 export class Overlay extends Component<Props, State> {
+  public static readonly displayName = 'Overlay'
+
   public static Container = OverlayContainer
   public static Mask = OverlayMask
   public static Header = OverlayHeader

--- a/src/Components/Overlay/OverlayBody.tsx
+++ b/src/Components/Overlay/OverlayBody.tsx
@@ -8,6 +8,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class OverlayBody extends PureComponent<Props> {
+  public static readonly displayName = 'Overlay.Body'
+
   public static defaultProps = {
     testID: 'overlay--body',
   }

--- a/src/Components/Overlay/OverlayContainer.tsx
+++ b/src/Components/Overlay/OverlayContainer.tsx
@@ -11,6 +11,8 @@ interface Props extends StandardProps {
 }
 
 export class OverlayContainer extends PureComponent<Props> {
+  public static readonly displayName = 'Overlay.Container'
+
   public static defaultProps = {
     maxWidth: 800,
     testID: 'overlay--container',

--- a/src/Components/Overlay/OverlayFooter.tsx
+++ b/src/Components/Overlay/OverlayFooter.tsx
@@ -17,6 +17,8 @@ import {
 interface Props extends StandardProps {}
 
 export class OverlayFooter extends PureComponent<Props> {
+  public static readonly displayName = 'Overlay.Footer'
+
   public static defaultProps = {
     testID: 'overlay--footer',
   }

--- a/src/Components/Overlay/OverlayHeader.tsx
+++ b/src/Components/Overlay/OverlayHeader.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class OverlayHeader extends PureComponent<Props> {
+  public static readonly displayName = 'Overlay.Header'
+
   public static defaultProps = {
     testID: 'overlay--header',
   }

--- a/src/Components/Overlay/OverlayMask.tsx
+++ b/src/Components/Overlay/OverlayMask.tsx
@@ -16,6 +16,8 @@ interface Props extends StandardProps {
 }
 
 export class OverlayMask extends PureComponent<Props> {
+  public static readonly displayName = 'Overlay.Mask'
+
   public static defaultProps = {
     gradient: Gradients.GundamPilot,
     testID: 'overlay--mask',

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class Page extends Component<Props> {
+  public static readonly displayName = 'Page'
+
   public static defaultProps = {
     testID: 'page',
   }

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -18,6 +18,8 @@ interface Props extends StandardProps {
 }
 
 export class PageContents extends Component<Props> {
+  public static readonly displayName = 'Page.Contents'
+
   public static defaultProps = {
     fullHeight: false,
     scrollable: false,

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class PageHeader extends Component<Props> {
+  public static readonly displayName = 'Page.Header'
+
   public static defaultProps = {
     hide: false,
     testID: 'page-header',

--- a/src/Components/Page/PageHeaderCenter.tsx
+++ b/src/Components/Page/PageHeaderCenter.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderCenter extends Component<Props> {
+  public static readonly displayName = 'Page.Header.Center'
+
   public static defaultProps = {
     widthPixels: DEFAULT_PAGE_HEADER_CENTER_WIDTH,
     testID: 'page-header--center',

--- a/src/Components/Page/PageHeaderLeft.tsx
+++ b/src/Components/Page/PageHeaderLeft.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderLeft extends Component<Props> {
+  public static readonly displayName = 'Page.Header.Left'
+
   public static defaultProps = {
     offsetPixels: DEFAULT_OFFSET,
     testID: 'page-header--left',

--- a/src/Components/Page/PageHeaderRight.tsx
+++ b/src/Components/Page/PageHeaderRight.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderRight extends Component<Props> {
+  public static readonly displayName = 'Page.Header.Right'
+
   public static defaultProps = {
     offsetPixels: DEFAULT_OFFSET,
     testID: 'page-header--right',

--- a/src/Components/Page/PageTitle.tsx
+++ b/src/Components/Page/PageTitle.tsx
@@ -12,6 +12,8 @@ interface Props extends StandardProps {
 }
 
 export class PageTitle extends PureComponent<Props> {
+  public static readonly displayName = 'Page.Title'
+
   public static defaultProps = {
     testID: 'page-title',
   }

--- a/src/Components/Panel/Panel.tsx
+++ b/src/Components/Panel/Panel.tsx
@@ -33,6 +33,8 @@ interface Props extends StandardProps {
 }
 
 export class Panel extends Component<Props> {
+  public static readonly displayName = 'Panel'
+
   public static defaultProps = {
     size: ComponentSize.Small,
     testID: 'panel',

--- a/src/Components/Panel/PanelBody.tsx
+++ b/src/Components/Panel/PanelBody.tsx
@@ -8,6 +8,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class PanelBody extends Component<Props> {
+  public static readonly displayName = 'Panel.Body'
+
   public static defaultProps = {
     testID: 'panel--body',
   }

--- a/src/Components/Panel/PanelFooter.tsx
+++ b/src/Components/Panel/PanelFooter.tsx
@@ -8,6 +8,8 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class PanelFooter extends Component<Props> {
+  public static readonly displayName = 'Panel.Footer'
+
   public static defaultProps = {
     testID: 'panel--footer',
   }

--- a/src/Components/Panel/PanelHeader.tsx
+++ b/src/Components/Panel/PanelHeader.tsx
@@ -19,6 +19,8 @@ interface Props extends StandardProps {
 }
 
 export class PanelHeader extends Component<Props> {
+  public static readonly displayName = 'Panel.Header'
+
   public static defaultProps = {
     testID: 'panel--header',
   }

--- a/src/Components/Radio/Radio.tsx
+++ b/src/Components/Radio/Radio.tsx
@@ -26,6 +26,8 @@ interface Props extends StandardProps {
 }
 
 export class Radio extends Component<Props> {
+  public static readonly displayName = 'Radio'
+
   public static defaultProps = {
     color: ComponentColor.Primary,
     size: ComponentSize.Small,

--- a/src/Components/Radio/RadioButton.tsx
+++ b/src/Components/Radio/RadioButton.tsx
@@ -23,6 +23,8 @@ interface Props extends StandardProps {
 }
 
 export class RadioButton extends Component<Props> {
+  public static readonly displayName = 'Radio.Button'
+
   public static defaultProps = {
     disabled: false,
     disabledTitleText: 'This option is disabled',

--- a/src/Components/SlideToggle/SlideToggle.tsx
+++ b/src/Components/SlideToggle/SlideToggle.tsx
@@ -27,6 +27,8 @@ interface Props extends StandardProps {
 }
 
 export class SlideToggle extends Component<Props> {
+  public static readonly displayName = 'SlideToggle'
+
   public static Label = SlideToggleLabel
 
   public static defaultProps = {

--- a/src/Components/SlideToggle/SlideToggleLabel.tsx
+++ b/src/Components/SlideToggle/SlideToggleLabel.tsx
@@ -15,6 +15,8 @@ interface Props extends StandardProps {
 }
 
 export class SlideToggleLabel extends Component<Props> {
+  public static readonly displayName = 'SlideToggle.Label'
+
   public static defaultProps = {
     active: true,
     size: ComponentSize.Small,

--- a/src/Components/Spinners/SparkleSpinner.tsx
+++ b/src/Components/Spinners/SparkleSpinner.tsx
@@ -16,6 +16,8 @@ interface Props extends StandardProps {
 }
 
 export class SparkleSpinner extends PureComponent<Props> {
+  public static readonly displayName = 'SparkleSpinner'
+
   public static defaultProps = {
     loading: RemoteDataState.NotStarted,
     testID: 'sparkle-spinner',

--- a/src/Components/Spinners/SpinnerContainer.tsx
+++ b/src/Components/Spinners/SpinnerContainer.tsx
@@ -16,6 +16,8 @@ interface Props extends StandardProps {
 }
 
 export class SpinnerContainer extends Component<Props> {
+  public static readonly displayName = 'SpinnerContainer'
+
   public static defaultProps = {
     testID: 'spinner-container',
   }

--- a/src/Components/Spinners/TechnoSpinner.tsx
+++ b/src/Components/Spinners/TechnoSpinner.tsx
@@ -15,6 +15,8 @@ interface Props extends StandardProps {
 }
 
 export class TechnoSpinner extends Component<Props> {
+  public static readonly displayName = 'TechnoSpinner'
+
   public static defaultProps: Props = {
     diameterPixels: 100,
     strokeWidth: ComponentSize.Small,

--- a/src/Components/WaitingText/WaitingText.tsx
+++ b/src/Components/WaitingText/WaitingText.tsx
@@ -13,6 +13,8 @@ interface Props extends StandardProps {
 }
 
 export class WaitingText extends Component<Props> {
+  public static readonly displayName = 'WaitingText'
+
   public static defaultProps = {
     testID: 'waiting-text',
   }


### PR DESCRIPTION
Closes #77

Rather than messing with minification I have used react's `displayName` property to ensure components are displayed correctly in the react inspector regardless of minification 