### PR TITLE
Add ID to standard props and remove . from displayNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 0.0.16
 
+- [#161](https://github.com/influxdata/clockface/pull/161): Remove `.` from all `displayName` properties
+- [#161](https://github.com/influxdata/clockface/pull/161): Add `id` to all components via `StandardProps`
 - [#159](https://github.com/influxdata/clockface/pull/159): Port `ResourceList` and `ResourceCard` component families from InfluxDB
 - [#157](https://github.com/influxdata/clockface/pull/157): Add display names to all components so they are legible despite minification in the React inspector
 - [#155](https://github.com/influxdata/clockface/pull/155): Add markdown documentation for `Radio` component family

--- a/src/Components/Alerts/Alert.tsx
+++ b/src/Components/Alerts/Alert.tsx
@@ -26,10 +26,10 @@ export class Alert extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, icon} = this.props
+    const {testID, children, icon, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {!!icon && <Icon glyph={icon} className="alert--icon" />}
         <div className="alert--contents">{children}</div>
       </div>

--- a/src/Components/AppWrapper/AppWrapper.tsx
+++ b/src/Components/AppWrapper/AppWrapper.tsx
@@ -1,13 +1,35 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import classnames from 'classnames'
 
 // Styles
 import './AppWrapper.scss'
 
-export class AppWrapper extends PureComponent<{}> {
+// Types
+import {StandardProps} from '../../Types'
+
+interface Props extends StandardProps {}
+
+export class AppWrapper extends PureComponent<Props> {
   public static readonly displayName = 'AppWrapper'
 
+  public static defaultProps = {
+    testID: 'app-wrapper',
+  }
+
   public render() {
-    return <div className="clockface--app-wrapper">{this.props.children}</div>
+    const {children, testID, id} = this.props
+
+    return (
+      <div className={this.className} data-testid={testID} id={id}>
+        {children}
+      </div>
+    )
+  }
+
+  private get className(): string {
+    const {className} = this.props
+
+    return classnames('clockface--app-wrapper', {[`${className}`]: className})
   }
 }

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -60,6 +60,7 @@ export class ButtonBase extends Component<Props> {
       testID,
       children,
       refObject,
+      id,
     } = this.props
 
     return (
@@ -71,6 +72,7 @@ export class ButtonBase extends Component<Props> {
         tabIndex={!!tabIndex ? tabIndex : 0}
         type={type}
         data-testid={testID}
+        id={id}
         ref={refObject}
       >
         {children}

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -78,6 +78,7 @@ export class Button extends Component<Props> {
       type,
       icon,
       size,
+      id,
     } = this.props
 
     if (!icon && !text) {
@@ -98,6 +99,7 @@ export class Button extends Component<Props> {
         shape={shape}
         type={type}
         size={size}
+        id={id}
       >
         {this.iconAndText}
         {this.statusIndicator}

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -69,6 +69,7 @@ export class SquareButton extends Component<Props> {
       color,
       type,
       size,
+      id,
     } = this.props
 
     return (
@@ -85,6 +86,7 @@ export class SquareButton extends Component<Props> {
         shape={ButtonShape.Square}
         type={type}
         size={size}
+        id={id}
       >
         {this.icon}
         {this.statusIndicator}

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -69,10 +69,11 @@ export class ColorPicker extends Component<Props, State> {
       color,
       colors,
       swatchesPerRow,
+      id,
     } = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         <div className="color-picker--swatches">
           {colors &&
             colors.map((color, i) => (

--- a/src/Components/ColorPicker/ColorPickerSwatch.tsx
+++ b/src/Components/ColorPicker/ColorPickerSwatch.tsx
@@ -21,14 +21,14 @@ interface Props extends StandardProps {
 }
 
 export class ColorPickerSwatch extends Component<Props> {
-  public static readonly displayName = 'ColorPicker.Swatch'
+  public static readonly displayName = 'ColorPickerSwatch'
 
   public static defaultProps = {
     testID: 'color-picker',
   }
 
   render() {
-    const {name, hex, testID} = this.props
+    const {name, hex, testID, id} = this.props
 
     return (
       <div
@@ -37,6 +37,7 @@ export class ColorPickerSwatch extends Component<Props> {
         onClick={this.handleClick}
         data-testid={`${testID}--swatch`}
         style={this.style}
+        id={id}
       >
         <span style={{backgroundColor: hex}} />
       </div>

--- a/src/Components/ComponentSpacer/ComponentSpacer.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacer.tsx
@@ -54,6 +54,7 @@ export class ComponentSpacer extends Component<Props> {
       margin,
       testID,
       style,
+      id,
     } = this.props
 
     return (
@@ -69,6 +70,7 @@ export class ComponentSpacer extends Component<Props> {
         })}
         data-testid={testID}
         style={style}
+        id={id}
       >
         {children}
       </div>

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -74,6 +74,7 @@ export class DapperScrollbars extends Component<Props> {
       children,
       testID,
       style,
+      id,
     } = this.props
 
     const classname = classnames('dapper-scrollbars', {
@@ -108,6 +109,7 @@ export class DapperScrollbars extends Component<Props> {
           style: this.thumbYStyle,
           className: 'dapper-scrollbars--thumb-y',
         }}
+        id={id}
       >
         {children}
       </Scrollbar>

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -5,7 +5,9 @@ import classnames from 'classnames'
 // Components
 import {DraggableResizerPanel} from './DraggableResizerPanel'
 import {DraggableResizerHandle} from './DraggableResizerHandle'
-import {Orientation, Gradients} from '../../Types'
+
+// Types
+import {StandardProps, Orientation, Gradients} from '../../Types'
 
 // Styles
 import './DraggableResizer.scss'
@@ -13,7 +15,7 @@ import './DraggableResizer.scss'
 // Constants
 const NULL_DRAG = -1
 
-interface Props {
+interface Props extends StandardProps {
   /** Orientation the draggable panels stack in */
   handleOrientation: Orientation
   /** Expects and array of numbers between 0 - 1 */
@@ -22,10 +24,6 @@ interface Props {
   onChangePositions: (positions: number[]) => void
   /** Gradient theme for handle */
   handleGradient: Gradients
-  /** Test ID for Integration Tests */
-  testID: string
-  /** Class name for custom styles */
-  className?: string
 }
 
 interface State {
@@ -63,13 +61,14 @@ export class DraggableResizer extends Component<Props, State> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
       <div
         className={this.className}
         ref={this.containerRef}
         data-testid={testID}
+        id={id}
       >
         {this.children}
       </div>

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -9,8 +9,6 @@ import {Gradients, Orientation, StandardProps} from '../../Types'
 import {getColorsFromGradient} from '../../Constants/colors'
 
 interface Props extends StandardProps {
-  /** Unique identifier used to update the size of this handle */
-  id: string
   /** Expects a number between 0 - 1 */
   position: number
   /** Gets passed a function by being a child of DraggableResizer */
@@ -26,7 +24,7 @@ interface Props extends StandardProps {
 }
 
 export class DraggableResizerHandle extends PureComponent<Props> {
-  public static readonly displayName = 'DraggableResizer.Handle'
+  public static readonly displayName = 'DraggableResizerHandle'
 
   public static defaultProps = {
     dragIndex: 9999,
@@ -35,7 +33,7 @@ export class DraggableResizerHandle extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
       <div
@@ -43,6 +41,7 @@ export class DraggableResizerHandle extends PureComponent<Props> {
         onMouseDown={this.handleMouseDown}
         title="Drag to resize"
         data-testid={testID}
+        id={id}
       >
         <div
           className="draggable-resizer--gradient"

--- a/src/Components/DraggableResizer/DraggableResizerPanel.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerPanel.tsx
@@ -14,7 +14,7 @@ interface Props extends StandardProps {
 }
 
 export class DraggableResizerPanel extends Component<Props> {
-  public static readonly displayName = 'DraggableResizer.Panel'
+  public static readonly displayName = 'DraggableResizerPanel'
 
   public static defaultProps = {
     minSizePixels: 0,
@@ -22,10 +22,15 @@ export class DraggableResizerPanel extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} style={this.style} data-testid={testID}>
+      <div
+        className={this.className}
+        style={this.style}
+        data-testid={testID}
+        id={id}
+      >
         {children}
       </div>
     )

--- a/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
@@ -61,6 +61,7 @@ export class MultiSelectDropdown extends Component<Props> {
 
   public render() {
     const {
+      id,
       testID,
       menuTheme,
       className,
@@ -74,6 +75,7 @@ export class MultiSelectDropdown extends Component<Props> {
 
     return (
       <Dropdown
+        id={id}
         testID={testID}
         className={className}
         widthPixels={widthPixels}

--- a/src/Components/Dropdowns/Composed/SelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/SelectDropdown.tsx
@@ -58,6 +58,7 @@ export class SelectDropdown extends Component<Props> {
 
   public render() {
     const {
+      id,
       testID,
       menuTheme,
       className,
@@ -72,6 +73,7 @@ export class SelectDropdown extends Component<Props> {
 
     return (
       <Dropdown
+        id={id}
         testID={testID}
         widthPixels={widthPixels}
         className={className}

--- a/src/Components/Dropdowns/Family/Dropdown.tsx
+++ b/src/Components/Dropdowns/Family/Dropdown.tsx
@@ -11,10 +11,13 @@ import {DropdownDivider} from './../Family/DropdownDivider'
 import {DropdownMenu} from './../Family/DropdownMenu'
 import {ClickOutside} from '../../ClickOutside/ClickOutside'
 
+// Types
+import {StandardProps} from '../../../Types'
+
 // Styles
 import '../Dropdown.scss'
 
-interface Props {
+interface Props extends StandardProps {
   /** Component to render as the button (use Dropdown.Button) */
   button: (
     active: boolean,
@@ -24,10 +27,6 @@ interface Props {
   menu: (onCollapse?: () => void) => JSX.Element
   /** Width of the dropdown in pixels, if blank the dropdown will expand to fill its parent's width */
   widthPixels?: number
-  /** Class name for custom styles */
-  className?: string
-  /** Test ID for Integration Tests */
-  testID: string
 }
 
 interface State {
@@ -56,13 +55,18 @@ export class Dropdown extends Component<Props, State> {
   }
 
   public render() {
-    const {widthPixels, button, testID} = this.props
+    const {widthPixels, button, testID, id} = this.props
     const {expanded} = this.state
     const width = widthPixels ? `${widthPixels}px` : '100%'
 
     return (
       <ClickOutside onClickOutside={this.collapseMenu}>
-        <div className={this.className} style={{width}} data-testid={testID}>
+        <div
+          className={this.className}
+          style={{width}}
+          data-testid={testID}
+          id={id}
+        >
           {button(expanded, this.toggleMenu)}
           <div className="dropdown--menu-container">{this.menu}</div>
         </div>

--- a/src/Components/Dropdowns/Family/DropdownButton.tsx
+++ b/src/Components/Dropdowns/Family/DropdownButton.tsx
@@ -37,7 +37,7 @@ interface Props extends StandardProps {
 }
 
 export class DropdownButton extends Component<Props> {
-  public static readonly displayName = 'Dropdown.Button'
+  public static readonly displayName = 'DropdownButton'
 
   public static defaultProps = {
     color: ComponentColor.Default,
@@ -57,6 +57,7 @@ export class DropdownButton extends Component<Props> {
       active,
       size,
       color,
+      id,
     } = this.props
     return (
       <ButtonBase
@@ -70,6 +71,7 @@ export class DropdownButton extends Component<Props> {
         active={active}
         color={color}
         size={size}
+        id={id}
       >
         {!!icon && <Icon glyph={icon} className="dropdown--icon" />}
         <span className="dropdown--selected">{children}</span>

--- a/src/Components/Dropdowns/Family/DropdownDivider.tsx
+++ b/src/Components/Dropdowns/Family/DropdownDivider.tsx
@@ -11,14 +11,14 @@ interface Props extends StandardProps {
 }
 
 export class DropdownDivider extends Component<Props> {
-  public static readonly displayName = 'Dropdown.Divider'
+  public static readonly displayName = 'DropdownDivider'
 
   public static defaultProps = {
     testID: 'dropdown-divider',
   }
 
   public render() {
-    const {text, testID, className} = this.props
+    const {text, testID, className, id} = this.props
 
     return (
       <div
@@ -27,6 +27,7 @@ export class DropdownDivider extends Component<Props> {
           [`${className}`]: className,
         })}
         data-testid={testID}
+        id={id}
       >
         {text}
       </div>

--- a/src/Components/Dropdowns/Family/DropdownItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownItem.tsx
@@ -19,7 +19,7 @@ interface Props extends StandardProps {
 }
 
 export class DropdownItem extends Component<Props> {
-  public static readonly displayName = 'Dropdown.Item'
+  public static readonly displayName = 'DropdownItem'
 
   public static defaultProps = {
     checkbox: false,
@@ -30,13 +30,14 @@ export class DropdownItem extends Component<Props> {
   }
 
   public render(): JSX.Element {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
       <div
         className={this.className}
         data-testid={testID}
         onClick={this.handleClick}
+        id={id}
       >
         {this.selectionIndicator}
         {this.childElements}

--- a/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
@@ -15,7 +15,7 @@ interface Props extends StandardProps {
 }
 
 export class DropdownLinkItem extends Component<Props> {
-  public static readonly displayName = 'Dropdown.LinkItem'
+  public static readonly displayName = 'DropdownLinkItem'
 
   public static defaultProps = {
     checkbox: false,
@@ -26,10 +26,10 @@ export class DropdownLinkItem extends Component<Props> {
   }
 
   public render(): JSX.Element {
-    const {testID, children} = this.props
+    const {testID, children, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.selectionIndicator}
         {children}
       </div>

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -24,7 +24,7 @@ interface Props extends StandardProps {
 }
 
 export class DropdownMenu extends Component<Props> {
-  public static readonly displayName = 'Dropdown.Menu'
+  public static readonly displayName = 'DropdownMenu'
 
   public static defaultProps = {
     theme: DropdownMenuTheme.Sapphire,
@@ -42,6 +42,7 @@ export class DropdownMenu extends Component<Props> {
       noScrollX,
       noScrollY,
       onCollapse,
+      id,
     } = this.props
 
     const {thumbStartColor, thumbStopColor} = this.thumbColorsFromTheme
@@ -66,7 +67,7 @@ export class DropdownMenu extends Component<Props> {
           noScrollX={noScrollX}
           noScrollY={noScrollY}
         >
-          <div className="dropdown-menu--contents" data-testid={testID}>
+          <div className="dropdown-menu--contents" data-testid={testID} id={id}>
             {children}
           </div>
         </DapperScrollbars>

--- a/src/Components/EmptyState/EmptyState.tsx
+++ b/src/Components/EmptyState/EmptyState.tsx
@@ -29,10 +29,10 @@ export class EmptyState extends Component<Props> {
   public static SubText = EmptyStateSubText
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/EmptyState/EmptyStateSubText.tsx
+++ b/src/Components/EmptyState/EmptyStateSubText.tsx
@@ -10,17 +10,17 @@ interface Props extends StandardProps {
 }
 
 export class EmptyStateSubText extends Component<Props> {
-  public static readonly displayName = 'EmptyState.SubText'
+  public static readonly displayName = 'EmptyStateSubText'
 
   public static defaultProps = {
     testID: 'empty-state--sub-text',
   }
 
   render() {
-    const {text, testID} = this.props
+    const {text, testID, id} = this.props
 
     return (
-      <p className={this.className} data-testid={testID}>
+      <p className={this.className} data-testid={testID} id={id}>
         {text}
       </p>
     )

--- a/src/Components/EmptyState/EmptyStateText.tsx
+++ b/src/Components/EmptyState/EmptyStateText.tsx
@@ -37,17 +37,17 @@ const highlighter = (
 }
 
 export class EmptyStateText extends Component<Props & StandardProps> {
-  public static readonly displayName = 'EmptyState.Text'
+  public static readonly displayName = 'EmptyStateText'
 
   public static defaultProps = {
     testID: 'empty-state--text',
   }
 
   render() {
-    const {text, highlightWords, testID} = this.props
+    const {text, highlightWords, testID, id} = this.props
 
     return (
-      <h4 className={this.className} data-testid={testID}>
+      <h4 className={this.className} data-testid={testID} id={id}>
         {highlighter(text, highlightWords)}
       </h4>
     )

--- a/src/Components/FormLayout/Form.tsx
+++ b/src/Components/FormLayout/Form.tsx
@@ -38,7 +38,7 @@ export class Form extends Component<Props> {
   public static Box = FormBox
 
   public render() {
-    const {children, style, testID} = this.props
+    const {children, style, testID, id} = this.props
 
     return (
       <form
@@ -46,6 +46,7 @@ export class Form extends Component<Props> {
         className={this.formWrapperClass}
         onSubmit={this.handleSubmit}
         data-testid={testID}
+        id={id}
       >
         {children}
       </form>

--- a/src/Components/FormLayout/FormBox.tsx
+++ b/src/Components/FormLayout/FormBox.tsx
@@ -7,7 +7,7 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class FormBox extends Component<Props> {
-  public static readonly displayName = 'Form.Box'
+  public static readonly displayName = 'FormBox'
 
   public static defaultProps = {
     className: '',
@@ -15,10 +15,10 @@ export class FormBox extends Component<Props> {
   }
 
   public render() {
-    const {children, className, testID} = this.props
+    const {children, className, testID, id} = this.props
 
     return (
-      <div className={`form--box ${className}`} data-testid={testID}>
+      <div className={`form--box ${className}`} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/FormLayout/FormDivider.tsx
+++ b/src/Components/FormLayout/FormDivider.tsx
@@ -11,17 +11,22 @@ interface Props extends StandardProps {
 }
 
 export class FormDivider extends Component<Props> {
-  public static readonly displayName = 'Form.Divider'
+  public static readonly displayName = 'FormDivider'
 
   public static defaultProps = {
     testID: 'form--divider',
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} style={this.style} />
+      <div
+        className={this.className}
+        data-testid={testID}
+        style={this.style}
+        id={id}
+      />
     )
   }
 

--- a/src/Components/FormLayout/FormElement.tsx
+++ b/src/Components/FormLayout/FormElement.tsx
@@ -24,17 +24,17 @@ interface Props extends StandardProps {
 }
 
 export class FormElement extends Component<Props> {
-  public static readonly displayName = 'Form.Element'
+  public static readonly displayName = 'FormElement'
 
   public static defaultProps = {
     testID: 'form--element',
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.label}
         {children}
         {this.errorMessage}

--- a/src/Components/FormLayout/FormElementError.tsx
+++ b/src/Components/FormLayout/FormElementError.tsx
@@ -17,9 +17,10 @@ export class FormElementError extends Component<Props> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
+
     return (
-      <span className={this.className} data-testid={testID}>
+      <span className={this.className} data-testid={testID} id={id}>
         {this.message}
       </span>
     )

--- a/src/Components/FormLayout/FormFooter.tsx
+++ b/src/Components/FormLayout/FormFooter.tsx
@@ -25,7 +25,7 @@ interface Props extends StandardProps {
 }
 
 export class FormFooter extends Component<Props> {
-  public static readonly displayName = 'Form.Footer'
+  public static readonly displayName = 'FormFooter'
 
   public static defaultProps = {
     testID: 'form--footer',
@@ -33,10 +33,10 @@ export class FormFooter extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/FormLayout/FormHelpText.tsx
+++ b/src/Components/FormLayout/FormHelpText.tsx
@@ -17,10 +17,10 @@ export class FormHelpText extends Component<Props> {
   }
 
   public render() {
-    const {text, testID} = this.props
+    const {text, testID, id} = this.props
 
     return (
-      <span className={this.className} data-testid={testID}>
+      <span className={this.className} data-testid={testID} id={id}>
         {text}
       </span>
     )

--- a/src/Components/FormLayout/FormLabel.tsx
+++ b/src/Components/FormLayout/FormLabel.tsx
@@ -12,17 +12,17 @@ interface Props extends StandardProps {
 }
 
 export class FormLabel extends Component<Props> {
-  public static readonly displayName = 'Form.Label'
+  public static readonly displayName = 'FormLabel'
 
   public static defaultProps = {
     testID: 'form--label',
   }
 
   public render() {
-    const {label, children, testID} = this.props
+    const {label, children, testID, id} = this.props
 
     return (
-      <label className={this.className} data-testid={testID}>
+      <label className={this.className} data-testid={testID} id={id}>
         <span>
           {label}
           {this.requiredIndicator}

--- a/src/Components/FormLayout/FormValidationElement.tsx
+++ b/src/Components/FormLayout/FormValidationElement.tsx
@@ -8,9 +8,9 @@ import {FormElementError} from './FormElementError'
 import {FormHelpText} from './FormHelpText'
 
 // Types
-import {ComponentStatus} from '../../Types'
+import {StandardProps, ComponentStatus} from '../../Types'
 
-interface Props {
+interface Props extends StandardProps {
   /** Child components */
   children: (status: ComponentStatus) => React.ReactNode
   /** Function used for validation check */
@@ -27,10 +27,6 @@ interface Props {
   helpText?: string
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
-  /** Test ID for Integration Tests */
-  testID: string
-  /** Class name for custom styles */
-  className?: string
 }
 
 interface State {
@@ -39,7 +35,7 @@ interface State {
 }
 
 export class FormValidationElement extends Component<Props, State> {
-  public static readonly displayName = 'Form.ValidationElement'
+  public static readonly displayName = 'FormValidationElement'
 
   public static defaultProps = {
     testID: 'form--validation-element',
@@ -73,10 +69,10 @@ export class FormValidationElement extends Component<Props, State> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.label}
         {this.children}
         {this.errorMessage}

--- a/src/Components/GridLayout/Grid.tsx
+++ b/src/Components/GridLayout/Grid.tsx
@@ -25,9 +25,10 @@ export class Grid extends Component<Props> {
   public static Column = GridColumn
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
+
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/GridLayout/GridColumn.tsx
+++ b/src/Components/GridLayout/GridColumn.tsx
@@ -25,7 +25,7 @@ interface Props extends StandardProps {
 }
 
 export class GridColumn extends Component<Props> {
-  public static readonly displayName = 'Grid.Column'
+  public static readonly displayName = 'GridColumn'
 
   public static defaultProps = {
     testID: 'grid--column',
@@ -33,10 +33,10 @@ export class GridColumn extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/GridLayout/GridRow.tsx
+++ b/src/Components/GridLayout/GridRow.tsx
@@ -8,17 +8,17 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class GridRow extends Component<Props> {
-  public static readonly displayName = 'Grid.Row'
+  public static readonly displayName = 'GridRow'
 
   public static defaultProps = {
     testID: 'grid--row',
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Icon/Icon.tsx
+++ b/src/Components/Icon/Icon.tsx
@@ -19,14 +19,19 @@ export class Icon extends Component<Props> {
   }
 
   render() {
-    const {glyph, testID} = this.props
+    const {glyph, testID, id} = this.props
 
     const className = this.props.className
       ? `icon ${glyph} ${this.props.className}`
       : `icon ${glyph}`
 
     return (
-      <span className={className} data-testid={testID} style={this.style} />
+      <span
+        className={className}
+        data-testid={testID}
+        style={this.style}
+        id={id}
+      />
     )
   }
 

--- a/src/Components/IndexList/IndexList.tsx
+++ b/src/Components/IndexList/IndexList.tsx
@@ -30,10 +30,10 @@ export class IndexList extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <table className={this.className} data-testid={testID}>
+      <table className={this.className} data-testid={testID} id={id}>
         {children}
       </table>
     )

--- a/src/Components/IndexList/IndexListBody.tsx
+++ b/src/Components/IndexList/IndexListBody.tsx
@@ -12,18 +12,18 @@ interface Props extends StandardProps {
 }
 
 export class IndexListBody extends Component<Props> {
-  public static readonly displayName = 'IndexList.Body'
+  public static readonly displayName = 'IndexListBody'
 
   public static defaultProps = {
     testID: 'index-list--body',
   }
 
   public render() {
-    const {children, columnCount, emptyState, testID} = this.props
+    const {children, columnCount, emptyState, testID, id} = this.props
 
     if (React.Children.count(children)) {
       return (
-        <tbody className={this.className} data-testid={testID}>
+        <tbody className={this.className} data-testid={testID} id={id}>
           {children}
         </tbody>
       )

--- a/src/Components/IndexList/IndexListHeader.tsx
+++ b/src/Components/IndexList/IndexListHeader.tsx
@@ -7,17 +7,17 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class IndexListHeader extends Component<Props> {
-  public static readonly displayName = 'IndexList.Header'
+  public static readonly displayName = 'IndexListHeader'
 
   public static defaultProps = {
     testID: 'index-list--header',
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <thead className={this.className} data-testid={testID}>
+      <thead className={this.className} data-testid={testID} id={id}>
         <tr>{children}</tr>
       </thead>
     )

--- a/src/Components/IndexList/IndexListHeaderCell.tsx
+++ b/src/Components/IndexList/IndexListHeaderCell.tsx
@@ -23,7 +23,7 @@ export interface IndexHeaderCellProps {
 type Props = IndexHeaderCellProps & StandardProps
 
 export class IndexListHeaderCell extends Component<Props> {
-  public static readonly displayName = 'IndexList.HeaderCell'
+  public static readonly displayName = 'IndexListHeaderCell'
 
   public static defaultProps = {
     columnName: '',
@@ -32,7 +32,7 @@ export class IndexListHeaderCell extends Component<Props> {
   }
 
   public render() {
-    const {columnName, width, testID} = this.props
+    const {columnName, width, testID, id} = this.props
 
     return (
       <th
@@ -40,6 +40,7 @@ export class IndexListHeaderCell extends Component<Props> {
         style={{width}}
         onClick={this.handleClick}
         data-testid={testID}
+        id={id}
       >
         {columnName}
         {this.sortIndicator}

--- a/src/Components/IndexList/IndexListRow.tsx
+++ b/src/Components/IndexList/IndexListRow.tsx
@@ -11,7 +11,7 @@ interface Props extends StandardProps {
 }
 
 export class IndexListRow extends Component<Props> {
-  public static readonly displayName = 'IndexList.Row'
+  public static readonly displayName = 'IndexListRow'
 
   public static defaultProps = {
     disabled: false,
@@ -19,10 +19,10 @@ export class IndexListRow extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <tr data-testid={testID} className={this.className}>
+      <tr data-testid={testID} className={this.className} id={id}>
         {children}
       </tr>
     )

--- a/src/Components/IndexList/IndexListRowCell.tsx
+++ b/src/Components/IndexList/IndexListRowCell.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class IndexListRowCell extends Component<Props> {
-  public static readonly displayName = 'IndexList.Cell'
+  public static readonly displayName = 'IndexListCell'
 
   public static defaultProps = {
     alignment: Alignment.Left,
@@ -22,11 +22,11 @@ export class IndexListRowCell extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
       <td className={this.className}>
-        <div className="index-list--cell" data-testid={testID}>
+        <div className="index-list--cell" data-testid={testID} id={id}>
           {children}
         </div>
       </td>

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -31,8 +31,6 @@ export enum InputType {
 }
 
 interface Props extends StandardProps {
-  /** Unique text field ID */
-  id?: string
   /** Minimum value for number type */
   min?: number
   /** Maximum value for number type */

--- a/src/Components/Inputs/TextArea.tsx
+++ b/src/Components/Inputs/TextArea.tsx
@@ -115,6 +115,7 @@ export class TextArea extends Component<Props> {
       onKeyUp,
       onKeyDown,
       testID,
+      id,
     } = this.props
 
     return (
@@ -143,6 +144,7 @@ export class TextArea extends Component<Props> {
           onKeyDown={onKeyDown}
           onChange={this.handleChange}
           data-testid={testID}
+          id={id}
         />
       </div>
     )

--- a/src/Components/Label/Label.tsx
+++ b/src/Components/Label/Label.tsx
@@ -47,7 +47,7 @@ export class Label extends Component<Props, State> {
   }
 
   public render() {
-    const {name, testID} = this.props
+    const {name, testID, id} = this.props
 
     return (
       <div
@@ -56,6 +56,7 @@ export class Label extends Component<Props, State> {
         onMouseLeave={this.handleMouseLeave}
         style={this.style}
         title={this.title}
+        id={id}
       >
         <span
           className="label--name"

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -33,7 +33,7 @@ export class NavMenu extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID, hide} = this.props
+    const {children, testID, hide, id} = this.props
 
     if (hide) {
       return
@@ -44,7 +44,7 @@ export class NavMenu extends PureComponent<Props> {
     })
 
     return (
-      <nav className={className} data-testid={testID}>
+      <nav className={className} data-testid={testID} id={id}>
         {children}
       </nav>
     )

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -15,7 +15,7 @@ interface Props extends StandardProps {
 }
 
 export class NavMenuItem extends PureComponent<Props> {
-  public static readonly displayName = 'NavMenu.Item'
+  public static readonly displayName = 'NavMenuItem'
 
   public static defaultProps = {
     testID: 'nav-menu--item',
@@ -29,6 +29,7 @@ export class NavMenuItem extends PureComponent<Props> {
       className,
       titleLink,
       iconLink,
+      id,
     } = this.props
 
     return (
@@ -38,6 +39,7 @@ export class NavMenuItem extends PureComponent<Props> {
           [`${className}`]: className,
         })}
         data-testid={testID}
+        id={id}
       >
         {iconLink('nav--item-icon')}
         <div className="nav--item-menu">

--- a/src/Components/NavMenu/NavMenuSubItem.tsx
+++ b/src/Components/NavMenu/NavMenuSubItem.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class NavMenuSubItem extends PureComponent<Props> {
-  public static readonly displayName = 'NavMenu.SubItem'
+  public static readonly displayName = 'NavMenuSubItem'
 
   public static defaultProps = {
     testID: 'nav-menu--link-item',

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -11,18 +11,14 @@ import {OverlayFooter} from './OverlayFooter'
 import {DapperScrollbars} from '../DapperScrollbars/DapperScrollbars'
 
 // Types
-import {InfluxColors} from '../../Types'
+import {StandardProps, InfluxColors} from '../../Types'
 
 // Styles
 import './Overlay.scss'
 
-interface Props {
+interface Props extends StandardProps {
   /** Controls showing/hiding the overlay */
   visible: boolean
-  /** Class name for custom styles */
-  className?: string
-  /** Test ID for Integration Tests */
-  testID: string
   /** Will replace the mask element with a custom element, useful for customizing the mask appearance */
   renderMaskElement: JSX.Element
 }
@@ -71,7 +67,7 @@ export class Overlay extends Component<Props, State> {
   }
 
   public render() {
-    const {testID, renderMaskElement} = this.props
+    const {testID, renderMaskElement, id} = this.props
 
     return (
       <DapperScrollbars
@@ -80,6 +76,7 @@ export class Overlay extends Component<Props, State> {
         thumbStopColor={InfluxColors.Moonstone}
         autoHide={false}
         testID={testID}
+        id={id}
       >
         {this.childContainer}
         {renderMaskElement}

--- a/src/Components/Overlay/OverlayBody.tsx
+++ b/src/Components/Overlay/OverlayBody.tsx
@@ -8,19 +8,19 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class OverlayBody extends PureComponent<Props> {
-  public static readonly displayName = 'Overlay.Body'
+  public static readonly displayName = 'OverlayBody'
 
   public static defaultProps = {
     testID: 'overlay--body',
   }
 
   public render() {
-    const {children, className, testID} = this.props
+    const {children, className, testID, id} = this.props
 
     const classname = classnames('overlay--body', {[`${className}`]: className})
 
     return (
-      <div className={classname} data-testid={testID}>
+      <div className={classname} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Overlay/OverlayContainer.tsx
+++ b/src/Components/Overlay/OverlayContainer.tsx
@@ -11,7 +11,7 @@ interface Props extends StandardProps {
 }
 
 export class OverlayContainer extends PureComponent<Props> {
-  public static readonly displayName = 'Overlay.Container'
+  public static readonly displayName = 'OverlayContainer'
 
   public static defaultProps = {
     maxWidth: 800,
@@ -19,7 +19,7 @@ export class OverlayContainer extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, className, testID} = this.props
+    const {children, className, testID, id} = this.props
 
     return (
       <div
@@ -28,6 +28,7 @@ export class OverlayContainer extends PureComponent<Props> {
         })}
         data-testid={testID}
         style={this.style}
+        id={id}
       >
         {children}
       </div>

--- a/src/Components/Overlay/OverlayFooter.tsx
+++ b/src/Components/Overlay/OverlayFooter.tsx
@@ -17,21 +17,21 @@ import {
 interface Props extends StandardProps {}
 
 export class OverlayFooter extends PureComponent<Props> {
-  public static readonly displayName = 'Overlay.Footer'
+  public static readonly displayName = 'OverlayFooter'
 
   public static defaultProps = {
     testID: 'overlay--footer',
   }
 
   public render() {
-    const {children, className, testID} = this.props
+    const {children, className, testID, id} = this.props
 
     const classname = classnames('overlay--footer', {
       [`${className}`]: className,
     })
 
     return (
-      <div className={classname} data-testid={testID}>
+      <div className={classname} data-testid={testID} id={id}>
         <ComponentSpacer
           margin={ComponentSize.Small}
           direction={FlexDirection.Row}

--- a/src/Components/Overlay/OverlayHeader.tsx
+++ b/src/Components/Overlay/OverlayHeader.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class OverlayHeader extends PureComponent<Props> {
-  public static readonly displayName = 'Overlay.Header'
+  public static readonly displayName = 'OverlayHeader'
 
   public static defaultProps = {
     testID: 'overlay--header',
@@ -24,14 +24,14 @@ export class OverlayHeader extends PureComponent<Props> {
   }
 
   public render() {
-    const {title, onDismiss, children, testID, className} = this.props
+    const {title, onDismiss, children, testID, className, id} = this.props
 
     const classname = classnames('overlay--header', {
       [`${className}`]: className,
     })
 
     return (
-      <div className={classname} data-testid={testID}>
+      <div className={classname} data-testid={testID} id={id}>
         <div className="overlay--title">{title}</div>
         {onDismiss && (
           <button

--- a/src/Components/Overlay/OverlayMask.tsx
+++ b/src/Components/Overlay/OverlayMask.tsx
@@ -16,7 +16,7 @@ interface Props extends StandardProps {
 }
 
 export class OverlayMask extends PureComponent<Props> {
-  public static readonly displayName = 'Overlay.Mask'
+  public static readonly displayName = 'OverlayMask'
 
   public static defaultProps = {
     gradient: Gradients.GundamPilot,
@@ -24,12 +24,17 @@ export class OverlayMask extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID, className} = this.props
+    const {testID, className, id} = this.props
 
     const classname = classnames('overlay--mask', {[`${className}`]: className})
 
     return (
-      <div className={classname} data-testid={testID} style={this.styles} />
+      <div
+        className={classname}
+        data-testid={testID}
+        style={this.styles}
+        id={id}
+      />
     )
   }
 

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -44,10 +44,10 @@ export class Page extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -18,7 +18,7 @@ interface Props extends StandardProps {
 }
 
 export class PageContents extends Component<Props> {
-  public static readonly displayName = 'Page.Contents'
+  public static readonly displayName = 'PageContents'
 
   public static defaultProps = {
     fullHeight: false,
@@ -27,7 +27,7 @@ export class PageContents extends Component<Props> {
   }
 
   public render() {
-    const {scrollable, testID} = this.props
+    const {scrollable, testID, id} = this.props
 
     if (scrollable) {
       return (
@@ -35,6 +35,7 @@ export class PageContents extends Component<Props> {
           className={this.className}
           autoHide={false}
           testID={testID}
+          id={id}
         >
           <div className="page-contents--padding">{this.children}</div>
         </DapperScrollbars>

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -19,7 +19,7 @@ interface Props extends StandardProps {
 }
 
 export class PageHeader extends Component<Props> {
-  public static readonly displayName = 'Page.Header'
+  public static readonly displayName = 'PageHeader'
 
   public static defaultProps = {
     hide: false,
@@ -31,14 +31,14 @@ export class PageHeader extends Component<Props> {
   public static Right = PageHeaderRight
 
   public render() {
-    const {hide, testID} = this.props
+    const {hide, testID, id} = this.props
 
     if (hide) {
       return null
     }
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         <div className="page-header--container">
           {this.childrenWithCorrectWidths}
         </div>

--- a/src/Components/Page/PageHeaderCenter.tsx
+++ b/src/Components/Page/PageHeaderCenter.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderCenter extends Component<Props> {
-  public static readonly displayName = 'Page.Header.Center'
+  public static readonly displayName = 'PageHeaderCenter'
 
   public static defaultProps = {
     widthPixels: DEFAULT_PAGE_HEADER_CENTER_WIDTH,
@@ -21,10 +21,15 @@ export class PageHeaderCenter extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} style={this.style} data-testid={testID}>
+      <div
+        className={this.className}
+        style={this.style}
+        data-testid={testID}
+        id={id}
+      >
         {children}
       </div>
     )

--- a/src/Components/Page/PageHeaderLeft.tsx
+++ b/src/Components/Page/PageHeaderLeft.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderLeft extends Component<Props> {
-  public static readonly displayName = 'Page.Header.Left'
+  public static readonly displayName = 'PageHeaderLeft'
 
   public static defaultProps = {
     offsetPixels: DEFAULT_OFFSET,
@@ -21,10 +21,15 @@ export class PageHeaderLeft extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} style={this.style} data-testid={testID}>
+      <div
+        className={this.className}
+        style={this.style}
+        data-testid={testID}
+        id={id}
+      >
         {children}
       </div>
     )

--- a/src/Components/Page/PageHeaderRight.tsx
+++ b/src/Components/Page/PageHeaderRight.tsx
@@ -13,7 +13,7 @@ interface Props extends StandardProps {
 }
 
 export class PageHeaderRight extends Component<Props> {
-  public static readonly displayName = 'Page.Header.Right'
+  public static readonly displayName = 'PageHeaderRight'
 
   public static defaultProps = {
     offsetPixels: DEFAULT_OFFSET,
@@ -21,10 +21,15 @@ export class PageHeaderRight extends Component<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} style={this.style} data-testid={testID}>
+      <div
+        className={this.className}
+        style={this.style}
+        data-testid={testID}
+        id={id}
+      >
         {children}
       </div>
     )

--- a/src/Components/Page/PageTitle.tsx
+++ b/src/Components/Page/PageTitle.tsx
@@ -12,17 +12,22 @@ interface Props extends StandardProps {
 }
 
 export class PageTitle extends PureComponent<Props> {
-  public static readonly displayName = 'Page.Title'
+  public static readonly displayName = 'PageTitle'
 
   public static defaultProps = {
     testID: 'page-title',
   }
 
   public render() {
-    const {title, altText, testID} = this.props
+    const {title, altText, testID, id} = this.props
 
     return (
-      <h1 className={this.className} title={altText} data-testid={testID}>
+      <h1
+        className={this.className}
+        title={altText}
+        data-testid={testID}
+        id={id}
+      >
         {title}
       </h1>
     )

--- a/src/Components/Panel/Panel.tsx
+++ b/src/Components/Panel/Panel.tsx
@@ -46,7 +46,7 @@ export class Panel extends Component<Props> {
   public static Footer = PanelFooter
 
   public render() {
-    const {children, className, gradient, size, testID} = this.props
+    const {children, className, gradient, size, testID, id} = this.props
 
     return (
       <div
@@ -57,6 +57,7 @@ export class Panel extends Component<Props> {
         })}
         style={this.style}
         data-testid={testID}
+        id={id}
       >
         {children}
       </div>

--- a/src/Components/Panel/PanelBody.tsx
+++ b/src/Components/Panel/PanelBody.tsx
@@ -8,17 +8,17 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class PanelBody extends Component<Props> {
-  public static readonly displayName = 'Panel.Body'
+  public static readonly displayName = 'PanelBody'
 
   public static defaultProps = {
     testID: 'panel--body',
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Panel/PanelFooter.tsx
+++ b/src/Components/Panel/PanelFooter.tsx
@@ -8,17 +8,17 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {}
 
 export class PanelFooter extends Component<Props> {
-  public static readonly displayName = 'Panel.Footer'
+  public static readonly displayName = 'PanelFooter'
 
   public static defaultProps = {
     testID: 'panel--footer',
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Panel/PanelHeader.tsx
+++ b/src/Components/Panel/PanelHeader.tsx
@@ -19,17 +19,17 @@ interface Props extends StandardProps {
 }
 
 export class PanelHeader extends Component<Props> {
-  public static readonly displayName = 'Panel.Header'
+  public static readonly displayName = 'PanelHeader'
 
   public static defaultProps = {
     testID: 'panel--header',
   }
 
   public render() {
-    const {children, title, testID} = this.props
+    const {children, title, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         <div className="panel--title">{title}</div>
         <div className="panel--controls">
           <ComponentSpacer

--- a/src/Components/Radio/Radio.tsx
+++ b/src/Components/Radio/Radio.tsx
@@ -38,10 +38,10 @@ export class Radio extends Component<Props> {
   public static Button = RadioButton
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.containerClassName} data-testid={testID}>
+      <div className={this.containerClassName} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/Radio/RadioButton.tsx
+++ b/src/Components/Radio/RadioButton.tsx
@@ -6,8 +6,6 @@ import classnames from 'classnames'
 import {StandardProps} from '../../Types'
 
 interface Props extends StandardProps {
-  /** id for individual radio button */
-  id: string
   /** Toggles radio button active state */
   active: boolean
   /** Input value of the selected radio button */
@@ -23,7 +21,7 @@ interface Props extends StandardProps {
 }
 
 export class RadioButton extends Component<Props> {
-  public static readonly displayName = 'Radio.Button'
+  public static readonly displayName = 'RadioButton'
 
   public static defaultProps = {
     disabled: false,
@@ -32,7 +30,7 @@ export class RadioButton extends Component<Props> {
   }
 
   public render() {
-    const {children, disabled, testID} = this.props
+    const {children, disabled, testID, id} = this.props
 
     return (
       <button
@@ -42,6 +40,7 @@ export class RadioButton extends Component<Props> {
         onClick={this.handleClick}
         title={this.title}
         data-testid={testID}
+        id={id}
       >
         {children}
       </button>

--- a/src/Components/ResourceList/Card/ResourceCard.tsx
+++ b/src/Components/ResourceList/Card/ResourceCard.tsx
@@ -42,10 +42,10 @@ export class ResourceCard extends PureComponent<Props> {
   public static Description = ResourceCardDescription
 
   public render() {
-    const {description, labels, children, testID, name} = this.props
+    const {description, labels, children, testID, name, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.toggle}
         <div className="resource-card--contents">
           <div className="resource-card--row">{name}</div>

--- a/src/Components/ResourceList/Card/ResourceCardDescription.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardDescription.tsx
@@ -45,12 +45,12 @@ export class ResourceCardDescription extends Component<Props, State> {
   }
 
   public render() {
-    const {description, testID} = this.props
+    const {description, testID, id} = this.props
     const {isEditing} = this.state
 
     if (isEditing) {
       return (
-        <div className={this.className} data-testid={testID}>
+        <div className={this.className} data-testid={testID} id={id}>
           <ClickOutside onClickOutside={this.handleStopEditing}>
             {this.input}
           </ClickOutside>

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -57,10 +57,10 @@ export class ResourceCardEditableName extends Component<Props, State> {
   }
 
   public render() {
-    const {name, noNameString, testID, buttonTestID} = this.props
+    const {name, noNameString, testID, buttonTestID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         <SpinnerContainer
           loading={this.state.loading}
           spinnerComponent={<TechnoSpinner diameterPixels={20} />}

--- a/src/Components/ResourceList/Card/ResourceCardName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardName.tsx
@@ -22,10 +22,10 @@ export class ResourceCardName extends Component<Props> {
   }
 
   public render() {
-    const {name, testID} = this.props
+    const {name, testID, id} = this.props
 
     return (
-      <div className="resource-name" data-testid={testID}>
+      <div className="resource-name" data-testid={testID} id={id}>
         <span className="resource-name--link" onClick={this.handleClick}>
           <span>{name}</span>
         </span>

--- a/src/Components/ResourceList/List/ResourceList.tsx
+++ b/src/Components/ResourceList/List/ResourceList.tsx
@@ -27,10 +27,10 @@ export class ResourceList extends PureComponent<Props> {
   public static Body = ResourceListBody
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/ResourceList/List/ResourceListBody.tsx
+++ b/src/Components/ResourceList/List/ResourceListBody.tsx
@@ -18,10 +18,10 @@ export class ResourceListBody extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.children}
       </div>
     )

--- a/src/Components/ResourceList/List/ResourceListHeader.tsx
+++ b/src/Components/ResourceList/List/ResourceListHeader.tsx
@@ -18,10 +18,10 @@ export class ResourceListHeader extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID} = this.props
+    const {children, testID, id} = this.props
 
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {this.filter}
         <div className="resource-list--sorting">{children}</div>
       </div>

--- a/src/Components/ResourceList/List/ResourceListSorter.tsx
+++ b/src/Components/ResourceList/List/ResourceListSorter.tsx
@@ -24,7 +24,7 @@ export class ResourceListSorter extends PureComponent<Props> {
   }
 
   public render() {
-    const {name, testID} = this.props
+    const {name, testID, id} = this.props
 
     return (
       <div
@@ -32,6 +32,7 @@ export class ResourceListSorter extends PureComponent<Props> {
         onClick={this.handleClick}
         title={this.title}
         data-testid={testID}
+        id={id}
       >
         {name}
         {this.sortIndicator}

--- a/src/Components/SlideToggle/SlideToggle.tsx
+++ b/src/Components/SlideToggle/SlideToggle.tsx
@@ -40,7 +40,7 @@ export class SlideToggle extends Component<Props> {
   }
 
   public render() {
-    const {tooltipText, testID} = this.props
+    const {tooltipText, testID, id} = this.props
 
     return (
       <div
@@ -48,6 +48,7 @@ export class SlideToggle extends Component<Props> {
         onClick={this.handleClick}
         title={tooltipText}
         data-testid={testID}
+        id={id}
       >
         <div className="slide-toggle--knob" />
       </div>

--- a/src/Components/SlideToggle/SlideToggleLabel.tsx
+++ b/src/Components/SlideToggle/SlideToggleLabel.tsx
@@ -15,7 +15,7 @@ interface Props extends StandardProps {
 }
 
 export class SlideToggleLabel extends Component<Props> {
-  public static readonly displayName = 'SlideToggle.Label'
+  public static readonly displayName = 'SlideToggleLabel'
 
   public static defaultProps = {
     active: true,
@@ -24,9 +24,10 @@ export class SlideToggleLabel extends Component<Props> {
   }
 
   public render() {
-    const {text, testID} = this.props
+    const {text, testID, id} = this.props
+
     return (
-      <div className={this.className} data-testid={testID}>
+      <div className={this.className} data-testid={testID} id={id}>
         {text}
       </div>
     )

--- a/src/Components/Spinners/SparkleSpinner.tsx
+++ b/src/Components/Spinners/SparkleSpinner.tsx
@@ -25,7 +25,7 @@ export class SparkleSpinner extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID, sizePixels} = this.props
+    const {testID, sizePixels, id} = this.props
 
     const style = {
       width: `${sizePixels}px`,
@@ -33,7 +33,12 @@ export class SparkleSpinner extends PureComponent<Props> {
     }
 
     return (
-      <div className={this.className} data-testid={testID} style={style}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        style={style}
+        id={id}
+      >
         <svg
           version="1.1"
           id="sparkle_spinner"

--- a/src/Components/Spinners/SpinnerContainer.tsx
+++ b/src/Components/Spinners/SpinnerContainer.tsx
@@ -23,14 +23,14 @@ export class SpinnerContainer extends Component<Props> {
   }
 
   public render() {
-    const {loading, children, spinnerComponent, testID} = this.props
+    const {loading, children, spinnerComponent, testID, id} = this.props
 
     if (
       loading === RemoteDataState.Loading ||
       loading === RemoteDataState.NotStarted
     ) {
       return (
-        <div className={this.className} data-testid={testID}>
+        <div className={this.className} data-testid={testID} id={id}>
           {spinnerComponent}
         </div>
       )

--- a/src/Components/Spinners/TechnoSpinner.tsx
+++ b/src/Components/Spinners/TechnoSpinner.tsx
@@ -24,10 +24,15 @@ export class TechnoSpinner extends Component<Props> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, id} = this.props
 
     return (
-      <div className={this.className} style={this.style} data-testid={testID} />
+      <div
+        className={this.className}
+        style={this.style}
+        data-testid={testID}
+        id={id}
+      />
     )
   }
 

--- a/src/Components/WaitingText/WaitingText.tsx
+++ b/src/Components/WaitingText/WaitingText.tsx
@@ -20,10 +20,14 @@ export class WaitingText extends Component<Props> {
   }
 
   public render() {
-    const {text, className, testID} = this.props
+    const {text, className, testID, id} = this.props
 
     return (
-      <div className={`waiting-text ${className || ''}`} data-testid={testID}>
+      <div
+        className={`waiting-text ${className || ''}`}
+        data-testid={testID}
+        id={id}
+      >
         {text}
       </div>
     )

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -3,6 +3,8 @@ export interface StandardProps {
   className?: string
   /** ID for Integration Tests */
   testID: string
+  /** Unique identifier for getting an element */
+  id?: string
 }
 
 export enum ComponentColor {


### PR DESCRIPTION
Closes #160
Closes #158 

### Changes

- Add `id` to `StandardProps` and implement in all components
- Remove `.` from all `displayName`s in components
- Ensure all components are extending `StandardProps`

### Checklist

- [ ] Change is reflected in documentation
- [x] Added entry to top of `changelog.md` with link to PR
- [ ] Signed CLA
