### PR TITLE
Prefix all CSS Classnames

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -635,7 +635,7 @@ table.two-axis-table {
   flex-wrap: wrap;
   width: 100%;
 
-  .icon {
+  .cf-icon {
     color: $g17-whisper;
     font-size: 4.25em;
     margin-bottom: $cf-marg-c;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.0.17 [Unreleassed]
 
+- [#180](https://github.com/influxdata/clockface/pull/180): Prefix all CSS classnames with `cf-` to avoid conflicts with older version in InfluxDB
 - [#178](https://github.com/influxdata/clockface/pull/178): Add markdown documentation for `Overlay` component family
 - [#170](https://github.com/influxdata/clockface/pull/170): Introduce and document `Table` component family
 - [#169](https://github.com/influxdata/clockface/pull/169): Introduce `DatePicker` and `DateRangePicker` components

--- a/src/Components/Alerts/Alert.scss
+++ b/src/Components/Alerts/Alert.scss
@@ -7,7 +7,7 @@
 
 $alert--icon-padding: $cf-marg-d + $cf-marg-a;
 
-.alert {
+.cf-alert {
   width: 100%;
   border-radius: $cf-radius;
   padding: $cf-border;
@@ -43,19 +43,19 @@ $alert--icon-padding: $cf-marg-d + $cf-marg-a;
   }
 }
 
-.alert--contents {
+.cf-alert--contents {
   width: 100%;
   border-radius: $cf-radius - 1px;
   padding: $cf-marg-b;
   background-color: rgba($g3-castle, 0.85);
 }
 
-.alert--has-icon {
+.cf-alert--has-icon {
   padding-left: $alert--icon-padding;
   position: relative;
 }
 
-.alert--icon {
+.cf-alert--icon {
   position: absolute;
   top: 50%;
   left: $alert--icon-padding / 2;
@@ -75,19 +75,19 @@ $alert--icon-padding: $cf-marg-d + $cf-marg-a;
   @include gradient-h($mainColor, $accentColor);
 }
 
-.alert--default {
+.cf-alert--default {
   @include alertColorModifier($g7-graphite, $g5-pepper, $g13-mist, $g20-white);
 }
 
-.alert--primary {
+.cf-alert--primary {
   @include alertColorModifier($c-ocean, $c-star, $c-hydrogen, $g20-white);
 }
 
-.alert--secondary {
+.cf-alert--secondary {
   @include alertColorModifier($c-comet, $c-star, $c-moonstone, $g20-white);
 }
 
-.alert--success {
+.cf-alert--success {
   @include alertColorModifier(
     $c-rainforest,
     $c-viridian,
@@ -96,11 +96,11 @@ $alert--icon-padding: $cf-marg-d + $cf-marg-a;
   );
 }
 
-.alert--warning {
+.cf-alert--warning {
   @include alertColorModifier($c-pineapple, $c-thunder, $c-sulfur, $g20-white);
 }
 
-.alert--danger {
+.cf-alert--danger {
   @include alertColorModifier(
     $c-dreamsicle,
     $c-curacao,

--- a/src/Components/Alerts/Alert.tsx
+++ b/src/Components/Alerts/Alert.tsx
@@ -30,8 +30,8 @@ export class Alert extends Component<Props> {
 
     return (
       <div className={this.className} data-testid={testID} id={id}>
-        {!!icon && <Icon glyph={icon} className="alert--icon" />}
-        <div className="alert--contents">{children}</div>
+        {!!icon && <Icon glyph={icon} className="cf-alert--icon" />}
+        <div className="cf-alert--contents">{children}</div>
       </div>
     )
   }
@@ -39,9 +39,9 @@ export class Alert extends Component<Props> {
   private get className(): string {
     const {color, icon, className} = this.props
 
-    return classnames('alert', {
-      [`alert--${color}`]: color,
-      'alert--has-icon': icon,
+    return classnames('cf-alert', {
+      [`cf-alert--${color}`]: color,
+      'cf-alert--has-icon': icon,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -91,11 +91,11 @@ export class ButtonBase extends Component<Props> {
   private get className(): string {
     const {color, size, shape, status, active, className} = this.props
 
-    return classnames(`button button-${size} button-${color}`, {
-      'button-square': shape === ButtonShape.Square,
-      'button-stretch': shape === ButtonShape.StretchToFit,
-      'button--loading': status === ComponentStatus.Loading,
-      'button--disabled': status === ComponentStatus.Disabled,
+    return classnames(`cf-button cf-button-${size} cf-button-${color}`, {
+      'cf-button-square': shape === ButtonShape.Square,
+      'cf-button-stretch': shape === ButtonShape.StretchToFit,
+      'cf-button--loading': status === ComponentStatus.Loading,
+      'cf-button--disabled': status === ComponentStatus.Disabled,
       active,
       [`${className}`]: className,
     })

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-.button {
+.cf-button {
   font-weight: 700;
   font-family: $cf-text-font;
   border-style: solid;
@@ -29,7 +29,7 @@
   }
 }
 
-.button-icon {
+.cf-button-icon {
   margin-right: 0.4em;
   margin-left: -0.1em;
   display: inline-block;
@@ -37,7 +37,7 @@
   transform: translateY(-5%);
   pointer-events: none;
 
-  .button--label + & {
+  .cf-button--label + & {
     margin-right: -0.1em;
     margin-left: 0.4em;
   }
@@ -57,26 +57,26 @@
   height: $height;
   line-height: $height - ($cf-border * 2);
 
-  .button-spinner {
+  .cf-button-spinner {
     width: $height * 0.5;
     height: $height * 0.5;
   }
 
-  .button-icon {
+  .cf-button-icon {
     font-size: floor($fontSize * 1.25);
   }
 }
 
-.button-xs {
+.cf-button-xs {
   @include buttonSizeModifier($form-xs-font, $form-xs-padding, $form-xs-height);
 }
-.button-sm {
+.cf-button-sm {
   @include buttonSizeModifier($form-sm-font, $form-sm-padding, $form-sm-height);
 }
-.button-md {
+.cf-button-md {
   @include buttonSizeModifier($form-md-font, $form-md-padding, $form-md-height);
 }
-.button-lg {
+.cf-button-lg {
   @include buttonSizeModifier($form-lg-font, $form-lg-padding, $form-lg-height);
 }
 
@@ -84,25 +84,25 @@
   Shape Modifiers
   ------------------------------------------------------------------------------
 */
-.button-square {
+.cf-button-square {
   padding: 0;
   text-align: center;
 
-  &.button-xs {
+  &.cf-button-xs {
     width: $form-xs-height;
   }
-  &.button-sm {
+  &.cf-button-sm {
     width: $form-sm-height;
   }
-  &.button-md {
+  &.cf-button-md {
     width: $form-md-height;
   }
-  &.button-lg {
+  &.cf-button-lg {
     width: $form-lg-height;
   }
 }
 
-.button-stretch {
+.cf-button-stretch {
   width: 100%;
 }
 
@@ -132,16 +132,16 @@
     box-shadow: 0 0 4px 1px $bg;
   }
 
-  &.button--loading,
-  &.button--loading:hover {
+  &.cf-button--loading,
+  &.cf-button--loading:hover {
     background-color: $bgHover;
     border-color: $bgHover;
     box-shadow: 0 0 0 0;
   }
 
-  &.button--disabled,
-  &.button--disabled:hover,
-  &.button--disabled:focus {
+  &.cf-button--disabled,
+  &.cf-button--disabled:hover,
+  &.cf-button--disabled:focus {
     color: rgba($text, 0.3);
     font-style: italic;
     background-color: mix($bg, $g4-onyx, 25%);
@@ -149,28 +149,28 @@
     box-shadow: none;
   }
 
-  .button-spinner {
+  .cf-button-spinner {
     border-color: rgba($text, 0.25);
     border-top-color: $text;
   }
 }
 
-.button-default {
+.cf-button-default {
   @include buttonColorModifier($g5-pepper, $g6-smoke, $g7-graphite, $g14-chromium, $g18-cloud);
 }
-.button-primary {
+.cf-button-primary {
   @include buttonColorModifier($c-pool, $c-laser, $c-hydrogen, $c-yeti, $g20-white);
 }
-.button-secondary {
+.cf-button-secondary {
   @include buttonColorModifier($c-star, $c-comet, $c-potassium, $c-twilight, $g20-white);
 }
-.button-success {
+.cf-button-success {
   @include buttonColorModifier($c-rainforest, $c-honeydew, $c-wasabi, $c-mint, $g20-white);
 }
-.button-warning {
+.cf-button-warning {
   @include buttonColorModifier($c-pineapple, $c-thunder, $c-daisy, $g20-white, $g20-white);
 }
-.button-danger {
+.cf-button-danger {
   @include buttonColorModifier($c-curacao, $c-dreamsicle, $c-tungsten, $g20-white, $g20-white);
 }
 
@@ -178,12 +178,12 @@
   Loading State
   ------------------------------------------------------------------------------
 */
-.button--loading,
-.button--loading:hover,
-.button--loading:active,
-.button--loading:active:hover,
-.button--loading[disabled],
-.button--loading[disabled]:hover {
+.cf-button--loading,
+.cf-button--loading:hover,
+.cf-button--loading:active,
+.cf-button--loading:active:hover,
+.cf-button--loading[disabled],
+.cf-button--loading[disabled]:hover {
   color: transparent;
   position: relative;
 }
@@ -202,7 +202,7 @@
   }
 }
 
-.button-spinner {
+.cf-button-spinner {
   pointer-events: none;
   border-style: solid;
   border-radius: 50%; 

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -131,7 +131,7 @@ export class Button extends Component<Props> {
     const {icon} = this.props
 
     if (icon) {
-      return <Icon glyph={icon} className="button-icon" />
+      return <Icon glyph={icon} className="cf-button-icon" />
     }
 
     return
@@ -144,14 +144,14 @@ export class Button extends Component<Props> {
       return
     }
 
-    return <span className="button--label">{text}</span>
+    return <span className="cf-button--label">{text}</span>
   }
 
   private get statusIndicator(): JSX.Element | undefined {
     const {status, size} = this.props
 
     if (status === ComponentStatus.Loading) {
-      return <div className={`button-spinner button-spinner--${size}`} />
+      return <div className={`cf-button-spinner cf-button-spinner--${size}`} />
     }
 
     return

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -98,7 +98,7 @@ export class SquareButton extends Component<Props> {
     const {icon} = this.props
 
     if (icon) {
-      return <Icon glyph={icon} className="button-icon" />
+      return <Icon glyph={icon} className="cf-button-icon" />
     }
 
     return null
@@ -108,7 +108,7 @@ export class SquareButton extends Component<Props> {
     const {status, size} = this.props
 
     if (status === ComponentStatus.Loading) {
-      return <div className={`button-spinner button-spinner--${size}`} />
+      return <div className={`cf-button-spinner cf-button-spinner--${size}`} />
     }
 
     return null

--- a/src/Components/ColorPicker/ColorPicker.scss
+++ b/src/Components/ColorPicker/ColorPicker.scss
@@ -7,7 +7,7 @@
 
 $color-picker--margin: 0;
 
-.color-picker {
+.cf-color-picker {
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -15,7 +15,7 @@ $color-picker--margin: 0;
   min-width: 160px;
 }
 
-.color-picker--swatches {
+.cf-color-picker--swatches {
   margin-bottom: $cf-marg-b;
   position: relative;
   padding: $color-picker--margin;
@@ -27,7 +27,7 @@ $color-picker--margin: 0;
   }
 }
 
-.color-picker--swatch {
+.cf-color-picker--swatch {
   width: 10%;
   padding-bottom: 10%;
   position: relative;
@@ -82,13 +82,13 @@ $color-picker--margin: 0;
   }
 }
 
-.color-picker--form {
+.cf-color-picker--form {
   display: flex;
   align-items: center;
   position: relative;
 }
 
-.input.color-picker--input {
+.input.cf-color-picker--input {
   flex: 1 0 0;
   margin-right: $cf-marg-a;
 
@@ -97,7 +97,7 @@ $color-picker--margin: 0;
   }
 }
 
-.color-picker--selected {
+.cf-color-picker--selected {
   pointer-events: none;
   z-index: 2;
   position: absolute;

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -74,7 +74,7 @@ export class ColorPicker extends Component<Props, State> {
 
     return (
       <div className={this.className} data-testid={testID} id={id}>
-        <div className="color-picker--swatches">
+        <div className="cf-color-picker--swatches">
           {colors &&
             colors.map((color, i) => (
               <ColorPickerSwatch
@@ -89,9 +89,9 @@ export class ColorPicker extends Component<Props, State> {
               />
             ))}
         </div>
-        <div className="color-picker--form">
+        <div className="cf-color-picker--form">
           <Input
-            className="color-picker--input"
+            className="cf-color-picker--input"
             placeholder="#000000"
             value={color}
             onChange={this.handleInputChange}
@@ -118,7 +118,7 @@ export class ColorPicker extends Component<Props, State> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('color-picker', {[`${className}`]: className})
+    return classnames('cf-color-picker', {[`${className}`]: className})
   }
 
   private get inputStatus(): ComponentStatus {
@@ -192,7 +192,10 @@ export class ColorPicker extends Component<Props, State> {
 
     if (errorMessage) {
       return (
-        <div className="color-picker--error" data-testid={`${testID}--error`}>
+        <div
+          className="cf-color-picker--error"
+          data-testid={`${testID}--error`}
+        >
           <FormElementError message={errorMessage} />
         </div>
       )
@@ -206,7 +209,7 @@ export class ColorPicker extends Component<Props, State> {
 
     return (
       <div
-        className="color-picker--selected"
+        className="cf-color-picker--selected"
         style={{backgroundColor: color}}
       />
     )

--- a/src/Components/ColorPicker/ColorPickerSwatch.tsx
+++ b/src/Components/ColorPicker/ColorPickerSwatch.tsx
@@ -57,13 +57,13 @@ export class ColorPickerSwatch extends Component<Props> {
   private get className(): string {
     const {className, index, swatchesCount, swatchesPerRow} = this.props
 
-    return classnames('color-picker--swatch', {
+    return classnames('cf-color-picker--swatch', {
       [`${className}`]: className,
-      'color-picker--swatch__top-left': index === 0,
-      'color-picker--swatch__top-right': index === swatchesPerRow - 1,
-      'color-picker--swatch__bottom-left':
+      'cf-color-picker--swatch__top-left': index === 0,
+      'cf-color-picker--swatch__top-right': index === swatchesPerRow - 1,
+      'cf-color-picker--swatch__bottom-left':
         index === swatchesCount - swatchesPerRow,
-      'color-picker--swatch__bottom-right': index === swatchesCount - 1,
+      'cf-color-picker--swatch__bottom-right': index === swatchesCount - 1,
     })
   }
 

--- a/src/Components/ComponentSpacer/ComponentSpacer.scss
+++ b/src/Components/ComponentSpacer/ComponentSpacer.scss
@@ -5,15 +5,15 @@
   ------------------------------------------------------------------------------
 */
 
-.component-spacer {
+.cf-component-spacer {
   display: flex;
   flex-wrap: nowrap;
 
-  &.component-spacer__stretch-w {
+  &.cf-component-spacer__stretch-w {
     width: 100%;
   }
 
-  &.component-spacer__stretch-h {
+  &.cf-component-spacer__stretch-h {
     height: 100%;
   }
 }
@@ -23,16 +23,16 @@
   ------------------------------------------------------------------------------
 */
 
-.component-spacer__row {
+.cf-component-spacer__row {
   flex-direction: row;
 }
-.component-spacer__row-reverse {
+.cf-component-spacer__row-reverse {
   flex-direction: row-reverse;
 }
-.component-spacer__column {
+.cf-component-spacer__column {
   flex-direction: column;
 }
-.component-spacer__column-reverse {
+.cf-component-spacer__column-reverse {
   flex-direction: column-reverse;
 }
 
@@ -41,16 +41,16 @@
   ------------------------------------------------------------------------------
 */
 
-.component-spacer__align-flex-start {
+.cf-component-spacer__align-flex-start {
   align-items: flex-start;
 }
-.component-spacer__align-flex-end {
+.cf-component-spacer__align-flex-end {
   align-items: flex-end;
 }
-.component-spacer__align-center {
+.cf-component-spacer__align-center {
   align-items: center;
 }
-.component-spacer__align-stretch {
+.cf-component-spacer__align-stretch {
   align-items: stretch;
 }
 
@@ -59,19 +59,19 @@
   ------------------------------------------------------------------------------
 */
 
-.component-spacer__justify-flex-start {
+.cf-component-spacer__justify-flex-start {
   justify-content: flex-start;
 }
-.component-spacer__justify-flex-end {
+.cf-component-spacer__justify-flex-end {
   justify-content: flex-end;
 }
-.component-spacer__justify-center {
+.cf-component-spacer__justify-center {
   justify-content: center;
 }
-.component-spacer__justify-space-between {
+.cf-component-spacer__justify-space-between {
   justify-content: space-between;
 }
-.component-spacer__justify-space-around {
+.cf-component-spacer__justify-space-around {
   justify-content: space-around;
 }
 
@@ -82,8 +82,8 @@
 
 @mixin componentSpacerMargins($margin) {
   // ROW
-  &.component-spacer__row {
-    &.component-spacer__justify-flex-start {
+  &.cf-component-spacer__row {
+    &.cf-component-spacer__justify-flex-start {
       > * {
         margin-right: $margin;
   
@@ -92,7 +92,7 @@
         }
       }
     }
-    &.component-spacer__justify-flex-end {
+    &.cf-component-spacer__justify-flex-end {
       > * {
         margin-left: $margin;
   
@@ -101,9 +101,9 @@
         }
       }
     }
-    &.component-spacer__justify-center,
-    &.component-spacer__justify-space-between,
-    &.component-spacer__justify-space-around {
+    &.cf-component-spacer__justify-center,
+    &.cf-component-spacer__justify-space-between,
+    &.cf-component-spacer__justify-space-around {
       > * {
         margin-left: $margin / 2;
         margin-right: $margin / 2;
@@ -119,8 +119,8 @@
     }
   }
   // ROW REVERSE
-  &.component-spacer__row-reverse {
-    &.component-spacer__justify-flex-start {
+  &.cf-component-spacer__row-reverse {
+    &.cf-component-spacer__justify-flex-start {
       > * {
         margin-left: $margin;
   
@@ -129,7 +129,7 @@
         }
       }
     }
-    &.component-spacer__justify-flex-end {
+    &.cf-component-spacer__justify-flex-end {
       > * {
         margin-right: $margin;
   
@@ -138,9 +138,9 @@
         }
       }
     }
-    &.component-spacer__justify-center,
-    &.component-spacer__justify-space-between,
-    &.component-spacer__justify-space-around {
+    &.cf-component-spacer__justify-center,
+    &.cf-component-spacer__justify-space-between,
+    &.cf-component-spacer__justify-space-around {
       > * {
         margin-right: $margin / 2;
         margin-left: $margin / 2;
@@ -156,8 +156,8 @@
     }
   }
   // COLUMN
-  &.component-spacer__column {
-    &.component-spacer__justify-flex-start {
+  &.cf-component-spacer__column {
+    &.cf-component-spacer__justify-flex-start {
       > * {
         margin-bottom: $margin;
   
@@ -166,7 +166,7 @@
         }
       }
     }
-    &.component-spacer__justify-flex-end {
+    &.cf-component-spacer__justify-flex-end {
       > * {
         margin-top: $margin;
   
@@ -175,9 +175,9 @@
         }
       }
     }
-    &.component-spacer__justify-center,
-    &.component-spacer__justify-space-between,
-    &.component-spacer__justify-space-around {
+    &.cf-component-spacer__justify-center,
+    &.cf-component-spacer__justify-space-between,
+    &.cf-component-spacer__justify-space-around {
       > * {
         margin-top: $margin / 2;
         margin-bottom: $margin / 2;
@@ -193,8 +193,8 @@
     }
   }
   // COLUMN REVERSE
-  &.component-spacer__column-reverse {
-    &.component-spacer__justify-flex-start {
+  &.cf-component-spacer__column-reverse {
+    &.cf-component-spacer__justify-flex-start {
       > * {
         margin-top: $margin;
   
@@ -203,7 +203,7 @@
         }
       }
     }
-    &.component-spacer__justify-flex-end {
+    &.cf-component-spacer__justify-flex-end {
       > * {
         margin-bottom: $margin;
   
@@ -212,9 +212,9 @@
         }
       }
     }
-    &.component-spacer__justify-center,
-    &.component-spacer__justify-space-between,
-    &.component-spacer__justify-space-around {
+    &.cf-component-spacer__justify-center,
+    &.cf-component-spacer__justify-space-between,
+    &.cf-component-spacer__justify-space-around {
       > * {
         margin-bottom: $margin / 2;
         margin-top: $margin / 2;
@@ -231,15 +231,15 @@
   }
 }
 
-.component-spacer__margin-xs {
+.cf-component-spacer__margin-xs {
   @include componentSpacerMargins($cf-border);
 }
-.component-spacer__margin-sm {
+.cf-component-spacer__margin-sm {
   @include componentSpacerMargins($cf-marg-a);
 }
-.component-spacer__margin-md {
+.cf-component-spacer__margin-md {
   @include componentSpacerMargins($cf-marg-b);
 }
-.component-spacer__margin-lg {
+.cf-component-spacer__margin-lg {
   @include componentSpacerMargins($cf-marg-c);
 }

--- a/src/Components/ComponentSpacer/ComponentSpacer.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacer.tsx
@@ -59,13 +59,13 @@ export class ComponentSpacer extends Component<Props> {
 
     return (
       <div
-        className={classnames('component-spacer', {
-          [`component-spacer__margin-${margin}`]: margin,
-          [`component-spacer__${direction}`]: direction,
-          [`component-spacer__justify-${justifyContent}`]: justifyContent,
-          [`component-spacer__align-${alignItems}`]: alignItems,
-          'component-spacer__stretch-w': stretchToFitWidth,
-          'component-spacer__stretch-h': stretchToFitHeight,
+        className={classnames('cf-component-spacer', {
+          [`cf-component-spacer__margin-${margin}`]: margin,
+          [`cf-component-spacer__${direction}`]: direction,
+          [`cf-component-spacer__justify-${justifyContent}`]: justifyContent,
+          [`cf-component-spacer__align-${alignItems}`]: alignItems,
+          'cf-component-spacer__stretch-w': stretchToFitWidth,
+          'cf-component-spacer__stretch-h': stretchToFitHeight,
           [`${className}`]: className,
         })}
         data-testid={testID}

--- a/src/Components/DapperScrollbars/DapperScrollbars.scss
+++ b/src/Components/DapperScrollbars/DapperScrollbars.scss
@@ -7,19 +7,19 @@
 
 $dapper-scrollbars--size: 6px;
 
-.dapper-scrollbars--wrapper {
+.cf-dapper-scrollbars--wrapper {
   margin-right: 0 !important;
   margin-bottom: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
 }
 
-.dapper-scrollbars--content {
+.cf-dapper-scrollbars--content {
   display: block !important;
 }
 
-.dapper-scrollbars--track-x,
-.dapper-scrollbars--track-y {
+.cf-dapper-scrollbars--track-x,
+.cf-dapper-scrollbars--track-y {
   border-radius: $dapper-scrollbars--size !important;
   position: absolute !important;
   background-color: rgba($g0-obsidian, 0.4) !important;
@@ -28,42 +28,42 @@ $dapper-scrollbars--size: 6px;
   transition: opacity 0.25s ease !important;
 }
 
-.dapper-scrollbars--track-x {
+.cf-dapper-scrollbars--track-x {
   height: $dapper-scrollbars--size !important;
   width: calc(100% - #{$dapper-scrollbars--size}) !important;
   bottom: $dapper-scrollbars--size / 2 !important;
   left: $dapper-scrollbars--size / 2 !important;
 }
 
-.dapper-scrollbars--track-y {
+.cf-dapper-scrollbars--track-y {
   width: $dapper-scrollbars--size !important;
   height: calc(100% - #{$dapper-scrollbars--size}) !important;
   right: $dapper-scrollbars--size / 2 !important;
   top: $dapper-scrollbars--size / 2 !important;
 }
 
-.dapper-scrollbars--thumb-x,
-.dapper-scrollbars--thumb-y {
+.cf-dapper-scrollbars--thumb-x,
+.cf-dapper-scrollbars--thumb-y {
   border-radius: $dapper-scrollbars--size / 2 !important;
 }
 
-.dapper-scrollbars--thumb-x {
+.cf-dapper-scrollbars--thumb-x {
   height: $dapper-scrollbars--size !important;
 }
 
-.dapper-scrollbars--thumb-y {
+.cf-dapper-scrollbars--thumb-y {
   width: $dapper-scrollbars--size !important;
 }
 
-.dapper-scrollbars--autohide {
-  .dapper-scrollbars--track-x,
-  .dapper-scrollbars--track-y {
+.cf-dapper-scrollbars--autohide {
+  .cf-dapper-scrollbars--track-x,
+  .cf-dapper-scrollbars--track-y {
     opacity: 0;
   }
 
   &:hover {
-    .dapper-scrollbars--track-x,
-    .dapper-scrollbars--track-y {
+    .cf-dapper-scrollbars--track-x,
+    .cf-dapper-scrollbars--track-y {
       opacity: 1;
     }
   }

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -77,8 +77,8 @@ export class DapperScrollbars extends Component<Props> {
       id,
     } = this.props
 
-    const classname = classnames('dapper-scrollbars', {
-      'dapper-scrollbars--autohide': autoHide,
+    const classname = classnames('cf-dapper-scrollbars', {
+      'cf-dapper-scrollbars--autohide': autoHide,
       [`${className}`]: className,
     })
 
@@ -97,17 +97,17 @@ export class DapperScrollbars extends Component<Props> {
         noScrollX={noScrollX}
         noScrollY={noScrollY}
         noScroll={noScroll}
-        wrapperProps={{className: 'dapper-scrollbars--wrapper'}}
-        contentProps={{className: 'dapper-scrollbars--content'}}
-        trackXProps={{className: 'dapper-scrollbars--track-x'}}
+        wrapperProps={{className: 'cf-dapper-scrollbars--wrapper'}}
+        contentProps={{className: 'cf-dapper-scrollbars--content'}}
+        trackXProps={{className: 'cf-dapper-scrollbars--track-x'}}
         thumbXProps={{
           style: this.thumbXStyle,
-          className: 'dapper-scrollbars--thumb-x',
+          className: 'cf-dapper-scrollbars--thumb-x',
         }}
-        trackYProps={{className: 'dapper-scrollbars--track-y'}}
+        trackYProps={{className: 'cf-dapper-scrollbars--track-y'}}
         thumbYProps={{
           style: this.thumbYStyle,
-          className: 'dapper-scrollbars--thumb-y',
+          className: 'cf-dapper-scrollbars--thumb-y',
         }}
         id={id}
       >

--- a/src/Components/DraggableResizer/DraggableResizer.scss
+++ b/src/Components/DraggableResizer/DraggableResizer.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-.draggable-resizer {
+.cf-draggable-resizer {
   display: flex;
   width: 100%;
   height: 100%;
@@ -13,26 +13,26 @@
   align-items: stretch;
   flex-wrap: nowrap;
 
-  &.draggable-resizer--horizontal {
+  &.cf-draggable-resizer--horizontal {
     flex-direction: column;
 
-    &.draggable-resizer--dragging,
-    &.draggable-resizer--dragging:hover {
+    &.cf-draggable-resizer--dragging,
+    &.cf-draggable-resizer--dragging:hover {
       cursor: row-resize !important;
     }
   }
 
-  &.draggable-resizer--vertical {
+  &.cf-draggable-resizer--vertical {
     flex-direction: row;
 
-    &.draggable-resizer--dragging,
-    &.draggable-resizer--dragging:hover {
+    &.cf-draggable-resizer--dragging,
+    &.cf-draggable-resizer--dragging:hover {
       cursor: col-resize !important;
     }
   }
 }
 
-.draggable-resizer--dragging {
+.cf-draggable-resizer--dragging {
   position: relative;
   z-index: $z--draggable-resizer-mask;
   user-select: none;
@@ -47,22 +47,22 @@
     left: 0;
   }
 
-  .draggable-resizer--panel {
+  .cf-draggable-resizer--panel {
     pointer-events: none;
   }
 }
 
-.draggable-resizer--panel {
+.cf-draggable-resizer--panel {
   position: relative;
 }
 
-.draggable-resizer--handle {
+.cf-draggable-resizer--handle {
   flex: 0 0 8px;
   background-color: transparent;
   position: relative;
 
   &:before,
-  > .draggable-resizer--gradient {
+  > .cf-draggable-resizer--gradient {
     content: '';
     background-color: $g5-pepper;
     position: absolute;
@@ -76,58 +76,58 @@
     z-index: 1;
   }
 
-  > .draggable-resizer--gradient {
+  > .cf-draggable-resizer--gradient {
     opacity: 0;
     z-index: 2;
     transition: opacity 0.25s ease, height 0.2s ease, width 0.2s ease;
   }
 
-  &:hover > .draggable-resizer--gradient {
+  &:hover > .cf-draggable-resizer--gradient {
     opacity: 1;
   }
 
   // Prevents adjacent handles from lighting up when one is being dragged
-  .draggable-resizer--dragging &:not(.draggable-resizer--handle-dragging):hover:after {
+  .cf-draggable-resizer--dragging &:not(.cf-draggable-resizer--handle-dragging):hover:after {
     opacity: 0;
   }
 }
 
 // Horizontal Handle Styles
-.draggable-resizer--horizontal .draggable-resizer--handle {
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle {
   &:hover {
     cursor: row-resize;
   }
 
   &:before,
-  > .draggable-resizer--gradient {
+  > .cf-draggable-resizer--gradient {
     width: 60px;
     height: 4px;
   }
 }
 
 // Vertical Handle Styles
-.draggable-resizer--vertical .draggable-resizer--handle {
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle {
   &:hover {
     cursor: col-resize;
   }
 
   &:before,
-  > .draggable-resizer--gradient {
+  > .cf-draggable-resizer--gradient {
     width: 4px;
     height: 60px;
   }
 }
 
 // Handle Dragging State
-.draggable-resizer--horizontal .draggable-resizer--handle-dragging > .draggable-resizer--gradient,
-.draggable-resizer--vertical .draggable-resizer--handle-dragging > .draggable-resizer--gradient {
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
   opacity: 1;
 }
 
-.draggable-resizer--horizontal .draggable-resizer--handle-dragging > .draggable-resizer--gradient {
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
   width: calc(100% - 60px);
 }
 
-.draggable-resizer--vertical .draggable-resizer--handle-dragging > .draggable-resizer--gradient {
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
   height: calc(100% - 60px);
 }

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -81,11 +81,12 @@ export class DraggableResizer extends Component<Props, State> {
 
     const isDragging = dragIndex !== NULL_DRAG
 
-    return classnames('draggable-resizer', {
-      'draggable-resizer--vertical': handleOrientation === Orientation.Vertical,
-      'draggable-resizer--horizontal':
+    return classnames('cf-draggable-resizer', {
+      'cf-draggable-resizer--vertical':
+        handleOrientation === Orientation.Vertical,
+      'cf-draggable-resizer--horizontal':
         handleOrientation === Orientation.Horizontal,
-      'draggable-resizer--dragging': isDragging,
+      'cf-draggable-resizer--dragging': isDragging,
       [`${className}`]: className,
     })
   }

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -44,7 +44,7 @@ export class DraggableResizerHandle extends PureComponent<Props> {
         id={id}
       >
         <div
-          className="draggable-resizer--gradient"
+          className="cf-draggable-resizer--gradient"
           style={this.gradientStyle}
         />
       </div>
@@ -60,8 +60,8 @@ export class DraggableResizerHandle extends PureComponent<Props> {
   private get className(): string {
     const {dragging, className} = this.props
 
-    return classnames('draggable-resizer--handle', {
-      'draggable-resizer--handle-dragging': dragging,
+    return classnames('cf-draggable-resizer--handle', {
+      'cf-draggable-resizer--handle-dragging': dragging,
       [`${className}`]: className,
     })
   }

--- a/src/Components/DraggableResizer/DraggableResizerPanel.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerPanel.tsx
@@ -39,7 +39,9 @@ export class DraggableResizerPanel extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('draggable-resizer--panel', {[`${className}`]: className})
+    return classnames('cf-draggable-resizer--panel', {
+      [`${className}`]: className,
+    })
   }
 
   private get style(): CSSProperties | undefined {

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -9,19 +9,19 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   Dropdown
   ------------------------------------------------------------------------------
 */
-.dropdown {
+.cf-dropdown {
   position: relative;
 
-  &.dropdown-xs {
+  &.cf-dropdown-xs {
     height: $form-xs-height;
   }
-  &.dropdown-sm {
+  &.cf-dropdown-sm {
     height: $form-sm-height;
   }
-  &.dropdown-md {
+  &.cf-dropdown-md {
     height: $form-md-height;
   }
-  &.dropdown-lg {
+  &.cf-dropdown-lg {
     height: $form-lg-height;
   }
 }
@@ -30,21 +30,21 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   Dropdown Menu
   ------------------------------------------------------------------------------
 */
-.dropdown--menu-container {
+.cf-dropdown--menu-container {
   position: absolute;
   width: 100%;
   left: 0;
   z-index: 500;
 }
 
-.dropdown-menu {
+.cf-dropdown-menu {
   overflow: hidden;
   border-radius: $cf-radius;
   box-shadow: 0 2px 5px 0.6px rgba($g0-obsidian, 0.2);
 }
 
 
-.dropdown-menu--contents {
+.cf-dropdown-menu--contents {
   user-select: none;
   display: flex;
   flex-direction: column;
@@ -65,7 +65,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   text-align: left;
 }
 
-.dropdown-divider {
+.cf-dropdown-divider {
   @include dropdownItemStyles();
 
   &.line {
@@ -78,22 +78,22 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   }
 }
 
-.dropdown-item {
+.cf-dropdown-item {
   @include dropdownItemStyles();
   color: rgba($g20-white, 0.75);
   position: relative;
 
-  &.dropdown-link-item {
+  &.cf-dropdown-link-item {
     padding: 0;
   }
 
-  &.dropdown-item__dot,
-  &.dropdown-item__dot.dropdown-link-item > a {
+  &.cf-dropdown-item__dot,
+  &.cf-dropdown-item__dot.cf-dropdown-link-item > a {
     padding-left: $dropdown-item--padding-h + ($dropdown-item--dot-radius * 2);
   }
 
-  &.dropdown-item__checkbox,
-  &.dropdown-item__checkbox.dropdown-link-item > a  {
+  &.cf-dropdown-item__checkbox,
+  &.cf-dropdown-item__checkbox.cf-dropdown-link-item > a  {
     padding-left: $dropdown-item--padding-h + $dropdown-item--checkbox-size + $dropdown-item--padding-v;
   }
 
@@ -104,27 +104,27 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   }
 }
 
-.dropdown-item__wrap .dropdown-item--children,
-.dropdown-item__wrap.dropdown-link-item a {
+.cf-dropdown-item__wrap .cf-dropdown-item--children,
+.cf-dropdown-item__wrap.cf-dropdown-link-item a {
   word-break: break-all;
   white-space: pre-wrap;
 }
 
-.dropdown-item__no-wrap .dropdown-item--children,
-.dropdown-item__no-wrap.dropdown-link-item a {
+.cf-dropdown-item__no-wrap .cf-dropdown-item--children,
+.cf-dropdown-item__no-wrap.cf-dropdown-link-item a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.dropdown-item--dot,
-.dropdown-item--checkbox {
+.cf-dropdown-item--dot,
+.cf-dropdown-item--checkbox {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
 }
 
-.dropdown-item--dot {
+.cf-dropdown-item--dot {
   left: $dropdown-item--padding-h + ($dropdown-item--dot-radius / 2);
   width: $dropdown-item--dot-radius;
   height: $dropdown-item--dot-radius;
@@ -134,7 +134,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   transition: opacity 0.25s ease;
 }
 
-.dropdown-item--checkbox {
+.cf-dropdown-item--checkbox {
   background-color: $g4-onyx;
   left: $dropdown-item--padding-h + ($dropdown-item--checkbox-size / 2);
   width: $dropdown-item--checkbox-size;
@@ -161,12 +161,12 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   }
 }
 
-.dropdown-item.active {
-  .dropdown-item--checkbox:after {
+.cf-dropdown-item.active {
+  .cf-dropdown-item--checkbox:after {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1, 1);
   }
-  .dropdown-item--dot {
+  .cf-dropdown-item--dot {
     opacity: 1;
   }
 }
@@ -176,11 +176,11 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   ------------------------------------------------------------------------------
 */
 
-.dropdown-item.dropdown-link-item {
+.cf-dropdown-item.cf-dropdown-link-item {
   padding: 0;
 
-  &.dropdown-item__dot,
-  &.dropdown-item__checkbox {
+  &.cf-dropdown-item__dot,
+  &.cf-dropdown-item__checkbox {
     padding-left: 0;
   }
 
@@ -224,23 +224,23 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
 ) {
   @include gradient-h($backgroundA, $backgroundB);
 
-  .dropdown-item:hover,
-  .dropdown-item.active {
+  .cf-dropdown-item:hover,
+  .cf-dropdown-item.active {
     @include gradient-h($hoverA, $hoverB);
   }
-  .dropdown-divider {
+  .cf-dropdown-divider {
     color: $dividerText;
     @include gradient-h($dividerA, $dividerB);
   }
-  .dropdown-item--checkbox {
+  .cf-dropdown-item--checkbox {
     background-color: $dividerA;
   }
-  .dropdown-item--checkbox:after {
+  .cf-dropdown-item--checkbox:after {
     background-color: $checkbox;
   }
 }
 
-.dropdown__amethyst {
+.cf-dropdown__amethyst {
   @include dropdownMenuColor(
     $c-star,
     $c-pool,
@@ -253,7 +253,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   );
 }
 
-.dropdown__sapphire {
+.cf-dropdown__sapphire {
   @include dropdownMenuColor(
     $c-ocean,
     $c-pool,
@@ -266,7 +266,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   );
 }
 
-.dropdown__malachite {
+.cf-dropdown__malachite {
   @include dropdownMenuColor(
     $c-ocean,
     $c-rainforest,
@@ -279,7 +279,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   );
 }
 
-.dropdown__onyx {
+.cf-dropdown__onyx {
   @include dropdownMenuColor(
     $g2-kevlar,
     $g4-onyx,

--- a/src/Components/Dropdowns/DropdownButton.scss
+++ b/src/Components/Dropdowns/DropdownButton.scss
@@ -6,30 +6,30 @@
 */
 
 /* Button */
-.dropdown--button {
+.cf-dropdown--button {
   position: relative;
 }
 
-.dropdown--selected,
-.dropdown--icon,
-.dropdown--caret {
+.cf-dropdown--selected,
+.cf-dropdown--icon,
+.cf-dropdown--caret {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
 }
 
-.dropdown--icon {
+.cf-dropdown--icon {
   top: 48%;
 }
 
-.dropdown--selected {
+.cf-dropdown--selected {
   text-align: left;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-.dropdown--caret {
+.cf-dropdown--caret {
   margin: 0;
   font-size: 0.9em;
   transition: transform 0.25s ease;
@@ -41,41 +41,41 @@
 
 /* Button Size Modifiers */
 @mixin buttonSizing($padding, $font, $height) {
-  .dropdown--icon,
-  .dropdown--selected {
+  .cf-dropdown--icon,
+  .cf-dropdown--selected {
     left: $padding;
   }
-  .dropdown--selected {
+  .cf-dropdown--selected {
     width: calc(100% - #{($padding * 2) + $font});
   }
-  .dropdown--icon + .dropdown--selected {
+  .cf-dropdown--icon + .cf-dropdown--selected {
     left: $padding + ($font * 1.5);
     width: calc(100% - #{($padding * 2) + ($font * 2.5)});
   }
-  .dropdown--caret {
+  .cf-dropdown--caret {
     right: $padding;
   }
-  & + .dropdown--menu-container {
+  & + .cf-dropdown--menu-container {
     top: $height;
   }
 }
 
-.dropdown--button.button-disabled {
+.cf-dropdown--button.cf-button-disabled {
   font-style: italic;
 }
 
-.dropdown--button.button-xs {
+.cf-dropdown--button.cf-button-xs {
   @include buttonSizing($form-xs-padding, $form-xs-font, $form-xs-height);
 }
 
-.dropdown--button.button-sm {
+.cf-dropdown--button.cf-button-sm {
   @include buttonSizing($form-sm-padding, $form-sm-font, $form-sm-height);
 }
 
-.dropdown--button.button-md {
+.cf-dropdown--button.cf-button-md {
   @include buttonSizing($form-md-padding, $form-md-font, $form-md-height);
 }
 
-.dropdown--button.button-lg {
+.cf-dropdown--button.cf-button-lg {
   @include buttonSizing($form-lg-padding, $form-lg-font, $form-lg-height);
 }

--- a/src/Components/Dropdowns/Family/Dropdown.tsx
+++ b/src/Components/Dropdowns/Family/Dropdown.tsx
@@ -68,7 +68,7 @@ export class Dropdown extends Component<Props, State> {
           id={id}
         >
           {button(expanded, this.toggleMenu)}
-          <div className="dropdown--menu-container">{this.menu}</div>
+          <div className="cf-dropdown--menu-container">{this.menu}</div>
         </div>
       </ClickOutside>
     )
@@ -97,7 +97,7 @@ export class Dropdown extends Component<Props, State> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('dropdown', {
+    return classnames('cf-dropdown', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Dropdowns/Family/DropdownButton.tsx
+++ b/src/Components/Dropdowns/Family/DropdownButton.tsx
@@ -73,9 +73,9 @@ export class DropdownButton extends Component<Props> {
         size={size}
         id={id}
       >
-        {!!icon && <Icon glyph={icon} className="dropdown--icon" />}
-        <span className="dropdown--selected">{children}</span>
-        <Icon glyph={IconFont.CaretDown} className="dropdown--caret" />
+        {!!icon && <Icon glyph={icon} className="cf-dropdown--icon" />}
+        <span className="cf-dropdown--selected">{children}</span>
+        <Icon glyph={IconFont.CaretDown} className="cf-dropdown--caret" />
       </ButtonBase>
     )
   }
@@ -83,7 +83,9 @@ export class DropdownButton extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `dropdown--button ${className}` : 'dropdown--button'
+    return className
+      ? `cf-dropdown--button ${className}`
+      : 'cf-dropdown--button'
   }
 
   private get status(): ComponentStatus {

--- a/src/Components/Dropdowns/Family/DropdownDivider.tsx
+++ b/src/Components/Dropdowns/Family/DropdownDivider.tsx
@@ -22,7 +22,7 @@ export class DropdownDivider extends Component<Props> {
 
     return (
       <div
-        className={classnames('dropdown-divider', {
+        className={classnames('cf-dropdown-divider', {
           line: !text,
           [`${className}`]: className,
         })}

--- a/src/Components/Dropdowns/Family/DropdownItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownItem.tsx
@@ -48,13 +48,13 @@ export class DropdownItem extends Component<Props> {
   private get className(): string {
     const {selected, wrapText, className, type} = this.props
 
-    return classnames('dropdown-item', {
-      [`dropdown-item__${type}`]:
+    return classnames('cf-dropdown-item', {
+      [`cf-dropdown-item__${type}`]:
         type === DropdownItemType.Checkbox || type === DropdownItemType.Dot,
       active: selected,
       [`${className}`]: className,
-      'dropdown-item__wrap': wrapText,
-      'dropdown-item__no-wrap': !wrapText,
+      'cf-dropdown-item__wrap': wrapText,
+      'cf-dropdown-item__no-wrap': !wrapText,
     })
   }
 
@@ -72,9 +72,9 @@ export class DropdownItem extends Component<Props> {
 
     switch (type) {
       case DropdownItemType.Checkbox:
-        return <div className="dropdown-item--checkbox" />
+        return <div className="cf-dropdown-item--checkbox" />
       case DropdownItemType.Dot:
-        return <div className="dropdown-item--dot" />
+        return <div className="cf-dropdown-item--dot" />
       case DropdownItemType.None:
       default:
         return
@@ -84,6 +84,6 @@ export class DropdownItem extends Component<Props> {
   private get childElements(): JSX.Element {
     const {children} = this.props
 
-    return <div className="dropdown-item--children">{children}</div>
+    return <div className="cf-dropdown-item--children">{children}</div>
   }
 }

--- a/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
@@ -39,13 +39,13 @@ export class DropdownLinkItem extends Component<Props> {
   private get className(): string {
     const {selected, wrapText, className, type} = this.props
 
-    return classnames('dropdown-item dropdown-link-item', {
-      [`dropdown-item__${type}`]:
+    return classnames('cf-dropdown-item cf-dropdown-link-item', {
+      [`cf-dropdown-item__${type}`]:
         type === DropdownItemType.Checkbox || type === DropdownItemType.Dot,
       active: selected,
       [`${className}`]: className,
-      'dropdown-item__wrap': wrapText,
-      'dropdown-item__no-wrap': !wrapText,
+      'cf-dropdown-item__wrap': wrapText,
+      'cf-dropdown-item__no-wrap': !wrapText,
     })
   }
 
@@ -54,9 +54,9 @@ export class DropdownLinkItem extends Component<Props> {
 
     switch (type) {
       case DropdownItemType.Checkbox:
-        return <div className="dropdown-item--checkbox" />
+        return <div className="cf-dropdown-item--checkbox" />
       case DropdownItemType.Dot:
-        return <div className="dropdown-item--dot" />
+        return <div className="cf-dropdown-item--dot" />
       case DropdownItemType.None:
       default:
         return

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -67,7 +67,11 @@ export class DropdownMenu extends Component<Props> {
           noScrollX={noScrollX}
           noScrollY={noScrollY}
         >
-          <div className="dropdown-menu--contents" data-testid={testID} id={id}>
+          <div
+            className="cf-dropdown-menu--contents"
+            data-testid={testID}
+            id={id}
+          >
             {children}
           </div>
         </DapperScrollbars>
@@ -78,9 +82,9 @@ export class DropdownMenu extends Component<Props> {
   private get containerClass(): string {
     const {className, theme} = this.props
 
-    return classnames('dropdown-menu', {
+    return classnames('cf-dropdown-menu', {
       [`${className}`]: className,
-      [`dropdown__${theme}`]: theme,
+      [`cf-dropdown__${theme}`]: theme,
     })
   }
 

--- a/src/Components/EmptyState/EmptyState.scss
+++ b/src/Components/EmptyState/EmptyState.scss
@@ -5,15 +5,15 @@
 
 @import '../../Styles/modules';
 
-.empty-state {
+.cf-empty-state {
   display: flex;
   width: 100%;
   flex-direction: column;
   align-items: center;
 }
 
-.empty-state--text,
-.empty-state--sub-text {
+.cf-empty-state--text,
+.cf-empty-state--sub-text {
   margin-bottom: 0;
   text-align: center;
   color: $empty-state-text;
@@ -33,18 +33,18 @@
 @mixin emptyStateSizeModifier($fontSize, $padding) {
   padding: ceil($padding * 2.75) 0;
 
-  .empty-state--text,
-  .empty-state--sub-text {
+  .cf-empty-state--text,
+  .cf-empty-state--sub-text {
     margin-top: ceil($fontSize * 0.75);
   }
 
-  .empty-state--text + .button,
-  .empty-state--text + .dropdown {
+  .cf-empty-state--text + .cf-button,
+  .cf-empty-state--text + .cf-dropdown {
     margin-top: $padding;
   }
 
-  .empty-state--sub-text + .button,
-  .empty-state--sub-text + .dropdown {
+  .cf-empty-state--sub-text + .cf-button,
+  .cf-empty-state--sub-text + .cf-dropdown {
     margin-top: $padding;
   }
 
@@ -52,27 +52,27 @@
     margin-bottom: ceil($fontSize * 0.75);
   }
 
-  .empty-state--text {
+  .cf-empty-state--text {
     font-size: ceil($fontSize * 1.25);
   }
 
-  .empty-state--sub-text {
+  .cf-empty-state--sub-text {
     font-size: $fontSize;
   }
 }
 
-.empty-state--xs {
+.cf-empty-state--xs {
   @include emptyStateSizeModifier($form-xs-font, $cf-marg-a);
 }
 
-.empty-state--sm {
+.cf-empty-state--sm {
   @include emptyStateSizeModifier($form-sm-font, $cf-marg-b);
 }
 
-.empty-state--md {
+.cf-empty-state--md {
   @include emptyStateSizeModifier($form-md-font, $cf-marg-c);
 }
 
-.empty-state--lg {
+.cf-empty-state--lg {
   @include emptyStateSizeModifier($form-lg-font, $cf-marg-d);
 }

--- a/src/Components/EmptyState/EmptyState.tsx
+++ b/src/Components/EmptyState/EmptyState.tsx
@@ -41,8 +41,8 @@ export class EmptyState extends Component<Props> {
   private get className(): string {
     const {className, size} = this.props
 
-    return classnames('empty-state', {
-      [`empty-state--${size}`]: size,
+    return classnames('cf-empty-state', {
+      [`cf-empty-state--${size}`]: size,
       [`${className}`]: className,
     })
   }

--- a/src/Components/EmptyState/EmptyStateSubText.tsx
+++ b/src/Components/EmptyState/EmptyStateSubText.tsx
@@ -30,7 +30,7 @@ export class EmptyStateSubText extends Component<Props> {
     const {className} = this.props
 
     return className
-      ? `empty-state--sub-text ${className}`
-      : 'empty-state--sub-text'
+      ? `cf-empty-state--sub-text ${className}`
+      : 'cf-empty-state--sub-text'
   }
 }

--- a/src/Components/EmptyState/EmptyStateText.tsx
+++ b/src/Components/EmptyState/EmptyStateText.tsx
@@ -56,6 +56,8 @@ export class EmptyStateText extends Component<Props & StandardProps> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `empty-state--text ${className}` : 'empty-state--text'
+    return className
+      ? `cf-empty-state--text ${className}`
+      : 'cf-empty-state--text'
   }
 }

--- a/src/Components/FormLayout/Form.scss
+++ b/src/Components/FormLayout/Form.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-.form--wrapper {
+.cf-form--wrapper {
   width: 100%;
 }
 
@@ -13,7 +13,7 @@
   Form Elements
   ------------------------------------------------------------------------------
 */
-.form--element {
+.cf-form--element {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -25,9 +25,9 @@
   Form Group Addons
   ------------------------------------------------------------------------------
 */
-.form--label,
-.form--help-text,
-.form--element-error {
+.cf-form--label,
+.cf-form--help-text,
+.cf-form--element-error {
   text-align: left;
   display: inline-block;
   font-size: 12px;
@@ -36,20 +36,20 @@
   @extend %no-user-select;
 }
 
-.form--label {
+.cf-form--label {
   width: 100%;
   color: $g11-sidewalk;
   margin: 0 0 $cf-marg-a 0;
 }
 
-.form--help-text {
+.cf-form--help-text {
   font-style: italic;
   line-height: 16px;
   color: $g11-sidewalk;
   margin: $cf-marg-a 0 0 0;
 }
 
-.form--element-error {
+.cf-form--element-error {
   line-height: 16px;
   color: $c-dreamsicle;
   margin: $cf-marg-a 0 0 0;
@@ -57,7 +57,7 @@
   word-wrap: break-word;
 }
 
-.form--label-required {
+.cf-form--label-required {
   color: $c-curacao;
 }
 
@@ -65,7 +65,7 @@
   Form Divider
   ------------------------------------------------------------------------------
 */
-.form--divider {
+.cf-form--divider {
   width: 100%;
   height: $form-sm-height - $cf-marg-b;
 
@@ -81,7 +81,7 @@
   Form Footer
   ------------------------------------------------------------------------------
 */
-.form--footer {
+.cf-form--footer {
   flex-direction: row;
   justify-content: center;
   align-items: center;
@@ -97,7 +97,7 @@
   Form Box
   ------------------------------------------------------------------------------
 */
-.form--box {
+.cf-form--box {
   width: 100%;
   border-radius: $cf-radius;
   background-color: $g4-onyx;

--- a/src/Components/FormLayout/Form.tsx
+++ b/src/Components/FormLayout/Form.tsx
@@ -65,7 +65,7 @@ export class Form extends Component<Props> {
   private get formWrapperClass(): string {
     const {className} = this.props
 
-    return classnames('form--wrapper', {
+    return classnames('cf-form--wrapper', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/FormLayout/FormBox.tsx
+++ b/src/Components/FormLayout/FormBox.tsx
@@ -18,7 +18,7 @@ export class FormBox extends Component<Props> {
     const {children, className, testID, id} = this.props
 
     return (
-      <div className={`form--box ${className}`} data-testid={testID} id={id}>
+      <div className={`cf-form--box ${className}`} data-testid={testID} id={id}>
         {children}
       </div>
     )

--- a/src/Components/FormLayout/FormDivider.tsx
+++ b/src/Components/FormLayout/FormDivider.tsx
@@ -33,9 +33,9 @@ export class FormDivider extends Component<Props> {
   private get className(): string {
     const {className, lineColor} = this.props
 
-    return classnames('form--divider', {
+    return classnames('cf-form--divider', {
       [`${className}`]: className,
-      'form--divider-line': lineColor,
+      'cf-form--divider-line': lineColor,
     })
   }
 

--- a/src/Components/FormLayout/FormElement.tsx
+++ b/src/Components/FormLayout/FormElement.tsx
@@ -46,7 +46,7 @@ export class FormElement extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('form--element', {[`${className}`]: className})
+    return classnames('cf-form--element', {[`${className}`]: className})
   }
 
   private get label(): JSX.Element | undefined {

--- a/src/Components/FormLayout/FormElementError.tsx
+++ b/src/Components/FormLayout/FormElementError.tsx
@@ -41,7 +41,7 @@ export class FormElementError extends Component<Props> {
     const {className} = this.props
 
     return className
-      ? `form--element-error ${className}`
-      : 'form--element-error'
+      ? `cf-form--element-error ${className}`
+      : 'cf-form--element-error'
   }
 }

--- a/src/Components/FormLayout/FormFooter.tsx
+++ b/src/Components/FormLayout/FormFooter.tsx
@@ -55,15 +55,15 @@ export class FormFooter extends Component<Props> {
       className,
     } = this.props
 
-    return classnames('form--element form--footer', {
-      [`col-xs-${widthXS}`]: widthXS,
-      [`col-sm-${widthSM}`]: widthSM,
-      [`col-md-${widthMD}`]: widthMD,
-      [`col-lg-${widthLG}`]: widthLG,
-      [`col-xs-offset-${offsetXS}`]: offsetXS,
-      [`col-sm-offset-${offsetSM}`]: offsetSM,
-      [`col-md-offset-${offsetMD}`]: offsetMD,
-      [`col-lg-offset-${offsetLG}`]: offsetLG,
+    return classnames('cf-form--element form--footer', {
+      [`cf-col-xs-${widthXS}`]: widthXS,
+      [`cf-col-sm-${widthSM}`]: widthSM,
+      [`cf-col-md-${widthMD}`]: widthMD,
+      [`cf-col-lg-${widthLG}`]: widthLG,
+      [`cf-col-xs-offset-${offsetXS}`]: offsetXS,
+      [`cf-col-sm-offset-${offsetSM}`]: offsetSM,
+      [`cf-col-md-offset-${offsetMD}`]: offsetMD,
+      [`cf-col-lg-offset-${offsetLG}`]: offsetLG,
       [`${className}`]: className,
     })
   }

--- a/src/Components/FormLayout/FormHelpText.tsx
+++ b/src/Components/FormLayout/FormHelpText.tsx
@@ -29,6 +29,6 @@ export class FormHelpText extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `form--help-text ${className}` : 'form--help-text'
+    return className ? `cf-form--help-text ${className}` : 'cf-form--help-text'
   }
 }

--- a/src/Components/FormLayout/FormLabel.tsx
+++ b/src/Components/FormLayout/FormLabel.tsx
@@ -39,12 +39,12 @@ export class FormLabel extends Component<Props> {
       return
     }
 
-    return <span className="form--label-required">*</span>
+    return <span className="cf-form--label-required">*</span>
   }
 
   private get className(): string {
     const {className} = this.props
 
-    return className ? `form--label ${className}` : 'form--label'
+    return className ? `cf-form--label ${className}` : 'cf-form--label'
   }
 }

--- a/src/Components/FormLayout/FormValidationElement.tsx
+++ b/src/Components/FormLayout/FormValidationElement.tsx
@@ -84,7 +84,7 @@ export class FormValidationElement extends Component<Props, State> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('form--element', {[`${className}`]: className})
+    return classnames('cf-form--element', {[`${className}`]: className})
   }
 
   private get label(): JSX.Element | undefined {

--- a/src/Components/GridLayout/Grid.scss
+++ b/src/Components/GridLayout/Grid.scss
@@ -25,11 +25,11 @@ $grid--col-10: 83.33333333%;
 $grid--col-11: 91.66666667%;
 $grid--col-12: 100%;
 
-.grid--container {
+.cf-grid--container {
   width: 100%;
 }
 
-.grid--row {
+.cf-grid--row {
   display: inline-block;
   width: calc(100% + #{$grid--gutter * 2});
   margin-left: -$grid--gutter;
@@ -42,7 +42,7 @@ $grid--col-12: 100%;
   }
 }
 
-.grid--column {
+.cf-grid--column {
   position: relative;
   float: left;
   min-height: 1px;
@@ -52,9 +52,9 @@ $grid--col-12: 100%;
 
 //  Extra Small Screen Grid
 //  ----------------------------------------------------------------------------
-.col-sm,
-.col-md,
-.col-lg {
+.cf-col-sm,
+.cf-col-md,
+.cf-col-lg {
   &-12,
   &-11,
   &-10,
@@ -70,7 +70,7 @@ $grid--col-12: 100%;
     width: $grid--col-12;
   }
 }
-.col-xs {
+.cf-col-xs {
   &-1 {
     width: $grid--col-1;
   }
@@ -108,7 +108,7 @@ $grid--col-12: 100%;
     width: $grid--col-12;
   }
 }
-.col-xs-offset {
+.cf-col-xs-offset {
   &-1 {
     margin-left: $grid--col-1;
   }
@@ -147,7 +147,7 @@ $grid--col-12: 100%;
 //  Small Screen Grid
 //  ----------------------------------------------------------------------------
 @media screen and (min-width: $grid--breakpoint-sm) {
-  .col-sm {
+  .cf-col-sm {
     &-1 {
       width: $grid--col-1;
     }
@@ -185,7 +185,7 @@ $grid--col-12: 100%;
       width: $grid--col-12;
     }
   }
-  .col-sm-offset {
+  .cf-col-sm-offset {
     &-1 {
       margin-left: $grid--col-1;
     }
@@ -225,7 +225,7 @@ $grid--col-12: 100%;
 //  Medium Screen Grid
 //  ----------------------------------------------------------------------------
 @media screen and (min-width: $grid--breakpoint-md) {
-  .col-md {
+  .cf-col-md {
     &-1 {
       width: $grid--col-1;
     }
@@ -263,7 +263,7 @@ $grid--col-12: 100%;
       width: $grid--col-12;
     }
   }
-  .col-md-offset {
+  .cf-col-md-offset {
     &-1 {
       margin-left: $grid--col-1;
     }
@@ -303,7 +303,7 @@ $grid--col-12: 100%;
 //  Large Screen Grid
 //  ----------------------------------------------------------------------------
 @media screen and (min-width: $grid--breakpoint-lg) {
-  .col-lg {
+  .cf-col-lg {
     &-1 {
       width: $grid--col-1;
     }
@@ -341,7 +341,7 @@ $grid--col-12: 100%;
       width: $grid--col-12;
     }
   }
-  .col-lg-offset {
+  .cf-col-lg-offset {
     &-1 {
       margin-left: $grid--col-1;
     }

--- a/src/Components/GridLayout/Grid.tsx
+++ b/src/Components/GridLayout/Grid.tsx
@@ -37,6 +37,6 @@ export class Grid extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('grid--container', {[`${className}`]: className})
+    return classnames('cf-grid--container', {[`${className}`]: className})
   }
 }

--- a/src/Components/GridLayout/GridColumn.tsx
+++ b/src/Components/GridLayout/GridColumn.tsx
@@ -55,16 +55,16 @@ export class GridColumn extends Component<Props> {
       className,
     } = this.props
 
-    return classnames('grid--column', {
+    return classnames('cf-grid--column', {
       [`${className}`]: className,
-      [`col-xs-${widthXS}`]: widthXS,
-      [`col-sm-${widthSM}`]: widthSM,
-      [`col-md-${widthMD}`]: widthMD,
-      [`col-lg-${widthLG}`]: widthLG,
-      [`col-xs-offset-${offsetXS}`]: offsetXS,
-      [`col-sm-offset-${offsetSM}`]: offsetSM,
-      [`col-md-offset-${offsetMD}`]: offsetMD,
-      [`col-lg-offset-${offsetLG}`]: offsetLG,
+      [`cf-col-xs-${widthXS}`]: widthXS,
+      [`cf-col-sm-${widthSM}`]: widthSM,
+      [`cf-col-md-${widthMD}`]: widthMD,
+      [`cf-col-lg-${widthLG}`]: widthLG,
+      [`cf-col-xs-offset-${offsetXS}`]: offsetXS,
+      [`cf-col-sm-offset-${offsetSM}`]: offsetSM,
+      [`cf-col-md-offset-${offsetMD}`]: offsetMD,
+      [`cf-col-lg-offset-${offsetLG}`]: offsetLG,
     })
   }
 }

--- a/src/Components/GridLayout/GridRow.tsx
+++ b/src/Components/GridLayout/GridRow.tsx
@@ -27,6 +27,6 @@ export class GridRow extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('grid--row', {[`${className}`]: className})
+    return classnames('cf-grid--row', {[`${className}`]: className})
   }
 }

--- a/src/Components/Icon/Icon.tsx
+++ b/src/Components/Icon/Icon.tsx
@@ -22,8 +22,8 @@ export class Icon extends Component<Props> {
     const {glyph, testID, id} = this.props
 
     const className = this.props.className
-      ? `icon ${glyph} ${this.props.className}`
-      : `icon ${glyph}`
+      ? `cf-icon ${glyph} ${this.props.className}`
+      : `cf-icon ${glyph}`
 
     return (
       <span

--- a/src/Components/IndexList/IndexList.scss
+++ b/src/Components/IndexList/IndexList.scss
@@ -171,7 +171,7 @@
   top: -1px;
   transition: opacity 0.25s ease, transform 0.25s ease;
 
-  > span.icon {
+  > span.cf-icon {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -21,11 +21,11 @@ $input-field-z: 1;
 $input-shadow-z: $input-field-z + 1;
 $input-status-z: $input-field-z + 2;
 
-.input {
+.cf-input {
   position: relative;
 }
 
-.input-field {
+.cf-input-field {
   position: relative;
   z-index: $input-field-z;
   width: 100%;
@@ -77,8 +77,8 @@ $input-status-z: $input-field-z + 2;
   Input Icons (Including Status)
   ------------------------------------------------------------------------------
 */
-.input-icon,
-.input-status {
+.cf-input-icon,
+.cf-input-status {
   pointer-events: none;
   top: 50%;
   position: absolute;
@@ -87,24 +87,24 @@ $input-status-z: $input-field-z + 2;
   font-size: 1.1em;
 }
 
-.input-status {
+.cf-input-status {
   transform: translate(50%, -50%);
 }
 
-.input-icon {
+.cf-input-icon {
   transform: translate(-50%, -50%);
   color: $input-text;
 }
 
-.input-field:hover + .input-icon {
+.cf-input-field:hover + .cf-input-icon {
   color: $input-hover-text;
 }
 
-.input-field:focus + .input-icon {
+.cf-input-field:focus + .cf-input-icon {
   color: $input-focus-text;
 }
 
-.input-shadow {
+.cf-input-shadow {
   pointer-events: none;
   position: absolute;
   z-index: $input-shadow-z;
@@ -119,7 +119,7 @@ $input-status-z: $input-field-z + 2;
   opacity: 0;
 }
 
-.input-status + .input-shadow {
+.cf-input-status + .cf-input-shadow {
   opacity: 1;
 }
 
@@ -127,12 +127,12 @@ $input-status-z: $input-field-z + 2;
   Checkbox Type Input
   ------------------------------------------------------------------------------
 */
-.input__has-checkbox .input-field {
+.cf-input__has-checkbox .cf-input-field {
   position: absolute;
   left: -9999px;
 }
 
-.input--checkbox {
+.cf-input--checkbox {
   position: relative;
   background-color: $g2-kevlar;
   border-radius: $cf-radius;
@@ -171,41 +171,41 @@ $input-status-z: $input-field-z + 2;
   height: $height;
   font-size: $fontSize;
 
-  .input-field {
+  .cf-input-field {
     font-size: $fontSize;
     padding: 0 $padding;
     height: $height;
   }
 
-  &.input__has-icon .input-field {
+  &.cf-input__has-icon .cf-input-field {
     padding-left: $height;
   }
 
-  .input-icon {
+  .cf-input-icon {
     left: ($height / 2) + $cf-border;
   }
 
-  .input-status {
+  .cf-input-status {
     right: $height / 2;
   }
 
-  .input-pseudo {
+  .cf-input-pseudo {
     height: $height;
     width: $height;
   }
 
-  .input-shadow {
+  .cf-input-shadow {
     width: $height;
     right: $padding;
     border-right-width: $padding;
   }
 
-  .input-spinner {
+  .cf-input-spinner {
     width: $height / 2;
     height: $height / 2;
   }
 
-  .input--checkbox {
+  .cf-input--checkbox {
     width: $height - ($cf-marg-a + $cf-border);
     height: $height - ($cf-marg-a + $cf-border);
     margin: 2px 0;
@@ -217,16 +217,16 @@ $input-status-z: $input-field-z + 2;
   }
 }
 
-.input-xs {
+.cf-input-xs {
   @include inputSizeModifier($form-xs-font, $form-xs-padding, $form-xs-height);
 }
-.input-sm {
+.cf-input-sm {
   @include inputSizeModifier($form-sm-font, $form-sm-padding, $form-sm-height);
 }
-.input-md {
+.cf-input-md {
   @include inputSizeModifier($form-md-font, $form-md-padding, $form-md-height);
 }
-.input-lg {
+.cf-input-lg {
   @include inputSizeModifier($form-lg-font, $form-lg-padding, $form-lg-height);
 }
 
@@ -244,17 +244,17 @@ $input-status-z: $input-field-z + 2;
   Error State
   ------------------------------------------------------------------------------
 */
-.input__error {
-  .input-status {
+.cf-input__error {
+  .cf-input-status {
     color: $c-dreamsicle;
   }
-  .input-field {
+  .cf-input-field {
     border-color: $c-curacao;
   }
-  .input-field:hover {
+  .cf-input-field:hover {
     border-color: $c-dreamsicle;
   }
-  .input-field:focus {
+  .cf-input-field:focus {
     border-color: $c-dreamsicle;
     box-shadow: 0 0 6px 0 $c-fire;
   }
@@ -264,8 +264,8 @@ $input-status-z: $input-field-z + 2;
   Loading State
   ------------------------------------------------------------------------------
 */
-.input__loading {
-  .input-status {
+.cf-input__loading {
+  .cf-input-status {
     color: $c-pool;
   }
 }
@@ -279,7 +279,7 @@ $input-status-z: $input-field-z + 2;
   }
 }
 
-.input-spinner {
+.cf-input-spinner {
   border-style: solid;
   border-radius: 50%;
   animation-duration: 0.85s;
@@ -294,12 +294,12 @@ $input-status-z: $input-field-z + 2;
   Disabled State
   ------------------------------------------------------------------------------
 */
-.input__disabled {
-  .input-icon,
-  .input-field:hover + .input-icon {
+.cf-input__disabled {
+  .cf-input-icon,
+  .cf-input-field:hover + .cf-input-icon {
     color: $input-disabled-text;
   }
-  .input--checkbox {
+  .cf-input--checkbox {
     &,
     &:hover {
       cursor: default;
@@ -313,8 +313,8 @@ $input-status-z: $input-field-z + 2;
   }
 }
 
-.input-field[disabled],
-.input-field[disabled]:hover {
+.cf-input-field[disabled],
+.cf-input-field[disabled]:hover {
   cursor: default;
   border-color: $input-disabled-border;
   background-color: $input-disabled-bg;

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -144,7 +144,7 @@ export class Input extends Component<Props> {
           onKeyPress={onKeyPress}
           onKeyUp={onKeyUp}
           onKeyDown={onKeyDown}
-          className="input-field"
+          className="cf-input-field"
           disabled={status === ComponentStatus.Disabled}
           maxLength={maxLength}
           tabIndex={tabIndex}
@@ -170,7 +170,7 @@ export class Input extends Component<Props> {
   private get checkbox(): JSX.Element | null {
     const {type, checked} = this.props
 
-    const className = classnames('input--checkbox', {checked})
+    const className = classnames('cf-input--checkbox', {checked})
 
     if (type === InputType.Checkbox) {
       return <div className={className} />
@@ -183,7 +183,7 @@ export class Input extends Component<Props> {
     const {icon} = this.props
 
     if (icon) {
-      return <Icon glyph={icon} className="input-icon" />
+      return <Icon glyph={icon} className="cf-input-icon" />
     }
 
     return null
@@ -209,10 +209,10 @@ export class Input extends Component<Props> {
     if (status === ComponentStatus.Loading) {
       return (
         <>
-          <div className="input-status">
-            <div className="input-spinner" />
+          <div className="cf-input-status">
+            <div className="cf-input-spinner" />
           </div>
-          <div className="input-shadow" />
+          <div className="cf-input-shadow" />
         </>
       )
     }
@@ -222,10 +222,10 @@ export class Input extends Component<Props> {
         <>
           <Icon
             glyph={IconFont.AlertTriangle}
-            className="input-status"
+            className="cf-input-status"
             testID="input-error"
           />
-          <div className="input-shadow" />
+          <div className="cf-input-shadow" />
         </>
       )
     }
@@ -235,28 +235,28 @@ export class Input extends Component<Props> {
         <>
           <Icon
             glyph={IconFont.Checkmark}
-            className="input-status"
+            className="cf-input-status"
             testID="input-valid"
           />
-          <div className="input-shadow" />
+          <div className="cf-input-shadow" />
         </>
       )
     }
 
-    return <div className="input-shadow" />
+    return <div className="cf-input-shadow" />
   }
 
   private get className(): string {
     const {type, size, status, icon, className} = this.props
 
-    return classnames('input', {
-      [`input-${size}`]: size,
-      'input__has-checkbox': type === InputType.Checkbox,
-      'input__has-icon': icon,
-      input__valid: status === ComponentStatus.Valid,
-      input__error: status === ComponentStatus.Error,
-      input__loading: status === ComponentStatus.Loading,
-      input__disabled: status === ComponentStatus.Disabled,
+    return classnames('cf-input', {
+      [`cf-input-${size}`]: size,
+      'cf-input__has-checkbox': type === InputType.Checkbox,
+      'cf-input__has-icon': icon,
+      'cf-input__valid': status === ComponentStatus.Valid,
+      'cf-input__error': status === ComponentStatus.Error,
+      'cf-input__loading': status === ComponentStatus.Loading,
+      'cf-input__disabled': status === ComponentStatus.Disabled,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Inputs/TextArea.scss
+++ b/src/Components/Inputs/TextArea.scss
@@ -20,11 +20,11 @@ $text-area-field-z: 1;
 $text-area-shadow-z: $text-area-field-z + 1;
 $text-area-status-z: $text-area-field-z + 2;
 
-.text-area--container {
+.cf-text-area--container {
   width: 100%;
   height: 100%;
 }
-.text-area {
+.cf-text-area {
   position: relative;
   padding: 15px;
   z-index: $text-area-field-z;

--- a/src/Components/Inputs/TextArea.tsx
+++ b/src/Components/Inputs/TextArea.tsx
@@ -135,7 +135,7 @@ export class TextArea extends Component<Props> {
           rows={rows}
           spellCheck={spellCheck}
           wrap={wrap}
-          className="text-area"
+          className="cf-text-area"
           value={value}
           onBlur={onBlur}
           onFocus={onFocus}
@@ -161,8 +161,8 @@ export class TextArea extends Component<Props> {
   private get className(): string {
     const {size, className} = this.props
 
-    return classnames('text-area--container', {
-      [`input-${size}`]: size,
+    return classnames('cf-text-area--container', {
+      [`cf-input-${size}`]: size,
       [`className`]: className,
     })
   }

--- a/src/Components/Label/Label.scss
+++ b/src/Components/Label/Label.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-.label {
+.cf-label {
   display: inline-flex;
   align-items: center;
   align-content: center;
@@ -14,7 +14,7 @@
   flex-wrap: nowrap;
 }
 
-.label--name {
+.cf-label--name {
   display: block;
   cursor: inherit;
   font-weight: 700;
@@ -23,14 +23,14 @@
   font-style: normal;
 }
 
-.label--clickable {
+.cf-label--clickable {
   &,
   &:hover {
     cursor: pointer;
   }
 }
 
-.label--delete {
+.cf-label--delete {
   display: block;
   background-color: transparent;
   position: relative;
@@ -45,7 +45,7 @@
   }
 }
 
-.label--delete-x {
+.cf-label--delete-x {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -66,54 +66,54 @@
 
 @mixin labelSizeModifier($fontSize, $padding, $height) {
   &,
-  & + .additional-labels {
+  & + .cf-additional-labels {
     border-radius: $height / 2;
     font-size: $fontSize;
     height: $height - $cf-marg-a;
   }
 
-  .label--name {
+  .cf-label--name {
     padding: 0 ($padding + $cf-border);
     height: $height - $cf-marg-a;
     line-height: $height - $cf-marg-a;
   }
 
-  &.label--deletable {
+  &.cf-label--deletable {
     padding-right: $padding + $cf-border;
   }
 
-  &.label--deletable .label--name {
+  &.cf-label--deletable .cf-label--name {
     padding-right: 0;
   }
 
-  .label--delete {
+  .cf-label--delete {
     height: $height - $cf-marg-a;
     transform: translateX($padding - $cf-border);
     width: 0;
   }
 
-  &:hover .label--delete {
+  &:hover .cf-label--delete {
     width: $height - $cf-marg-a - $cf-border;
   }
 }
 
-.label--xs {
+.cf-label--xs {
   @include labelSizeModifier($form-xs-font, $form-xs-padding, $form-xs-height);
 }
 
-.label--sm {
+.cf-label--sm {
   @include labelSizeModifier($form-sm-font, $form-sm-padding, $form-sm-height);
 }
 
-.label--md {
+.cf-label--md {
   @include labelSizeModifier($form-md-font, $form-md-padding, $form-md-height);
 }
 
-.label--lg {
+.cf-label--lg {
   @include labelSizeModifier($form-lg-font, $form-lg-padding, $form-lg-height);
 }
 
-.label--colorless {
+.cf-label--colorless {
   font-weight: 600;
   font-style: italic;
 

--- a/src/Components/Label/Label.tsx
+++ b/src/Components/Label/Label.tsx
@@ -59,7 +59,7 @@ export class Label extends Component<Props, State> {
         id={id}
       >
         <span
-          className="label--name"
+          className="cf-label--name"
           onClick={this.handleClick}
           data-testid={`${testID} ${name}`}
         >
@@ -107,11 +107,11 @@ export class Label extends Component<Props, State> {
   private get className(): string {
     const {size, onClick, onDelete, className} = this.props
 
-    return classnames('label', {
+    return classnames('cf-label', {
       [`${className}`]: className,
-      [`label--${size}`]: size,
-      'label--deletable': onDelete,
-      'label--clickable': onClick,
+      [`cf-label--${size}`]: size,
+      'cf-label--deletable': onDelete,
+      'cf-label--clickable': onClick,
     })
   }
 
@@ -131,18 +131,18 @@ export class Label extends Component<Props, State> {
     if (onDelete) {
       return (
         <button
-          className="label--delete"
+          className="cf-label--delete"
           onClick={this.handleDelete}
           type="button"
           title={`Remove label "${name}"`}
           data-testid={`${testID}--delete ${name}`}
         >
           <div
-            className="label--delete-x"
+            className="cf-label--delete-x"
             style={{backgroundColor: this.textColor}}
           />
           <div
-            className="label--delete-x"
+            className="cf-label--delete-x"
             style={{backgroundColor: this.textColor}}
           />
         </button>

--- a/src/Components/NavMenu/NavMenu.scss
+++ b/src/Components/NavMenu/NavMenu.scss
@@ -5,7 +5,7 @@
     ----------------------------------------------------------------------------
 */
 
-.nav {
+.cf-nav {
   display: flex;
   flex-direction: row;
   background-color: $g3-castle;
@@ -13,19 +13,19 @@
   height: $nav-menu--size;
 }
 
-.nav--item {
+.cf-nav--item {
   width: $nav-menu--size;
   height: $nav-menu--size;
   position: relative;
 }
 
-.nav--item-icon {
+.cf-nav--item-icon {
   display: block;
   width: 100%;
   height: 100%;
   position: relative;
   
-  > .icon {
+  > .cf-icon {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -42,7 +42,7 @@
   }
 }
 
-.nav--avatar {
+.cf-nav--avatar {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -51,15 +51,15 @@
     box-shadow 0.4s ease;
 }
 
-.nav--item:first-child .nav--item-icon {
+.cf-nav--item:first-child .cf-nav--item-icon {
   border-bottom-left-radius: $cf-radius;
 }
 
-.nav--item:last-child .nav--item-icon {
+.cf-nav--item:last-child .cf-nav--item-icon {
   border-bottom-right-radius: $cf-radius;
 }
 
-.nav--item-menu {
+.cf-nav--item-menu {
   position: absolute;
   top: $nav-menu--size;
   left: 50%;
@@ -72,7 +72,7 @@
   overflow: hidden;
 }
 
-.nav--item-header {
+.cf-nav--item-header {
   display: block;
   height: $nav-menu--size;
   line-height: $nav-menu--size;
@@ -92,23 +92,23 @@
 }
 
 // Hover State
-.nav--item:hover {
+.cf-nav--item:hover {
   z-index: 9000;
 
-  .nav--item-icon {
+  .cf-nav--item-icon {
     color: $g20-white;
     background-color: $nav-menu--bg;
     border-radius: 0;
   }
 
-  .nav--item-menu {
+  .cf-nav--item-menu {
     display: flex;
   }
 }
 
 // Active State
-.nav--item.active {
-  .nav--item-icon {
+.cf-nav--item.active {
+  .cf-nav--item-icon {
     color: $g20-white;
     background-color: $g6-smoke;
     text-shadow:
@@ -119,8 +119,8 @@
 }
 
 // Active Hover State
-.nav--item.active:hover {
-  .nav--item-icon {
+.cf-nav--item.active:hover {
+  .cf-nav--item-icon {
     color: $g20-white;
     background-color: $nav-menu--bg;
     text-shadow:
@@ -132,14 +132,14 @@
 
 // Vertical Menu
 @media screen and (min-width: $nav-menu--breakpoint) {
-  .nav {
+  .cf-nav {
     flex-direction: column;
     height: auto;
     width: $nav-menu--size;
     border-radius: 0 $cf-radius $cf-radius 0;
   }
 
-  .nav--item-menu {
+  .cf-nav--item-menu {
     top: 0;
     left: $nav-menu--size;
     border-radius: 0 $cf-radius $cf-radius 0;
@@ -147,22 +147,22 @@
     @include gradient-h($nav-menu--bg,$nav-menu--bg-accent);
   }
 
-  .nav--item:first-child .nav--item-icon {
+  .cf-nav--item:first-child .cf-nav--item-icon {
     border-bottom-left-radius: 0;
     border-top-right-radius: $cf-radius;
   }
 
-  .nav--item:last-child .nav--item-icon {
+  .cf-nav--item:last-child .cf-nav--item-icon {
     border-bottom-right-radius: $cf-radius;
   }
 
-  .nav--item:hover .nav--item-icon {
+  .cf-nav--item:hover .cf-nav--item-icon {
     border-radius: 0;
   }
 }
 
 // Sub Menu Items
-.nav--sub-item {
+.cf-nav--sub-item {
   padding: 6px $nav-menu--gutter;
   user-select: none;
   font-size: 13px;
@@ -211,9 +211,9 @@
   ------------------------------------------------------------------------------
 */
 
-.nav--item,
-.nav--item-header,
-.nav--sub-item {
+.cf-nav--item,
+.cf-nav--item-header,
+.cf-nav--sub-item {
   &:link,
   &:active,
   &:visited,

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -39,7 +39,7 @@ export class NavMenu extends PureComponent<Props> {
       return
     }
 
-    const className = classnames('nav', {
+    const className = classnames('cf-nav', {
       [`${this.props.className}`]: this.props.className,
     })
 

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -34,16 +34,16 @@ export class NavMenuItem extends PureComponent<Props> {
 
     return (
       <div
-        className={classnames('nav--item', {
+        className={classnames('cf-nav--item', {
           active,
           [`${className}`]: className,
         })}
         data-testid={testID}
         id={id}
       >
-        {iconLink('nav--item-icon')}
-        <div className="nav--item-menu">
-          {titleLink('nav--item-header')}
+        {iconLink('cf-nav--item-icon')}
+        <div className="cf-nav--item-menu">
+          {titleLink('cf-nav--item-header')}
           {children}
         </div>
       </div>

--- a/src/Components/NavMenu/NavMenuSubItem.tsx
+++ b/src/Components/NavMenu/NavMenuSubItem.tsx
@@ -22,7 +22,7 @@ export class NavMenuSubItem extends PureComponent<Props> {
   public render() {
     const {active, className, titleLink, testID} = this.props
 
-    const titleClass = classnames('nav--sub-item', {
+    const titleClass = classnames('cf-nav--sub-item', {
       active,
       [`${className}`]: className,
     })

--- a/src/Components/Overlay/Overlay.scss
+++ b/src/Components/Overlay/Overlay.scss
@@ -25,14 +25,14 @@ $overlay--transition-distance: 72px;
   width: 100%;
 }
 
-.overlay--mask {
+.cf-overlay--mask {
   z-index: 0;
   @extend %overlay-styles;
   opacity: 0;
   transition: opacity 0.25s ease;
 }
 
-.overlay--transition {
+.cf-overlay--transition {
   position: relative;
   z-index: 2;
   transform: translateY($overlay--transition-distance);
@@ -41,7 +41,7 @@ $overlay--transition-distance: 72px;
     opacity 0.25s ease;
 }
 
-.overlay {
+.cf-overlay {
   z-index: $z--overlays;
   @extend %overlay-styles;
   transition: all 0.25s ease;
@@ -55,24 +55,24 @@ $overlay--transition-distance: 72px;
 }
 
 // Open State
-.overlay.show {
-  .overlay--mask {
+.cf-overlay.show {
+  .cf-overlay--mask {
     opacity: 0.7;
   }
-  .overlay--transition {
+  .cf-overlay--transition {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-.overlay--container {
+.cf-overlay--container {
   @extend %overlay-children;
   margin: $overlay--container-padding auto;
   @include gradient-v($g3-castle, $g2-kevlar);
   border-radius: $cf-radius;
 }
 
-.overlay--header {
+.cf-overlay--header {
   @extend %overlay-children;
   height: $overlay--header-height;
   display: flex;
@@ -82,14 +82,14 @@ $overlay--transition-distance: 72px;
   @include no-user-select();
 }
 
-.overlay--title {
+.cf-overlay--title {
   font-size: $overlay--title-size;
   font-weight: $overlay--title-weight;
   color: $g17-whisper;
   white-space: nowrap;
 }
 
-.overlay--dismiss {
+.cf-overlay--dismiss {
   width: ($overlay--header-height - 20px);
   height: ($overlay--header-height - 20px);
   position: relative;
@@ -126,7 +126,7 @@ $overlay--transition-distance: 72px;
   }
 }
 
-.overlay--body {
+.cf-overlay--body {
   @extend %overlay-children;
   padding: $overlay--gutter;
   padding-top: 0;
@@ -137,7 +137,7 @@ $overlay--transition-distance: 72px;
   }
 }
 
-.overlay--footer {
+.cf-overlay--footer {
   @extend %overlay-children;
   padding: $overlay--gutter;
   padding-top: 0;

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -91,7 +91,7 @@ export class Overlay extends Component<Props, State> {
     if (showChildren) {
       return (
         <div
-          className="overlay--transition"
+          className="cf-overlay--transition"
           data-testid={`${testID}--children`}
         >
           {children}
@@ -101,7 +101,7 @@ export class Overlay extends Component<Props, State> {
 
     return (
       <div
-        className="overlay--transition"
+        className="cf-overlay--transition"
         data-testid={`${testID}--children`}
       />
     )
@@ -110,7 +110,7 @@ export class Overlay extends Component<Props, State> {
   private get overlayClass(): string {
     const {visible, className} = this.props
 
-    return classnames('overlay', {
+    return classnames('cf-overlay', {
       show: visible,
       [`${className}`]: className,
     })

--- a/src/Components/Overlay/OverlayBody.tsx
+++ b/src/Components/Overlay/OverlayBody.tsx
@@ -17,7 +17,9 @@ export class OverlayBody extends PureComponent<Props> {
   public render() {
     const {children, className, testID, id} = this.props
 
-    const classname = classnames('overlay--body', {[`${className}`]: className})
+    const classname = classnames('cf-overlay--body', {
+      [`${className}`]: className,
+    })
 
     return (
       <div className={classname} data-testid={testID} id={id}>

--- a/src/Components/Overlay/OverlayContainer.tsx
+++ b/src/Components/Overlay/OverlayContainer.tsx
@@ -23,7 +23,7 @@ export class OverlayContainer extends PureComponent<Props> {
 
     return (
       <div
-        className={classnames('overlay--container', {
+        className={classnames('cf-overlay--container', {
           [`${className}`]: className,
         })}
         data-testid={testID}

--- a/src/Components/Overlay/OverlayFooter.tsx
+++ b/src/Components/Overlay/OverlayFooter.tsx
@@ -26,7 +26,7 @@ export class OverlayFooter extends PureComponent<Props> {
   public render() {
     const {children, className, testID, id} = this.props
 
-    const classname = classnames('overlay--footer', {
+    const classname = classnames('cf-overlay--footer', {
       [`${className}`]: className,
     })
 

--- a/src/Components/Overlay/OverlayHeader.tsx
+++ b/src/Components/Overlay/OverlayHeader.tsx
@@ -26,16 +26,16 @@ export class OverlayHeader extends PureComponent<Props> {
   public render() {
     const {title, onDismiss, children, testID, className, id} = this.props
 
-    const classname = classnames('overlay--header', {
+    const classname = classnames('cf-overlay--header', {
       [`${className}`]: className,
     })
 
     return (
       <div className={classname} data-testid={testID} id={id}>
-        <div className="overlay--title">{title}</div>
+        <div className="cf-overlay--title">{title}</div>
         {onDismiss && (
           <button
-            className="overlay--dismiss"
+            className="cf-overlay--dismiss"
             onClick={onDismiss}
             type="button"
           />

--- a/src/Components/Overlay/OverlayMask.tsx
+++ b/src/Components/Overlay/OverlayMask.tsx
@@ -26,7 +26,9 @@ export class OverlayMask extends PureComponent<Props> {
   public render() {
     const {testID, className, id} = this.props
 
-    const classname = classnames('overlay--mask', {[`${className}`]: className})
+    const classname = classnames('cf-overlay--mask', {
+      [`${className}`]: className,
+    })
 
     return (
       <div

--- a/src/Components/Page/Page.scss
+++ b/src/Components/Page/Page.scss
@@ -5,7 +5,7 @@
    -----------------------------------------------------------------------------
 */
 
-.page {
+.cf-page {
   width: 100%;
   flex: 1 0 calc(100% - #{$nav-menu--size});
   display: flex;
@@ -14,20 +14,20 @@
 }
 
 @media screen and (min-width: $nav-menu--breakpoint) {
-  .page {
+  .cf-page {
     width: auto;
     height: 100%;
   }
 }
 
-.page-header {
+.cf-page-header {
   height: $page--header-size;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.page-header--container {
+.cf-page-header--container {
   display: flex;
   padding: 0 $page--gutter;
   align-items: center;
@@ -37,25 +37,25 @@
   max-width: $page--max-width;
 }
 
-.page-header--left,
-.page-header--right,
-.page-header--center {
+.cf-page-header--left,
+.cf-page-header--right,
+.cf-page-header--center {
   display: flex;
   align-items: center;
 }
 
-.page-header--left {
+.cf-page-header--left {
   justify-content: flex-start;
   > * {
     margin: 0 $cf-marg-a 0 0;
   }
 }
 
-.page-header--center {
+.cf-page-header--center {
   justify-content: center;
 }
 
-.page-header--right {
+.cf-page-header--right {
   justify-content: flex-end;
   > * {
     margin: 0 0 0 $cf-marg-a !important;
@@ -66,7 +66,7 @@
   }
 }
 
-.page--title {
+.cf-page--title {
   letter-spacing: 0;
   text-transform: none;
   font-size: $page--title-size;
@@ -77,13 +77,13 @@
   cursor: default;
 }
 
-.page-contents {
+.cf-page-contents {
   width: 100%;
   position: relative;
   height: calc(100% - #{$page--header-size}) !important;
   overflow: hidden;
 
-  & > .dapper-scrollbars--track-y {
+  & > .cf-dapper-scrollbars--track-y {
     background: linear-gradient(
       to bottom,
       $g6-smoke 0%,
@@ -108,15 +108,15 @@
   ------------------------------------------------------------------------------
 */
 
-.page-contents.full-width .page-contents--padding {
+.cf-page-contents.full-width .cf-page-contents--padding {
   padding: 0 $page--gutter;
 }
 
-.page-contents--container.full-width {
+.cf-page-contents--container.full-width {
   max-width: 100%;
 }
 
-.page-header.full-width .page-header--container {
+.cf-page-header.full-width .cf-page-header--container {
   max-width: 100%;
 }
 
@@ -125,7 +125,7 @@
   ------------------------------------------------------------------------------
 */
 
-.page-contents.dapper-scrollbars > .page-contents--padding {
+.cf-page-contents.cf-dapper-scrollbars > .cf-page-contents--padding {
   padding-bottom: $page--gutter;
 }
 
@@ -134,14 +134,14 @@
   ------------------------------------------------------------------------------
 */
 
-.page-contents.full-height {
+.cf-page-contents.full-height {
   height: 100% !important;
 }
 
-.page-contents.full-height .page-contents--padding {
+.cf-page-contents.full-height .cf-page-contents--padding {
   padding: $cf-marg-b;
 }
 
-.page-contents.full-height.dapper-scrollbars .page-contents--padding {
+.cf-page-contents.full-height.cf-dapper-scrollbars .cf-page-contents--padding {
   padding-right: $cf-marg-c;
 }

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -56,7 +56,7 @@ export class Page extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('page', {
+    return classnames('cf-page', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -37,14 +37,14 @@ export class PageContents extends Component<Props> {
           testID={testID}
           id={id}
         >
-          <div className="page-contents--padding">{this.children}</div>
+          <div className="cf-page-contents--padding">{this.children}</div>
         </DapperScrollbars>
       )
     }
 
     return (
       <div className={this.className} data-testid={testID}>
-        <div className="page-contents--padding">{this.children}</div>
+        <div className="cf-page-contents--padding">{this.children}</div>
       </div>
     )
   }
@@ -52,7 +52,7 @@ export class PageContents extends Component<Props> {
   private get className(): string {
     const {fullWidth, fullHeight, className} = this.props
 
-    return classnames('page-contents', {
+    return classnames('cf-page-contents', {
       'full-width': fullWidth,
       'full-height': fullHeight,
       [`${className}`]: className,
@@ -66,6 +66,6 @@ export class PageContents extends Component<Props> {
       return children
     }
 
-    return <div className="page-contents--container">{children}</div>
+    return <div className="cf-page-contents--container">{children}</div>
   }
 }

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -39,7 +39,7 @@ export class PageHeader extends Component<Props> {
 
     return (
       <div className={this.className} data-testid={testID} id={id}>
-        <div className="page-header--container">
+        <div className="cf-page-header--container">
           {this.childrenWithCorrectWidths}
         </div>
       </div>
@@ -49,7 +49,7 @@ export class PageHeader extends Component<Props> {
   private get className(): string {
     const {fullWidth, className} = this.props
 
-    return classnames('page-header', {
+    return classnames('cf-page-header', {
       'full-width': fullWidth,
       [`${className}`]: className,
     })

--- a/src/Components/Page/PageHeaderCenter.tsx
+++ b/src/Components/Page/PageHeaderCenter.tsx
@@ -39,8 +39,8 @@ export class PageHeaderCenter extends Component<Props> {
     const {className} = this.props
 
     return className
-      ? `page-header--center ${className}`
-      : 'page-header--center'
+      ? `cf-page-header--center ${className}`
+      : 'cf-page-header--center'
   }
 
   private get style(): CSSProperties {

--- a/src/Components/Page/PageHeaderLeft.tsx
+++ b/src/Components/Page/PageHeaderLeft.tsx
@@ -38,7 +38,9 @@ export class PageHeaderLeft extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `page-header--left ${className}` : 'page-header--left'
+    return className
+      ? `cf-page-header--left ${className}`
+      : 'cf-page-header--left'
   }
 
   private get style(): CSSProperties | undefined {

--- a/src/Components/Page/PageHeaderRight.tsx
+++ b/src/Components/Page/PageHeaderRight.tsx
@@ -38,7 +38,9 @@ export class PageHeaderRight extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `page-header--right ${className}` : 'page-header--right'
+    return className
+      ? `cf-page-header--right ${className}`
+      : 'cf-page-header--right'
   }
 
   private get style(): CSSProperties | undefined {

--- a/src/Components/Page/PageTitle.tsx
+++ b/src/Components/Page/PageTitle.tsx
@@ -36,6 +36,6 @@ export class PageTitle extends PureComponent<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `page--title ${className}` : 'page--title'
+    return className ? `cf-page--title ${className}` : 'cf-page--title'
   }
 }

--- a/src/Components/Panel/Panel.scss
+++ b/src/Components/Panel/Panel.scss
@@ -5,20 +5,20 @@
    -----------------------------------------------------------------------------
 */
 
-.panel {
+.cf-panel {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   border-radius: $cf-radius;
 }
 
-.panel--header {
+.cf-panel--header {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.panel--title {
+.cf-panel--title {
   font-style: normal;
   font-weight: 600;
   letter-spacing: 0.015em;
@@ -27,18 +27,18 @@
   @extend %no-user-select;
 }
 
-.panel--controls {
+.cf-panel--controls {
   display: flex;
   align-items: center;
 }
 
-.panel--body {
+.cf-panel--body {
   > *:last-child {
     margin-bottom: 0;
   }
 }
 
-.panel--footer {
+.cf-panel--footer {
   border-radius: 0 0 $cf-radius $cf-radius;
   background-color: rgba($g0-obsidian, 0.1);
 }
@@ -50,15 +50,15 @@
 
 $panel--dismiss-button: 30px;
 
-.panel__dismissable {
+.cf-panel__dismissable {
   position: relative;
 
-  > .panel--header {
+  > .cf-panel--header {
     padding-right: 40px;
   }
 }
 
-.panel--dismiss {
+.cf-panel--dismiss {
   position: absolute;
   background-color: transparent;
   border: 0;
@@ -95,50 +95,50 @@ $panel--dismiss-button: 30px;
   ------------------------------------------------------------------------------
 */
 @mixin panelSizeModifier($fontSize, $fontWeight, $padding, $dismissSize) {
-  > .panel--header {
+  > .cf-panel--header {
     padding: $padding * 2;
   }
-  > .panel--body {
+  > .cf-panel--body {
     font-size: $fontSize;
     padding: $padding * 2;
   }
-  > .panel--header + .panel--body {
+  > .cf-panel--header + .cf-panel--body {
     padding-top: 0;
   }
-  > .panel--header > .panel--title {
+  > .cf-panel--header > .cf-panel--title {
     font-weight: $fontWeight;
     font-size: $fontSize * 1.5;
   }
-  > .panel--footer {
+  > .cf-panel--footer {
     padding: $padding ($padding * 2);
   }
-  &.panel__dismissable > .panel--header {
+  &.cf-panel__dismissable > .cf-panel--header {
     padding-right: $dismissSize + $padding;
   }
 
-  .panel--dismiss {
+  .cf-panel--dismiss {
     width: $dismissSize - $cf-border;
     height: $dismissSize - $cf-border;
     top: ($padding / 2);
     right: ($padding / 2);
   }
 
-  .panel--dismiss:before,
-  .panel--dismiss:after {
+  .cf-panel--dismiss:before,
+  .cf-panel--dismiss:after {
     width: $dismissSize * 0.55;
   }
 }
 
-.panel--xs {
+.cf-panel--xs {
   @include panelSizeModifier($form-xs-font, 600, $form-xs-padding, $form-xs-height);
 }
-.panel--sm {
+.cf-panel--sm {
   @include panelSizeModifier($form-sm-font, 500, $form-sm-padding, $form-sm-height);
 }
-.panel--md {
+.cf-panel--md {
   @include panelSizeModifier($form-md-font, 500, $form-md-padding, $form-md-height);
 }
-.panel--lg {
+.cf-panel--lg {
   @include panelSizeModifier($form-lg-font, 400, $form-lg-padding, $form-md-height);
 }
 
@@ -147,30 +147,30 @@ $panel--dismiss-button: 30px;
   ------------------------------------------------------------------------------
 */
 
-.panel__dark-text {
-  > .panel--header > .panel--title {
+.cf-panel__dark-text {
+  > .cf-panel--header > .cf-panel--title {
     color: $g4-onyx;
   }
-  > .panel--body,
-  > .panel--footer {
+  > .cf-panel--body,
+  > .cf-panel--footer {
     color: rgba($g4-onyx, 0.75);
   }
-  > .panel--dismiss:before,
-  > .panel--dismiss:after {
+  > .cf-panel--dismiss:before,
+  > .cf-panel--dismiss:after {
     background-color: $g4-onyx;
   }
 }
 
-.panel__light-text {
-  > .panel--header > .panel--title {
+.cf-panel__light-text {
+  > .cf-panel--header > .cf-panel--title {
     color: $g18-cloud;
   }
-  > .panel--body,
-  > .panel--footer {
+  > .cf-panel--body,
+  > .cf-panel--footer {
     color: rgba($g18-cloud, 0.75);
   }
-  > .panel--dismiss:before,
-  > .panel--dismiss:after {
+  > .cf-panel--dismiss:before,
+  > .cf-panel--dismiss:after {
     background-color: $g18-cloud;
   }
 }
@@ -180,7 +180,7 @@ $panel--dismiss-button: 30px;
   ------------------------------------------------------------------------------
 */
 
-.panel--body hr {
+.cf-panel--body hr {
   margin: $cf-marg-c 0;
 }
 

--- a/src/Components/Panel/Panel.tsx
+++ b/src/Components/Panel/Panel.tsx
@@ -66,11 +66,11 @@ export class Panel extends Component<Props> {
   private get className(): string {
     const {className, gradient, size, onDismiss} = this.props
 
-    return classnames(`panel panel--${size}`, {
+    return classnames(`cf-panel cf-panel--${size}`, {
       [`${className}`]: className,
-      panel__gradient: gradient,
-      panel__dismissable: onDismiss,
-      [`panel__${this.useContrastText}-text`]: this.useContrastText,
+      'cf-panel__gradient': gradient,
+      'cf-panel__dismissable': onDismiss,
+      [`cf-panel__${this.useContrastText}-text`]: this.useContrastText,
     })
   }
 
@@ -108,7 +108,11 @@ export class Panel extends Component<Props> {
 
     if (onDismiss) {
       return (
-        <button className="panel--dismiss" type="button" onClick={onDismiss} />
+        <button
+          className="cf-panel--dismiss"
+          type="button"
+          onClick={onDismiss}
+        />
       )
     }
 

--- a/src/Components/Panel/PanelBody.tsx
+++ b/src/Components/Panel/PanelBody.tsx
@@ -27,6 +27,6 @@ export class PanelBody extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('panel--body', {[`${className}`]: className})
+    return classnames('cf-panel--body', {[`${className}`]: className})
   }
 }

--- a/src/Components/Panel/PanelFooter.tsx
+++ b/src/Components/Panel/PanelFooter.tsx
@@ -27,6 +27,6 @@ export class PanelFooter extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('panel--footer', {[`${className}`]: className})
+    return classnames('cf-panel--footer', {[`${className}`]: className})
   }
 }

--- a/src/Components/Panel/PanelHeader.tsx
+++ b/src/Components/Panel/PanelHeader.tsx
@@ -30,8 +30,8 @@ export class PanelHeader extends Component<Props> {
 
     return (
       <div className={this.className} data-testid={testID} id={id}>
-        <div className="panel--title">{title}</div>
-        <div className="panel--controls">
+        <div className="cf-panel--title">{title}</div>
+        <div className="cf-panel--controls">
           <ComponentSpacer
             direction={FlexDirection.Row}
             justifyContent={JustifyContent.FlexEnd}
@@ -47,6 +47,6 @@ export class PanelHeader extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('panel--header', {[`${className}`]: className})
+    return classnames('cf-panel--header', {[`${className}`]: className})
   }
 }

--- a/src/Components/Radio/Radio.scss
+++ b/src/Components/Radio/Radio.scss
@@ -7,7 +7,7 @@
 
 $radio-buttons--padding: $cf-marg-a;
 
-.radio-buttons {
+.cf-radio-buttons {
   display: inline-flex;
   align-items: stretch;
   padding: $radio-buttons--padding;
@@ -15,7 +15,7 @@ $radio-buttons--padding: $cf-marg-a;
   background-color: $g5-pepper;
 }
 
-.radio-button {
+.cf-radio-button {
   @include no-user-select();
   border: 0;
   font-family: $cf-text-font;
@@ -53,7 +53,7 @@ $radio-buttons--padding: $cf-marg-a;
 @mixin radioButtonSizeModifier($fontSize, $padding, $height) {
   height: $height;
 
-  .radio-button {
+  .cf-radio-button {
     height: $height - ($radio-buttons--padding * 2);
     line-height: $height - ($radio-buttons--padding * 2);
     padding: 0 $padding;
@@ -61,16 +61,16 @@ $radio-buttons--padding: $cf-marg-a;
   }
 }
 
-.radio-buttons--xs {
+.cf-radio-buttons--xs {
   @include radioButtonSizeModifier($form-xs-font, $form-xs-padding, $form-xs-height);
 }
-.radio-buttons--sm {
+.cf-radio-buttons--sm {
   @include radioButtonSizeModifier($form-sm-font, $form-sm-padding, $form-sm-height);
 }
-.radio-buttons--md {
+.cf-radio-buttons--md {
   @include radioButtonSizeModifier($form-md-font, $form-md-padding, $form-md-height);
 }
-.radio-buttons--lg {
+.cf-radio-buttons--lg {
   @include radioButtonSizeModifier($form-lg-font, $form-lg-padding, $form-lg-height);
 }
 
@@ -79,33 +79,33 @@ $radio-buttons--padding: $cf-marg-a;
   Color Modifiers
   ------------------------------------------------------------------------------
 */
-.radio-buttons--default {
-  .radio-button.active {
+.cf-radio-buttons--default {
+  .cf-radio-button.active {
     background-color: $g7-graphite;
   }
 }
-.radio-buttons--primary {
-  .radio-button.active {
+.cf-radio-buttons--primary {
+  .cf-radio-button.active {
     background-color: $c-pool;
   }
 }
-.radio-buttons--secondary {
-  .radio-button.active {
+.cf-radio-buttons--secondary {
+  .cf-radio-button.active {
     background-color: $c-star;
   }
 }
-.radio-buttons--success {
-  .radio-button.active {
+.cf-radio-buttons--success {
+  .cf-radio-button.active {
     background-color: $c-rainforest;
   }
 }
-.radio-buttons--danger {
-  .radio-button.active {
+.cf-radio-buttons--danger {
+  .cf-radio-button.active {
     background-color: $c-curacao;
   }
 }
-.radio-buttons--warning {
-  .radio-button.active {
+.cf-radio-buttons--warning {
+  .cf-radio-button.active {
     background-color: $c-pineapple;
   }
 }
@@ -114,32 +114,32 @@ $radio-buttons--padding: $cf-marg-a;
   Shape Modifiers
   ------------------------------------------------------------------------------
 */
-.radio-buttons.radio-buttons--square {
-  &.radio-buttons--xs .radio-button {
+.cf-radio-buttons.cf-radio-buttons--square {
+  &.cf-radio-buttons--xs .cf-radio-button {
     width: $form-xs-height;
   }
   
-  &.radio-buttons--sm .radio-button {
+  &.cf-radio-buttons--sm .cf-radio-button {
     width: $form-sm-height;
   }
   
-  &.radio-buttons--md .radio-button {
+  &.cf-radio-buttons--md .cf-radio-button {
     width: $form-md-height;
   }
 
-  &.radio-buttons--lg .radio-button {
+  &.cf-radio-buttons--lg .cf-radio-button {
     width: $form-lg-height;
   }
 
-  .radio-button {
+  .cf-radio-button {
     padding: 0;
   }
 }
 
-.radio-buttons.radio-buttons--stretch {
+.cf-radio-buttons.cf-radio-buttons--stretch {
   width: 100%;
 
-  .radio-button {
+  .cf-radio-button {
     flex: 1 0 0;
   }
 }

--- a/src/Components/Radio/Radio.tsx
+++ b/src/Components/Radio/Radio.tsx
@@ -50,11 +50,11 @@ export class Radio extends Component<Props> {
   private get containerClassName(): string {
     const {color, size, shape, className} = this.props
 
-    return classnames('radio-buttons', {
-      [`radio-buttons--${color}`]: color,
-      [`radio-buttons--${size}`]: size,
-      'radio-buttons--square': shape === ButtonShape.Square,
-      'radio-buttons--stretch': shape === ButtonShape.StretchToFit,
+    return classnames('cf-radio-buttons', {
+      [`cf-radio-buttons--${color}`]: color,
+      [`cf-radio-buttons--${size}`]: size,
+      'cf-radio-buttons--square': shape === ButtonShape.Square,
+      'cf-radio-buttons--stretch': shape === ButtonShape.StretchToFit,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Radio/RadioButton.tsx
+++ b/src/Components/Radio/RadioButton.tsx
@@ -50,7 +50,7 @@ export class RadioButton extends Component<Props> {
   private get className(): string {
     const {active, disabled, className} = this.props
 
-    return classnames('radio-button', {
+    return classnames('cf-radio-button', {
       active,
       disabled,
       [`${className}`]: className,

--- a/src/Components/ResourceList/Card/ResourceCardDescription.scss
+++ b/src/Components/ResourceList/Card/ResourceCardDescription.scss
@@ -36,7 +36,7 @@
     border-color 0.25s ease;
   line-height: $form-xs-font + $cf-border;
 
-  .icon {
+  .cf-icon {
     position: relative;
     top: -2px;
     display: inline-block;
@@ -46,7 +46,7 @@
     color: $g11-sidewalk;
   }
 
-  &:hover .icon {
+  &:hover .cf-icon {
     opacity: 1;
   }
 

--- a/src/Components/ResourceList/List/ResourceList.scss
+++ b/src/Components/ResourceList/List/ResourceList.scss
@@ -75,7 +75,7 @@
     opacity: 1;
   }
 
-  > span.icon {
+  > span.cf-icon {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -83,11 +83,11 @@
     transition: transform 0.25s ease;
   }
 
-  .resource-list--sort-descending & > span.icon {
+  .resource-list--sort-descending & > span.cf-icon {
     transform: translate(-50%, -50%) rotate(0deg);
   }
 
-  .resource-list--sort-ascending & > span.icon {
+  .resource-list--sort-ascending & > span.cf-icon {
     transform: translate(-50%, -50%) rotate(180deg);
   }
 }

--- a/src/Components/SlideToggle/SlideToggle.scss
+++ b/src/Components/SlideToggle/SlideToggle.scss
@@ -7,7 +7,7 @@
 
 $slide-toggle--gap: $cf-border * 2;
 
-.slide-toggle {
+.cf-slide-toggle {
   position: relative;
   display: inline-block;
   transition: background-color 0.25s ease, border-color 0.25s ease;
@@ -19,7 +19,7 @@ $slide-toggle--gap: $cf-border * 2;
   }
 }
 
-.slide-toggle--knob {
+.cf-slide-toggle--knob {
   position: absolute;
   top: 50%;
   transition: background-color 0.35s ease,
@@ -29,7 +29,7 @@ $slide-toggle--gap: $cf-border * 2;
   box-shadow: 0 0 $slide-toggle--gap ($slide-toggle--gap / 2) rgba($g0-obsidian, 0.25);
   background-color: $g13-mist;
     
-  .slide-toggle:hover & {
+  .cf-slide-toggle:hover & {
     background-color: $g20-white;
   }
 }
@@ -38,7 +38,7 @@ $slide-toggle--gap: $cf-border * 2;
   Active State
   ------------------------------------------------------------------------------
 */
-.slide-toggle.active .slide-toggle--knob {
+.cf-slide-toggle.active .cf-slide-toggle--knob {
   transform: translate(calc(100% + #{$slide-toggle--gap}), -50%);
   background-color: $g20-white;
 }
@@ -47,12 +47,12 @@ $slide-toggle--gap: $cf-border * 2;
   Disabled State
   ------------------------------------------------------------------------------
 */
-.slide-toggle.disabled,
-.slide-toggle.disabled:hover {
+.cf-slide-toggle.disabled,
+.cf-slide-toggle.disabled:hover {
   cursor: default;
   background-color: $g5-pepper;
 
-  .slide-toggle--knob {
+  .cf-slide-toggle--knob {
     background-color: $g2-kevlar;
   }
 }
@@ -68,25 +68,25 @@ $slide-toggle--gap: $cf-border * 2;
   width: (floor($size * 0.75) * 2) - $slide-toggle--gap;
 
 
-  .slide-toggle--knob,
-  .slide-toggle--knob:before,
-  .slide-toggle--knob:after {
+  .cf-slide-toggle--knob,
+  .cf-slide-toggle--knob:before,
+  .cf-slide-toggle--knob:after {
     width: floor($size * 0.75) - ($slide-toggle--gap * 2);
     height: floor($size * 0.75) - ($slide-toggle--gap * 2);
   }
 }
 
-.slide-toggle {
-  &.slide-toggle-xs {
+.cf-slide-toggle {
+  &.cf-slide-toggle-xs {
     @include slideToggleSizeModifier($form-xs-height);
   }
-  &.slide-toggle-sm {
+  &.cf-slide-toggle-sm {
     @include slideToggleSizeModifier($form-sm-height);
   }
-  &.slide-toggle-md {
+  &.cf-slide-toggle-md {
     @include slideToggleSizeModifier($form-md-height);
   }
-  &.slide-toggle-lg {
+  &.cf-slide-toggle-lg {
     @include slideToggleSizeModifier($form-lg-height);
   }
 }
@@ -108,23 +108,23 @@ $slide-toggle--gap: $cf-border * 2;
   }
 }
 
-.slide-toggle {
-  &.slide-toggle-default {
+.cf-slide-toggle {
+  &.cf-slide-toggle-default {
     @include slideToggleColorModifier($g10-wolf, $g12-forge);
   }
-  &.slide-toggle-primary.active {
+  &.cf-slide-toggle-primary.active {
     @include slideToggleColorModifier($c-pool, $c-laser);
   }
-  &.slide-toggle-secondary.active {
+  &.cf-slide-toggle-secondary.active {
     @include slideToggleColorModifier($c-star, $c-comet);
   }
-  &.slide-toggle-success.active {
+  &.cf-slide-toggle-success.active {
     @include slideToggleColorModifier($c-rainforest, $c-honeydew);
   }
-  &.slide-toggle-danger.active {
+  &.cf-slide-toggle-danger.active {
     @include slideToggleColorModifier($c-curacao, $c-dreamsicle);
   }
-  &.slide-toggle-warning.active {
+  &.cf-slide-toggle-warning.active {
     @include slideToggleColorModifier($c-pineapple, $c-thunder);
   }
 }
@@ -133,7 +133,7 @@ $slide-toggle--gap: $cf-border * 2;
   Optional Label
   ------------------------------------------------------------------------------
 */
-.slide-toggle--label {
+.cf-slide-toggle--label {
   white-space: nowrap;
   font-weight: 600;
   @include no-user-select();
@@ -142,21 +142,21 @@ $slide-toggle--gap: $cf-border * 2;
   transition: opacity 0.25s ease;
   font-style: italic;
   
-  &.slide-toggle--label__active {
+  &.cf-slide-toggle--label__active {
     font-style: normal;
     opacity: 1;
   }
 }
 
-.slide-toggle--label-xs {
+.cf-slide-toggle--label-xs {
   font-size: $form-xs-font;
 }
-.slide-toggle--label-sm {
+.cf-slide-toggle--label-sm {
   font-size: $form-sm-font;
 }
-.slide-toggle--label-md {
+.cf-slide-toggle--label-md {
   font-size: $form-md-font;
 }
-.slide-toggle--label-lg {
+.cf-slide-toggle--label-lg {
   font-size: $form-lg-font;
 }

--- a/src/Components/SlideToggle/SlideToggle.tsx
+++ b/src/Components/SlideToggle/SlideToggle.tsx
@@ -50,7 +50,7 @@ export class SlideToggle extends Component<Props> {
         data-testid={testID}
         id={id}
       >
-        <div className="slide-toggle--knob" />
+        <div className="cf-slide-toggle--knob" />
       </div>
     )
   }
@@ -68,12 +68,12 @@ export class SlideToggle extends Component<Props> {
   private get className(): string {
     const {size, color, disabled, active, className} = this.props
 
-    return classnames('slide-toggle', {
+    return classnames('cf-slide-toggle', {
       active,
       disabled,
       [`${className}`]: className,
-      [`slide-toggle-${size}`]: size,
-      [`slide-toggle-${color}`]: color,
+      [`cf-slide-toggle-${size}`]: size,
+      [`cf-slide-toggle-${color}`]: color,
     })
   }
 }

--- a/src/Components/SlideToggle/SlideToggleLabel.tsx
+++ b/src/Components/SlideToggle/SlideToggleLabel.tsx
@@ -36,10 +36,10 @@ export class SlideToggleLabel extends Component<Props> {
   private get className(): string {
     const {className, size, active} = this.props
 
-    return classnames('slide-toggle--label', {
+    return classnames('cf-slide-toggle--label', {
       [`${className}`]: className,
-      [`slide-toggle--label-${size}`]: size,
-      'slide-toggle--label__active': active,
+      [`cf-slide-toggle--label-${size}`]: size,
+      'cf-slide-toggle--label__active': active,
     })
   }
 }

--- a/src/Components/Spinners/SparkleSpinner.scss
+++ b/src/Components/Spinners/SparkleSpinner.scss
@@ -5,12 +5,12 @@
   ------------------------------------------------------------------------------
 */
 
-.sparkle-spinner {
+.cf-sparkle-spinner {
   height: 100%;
   width: 100%;
 }
 
-.sparkle-spinner--stroke {
+.cf-sparkle-spinner--stroke {
   fill: none;
   stroke-width: 1.3802;
   stroke-linecap: round;
@@ -18,42 +18,42 @@
   stroke-miterlimit: 10;
 }
 
-.sparkle-spinner--stroke-light {
+.cf-sparkle-spinner--stroke-light {
   transition: stroke .5s ease;
   stroke: $g8-storm;
 }
 
-.sparkle-spinner--stroke-medium {
+.cf-sparkle-spinner--stroke-medium {
   transition: stroke .5s ease;
   stroke: $g7-graphite;
 }
 
-.sparkle-spinner--stroke-dark {
+.cf-sparkle-spinner--stroke-dark {
   transition: stroke .5s ease;
   stroke: $g6-smoke;
 }
 
-.sparkle-spinner--fill-light {
+.cf-sparkle-spinner--fill-light {
   transition: fill .5s ease;
   fill: $g8-storm;
 }
 
-.sparkle-spinner--fill-medium {
+.cf-sparkle-spinner--fill-medium {
   transition: fill .5s ease;
   fill: $g7-graphite;
 }
 
-.sparkle-spinner--fill-dark {
+.cf-sparkle-spinner--fill-dark {
   transition: fill .5s ease;
   fill: $g6-smoke;
 }
 
-.sparkle-spinner--fill-error {
+.cf-sparkle-spinner--fill-error {
   transition: all .5s ease;
   fill: $c-curacao;
 }
 
-.sparkle-spinner--fill-done {
+.cf-sparkle-spinner--fill-done {
   transition: all .5s ease;
   fill: $c-rainforest;
 }
@@ -64,18 +64,18 @@
   100% { opacity: 1; }
 }
 
-.sparkle-spinner--animate-sparkle {
+.cf-sparkle-spinner--animate-sparkle {
   animation: sparkleAnimation 2.1s infinite;
 }
 
-.sparkle-spinner--delay-1 {
+.cf-sparkle-spinner--delay-1 {
   animation-delay: .3s;
 }
 
-.sparkle-spinner--delay-2 {
+.cf-sparkle-spinner--delay-2 {
   animation-delay: .6s;
 }
 
-.sparkle-spinner--delay-3 {
+.cf-sparkle-spinner--delay-3 {
   animation-delay: .9s;
 }

--- a/src/Components/Spinners/SparkleSpinner.tsx
+++ b/src/Components/Spinners/SparkleSpinner.tsx
@@ -49,7 +49,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           viewBox="0 0 250 250"
         >
           <path
-            className={`sparkle-spinner--fill-medium sparkle-spinner--delay-3 ${
+            className={`cf-sparkle-spinner--fill-medium cf-sparkle-spinner--delay-3 ${
               this.animationState
             }`}
             d="M250,9.1C250,9.1,250,9.1,250,9.1l-1.6-7c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0l0,0l0,0c0,0,0,0,0,0L241.5,0
@@ -58,7 +58,7 @@ export class SparkleSpinner extends PureComponent<Props> {
 	C250,9.2,250,9.2,250,9.1L250,9.1L250,9.1C250,9.2,250,9.1,250,9.1C250,9.1,250,9.1,250,9.1z"
           />
           <path
-            className={`sparkle-spinner--fill-dark sparkle-spinner--delay-1 ${
+            className={`cf-sparkle-spinner--fill-dark cf-sparkle-spinner--delay-1 ${
               this.animationState
             }`}
             d="M168.5,187.9C168.5,187.9,168.5,187.9,168.5,187.9l-0.8-3.5c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0l0,0l0,0
@@ -68,7 +68,7 @@ export class SparkleSpinner extends PureComponent<Props> {
 	C168.5,187.9,168.5,187.9,168.5,187.9z"
           />
           <circle
-            className={`sparkle-spinner--fill-light sparkle-spinner--delay-2 ${
+            className={`cf-sparkle-spinner--fill-light cf-sparkle-spinner--delay-2 ${
               this.animationState
             }`}
             cx="231.5"
@@ -91,7 +91,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           />
           <g>
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-medium sparkle-spinner--delay-2 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-medium cf-sparkle-spinner--delay-2 ${
                 this.animationState
               }`}
               x1="30"
@@ -100,7 +100,7 @@ export class SparkleSpinner extends PureComponent<Props> {
               y2="104.4"
             />
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-medium sparkle-spinner--delay-2 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-medium cf-sparkle-spinner--delay-2 ${
                 this.animationState
               }`}
               x1="37"
@@ -111,7 +111,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           </g>
           <g>
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-2 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-2 ${
                 this.animationState
               }`}
               x1="165.7"
@@ -120,7 +120,7 @@ export class SparkleSpinner extends PureComponent<Props> {
               y2="19.9"
             />
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-2 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-2 ${
                 this.animationState
               }`}
               x1="169.2"
@@ -131,7 +131,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           </g>
           <g>
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-dark sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-dark cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="5.1"
@@ -140,7 +140,7 @@ export class SparkleSpinner extends PureComponent<Props> {
               y2="248.4"
             />
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-dark sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-dark cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="8.6"
@@ -151,7 +151,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           </g>
           <g>
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="176.5"
@@ -160,7 +160,7 @@ export class SparkleSpinner extends PureComponent<Props> {
               y2="229.2"
             />
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="176.5"
@@ -171,7 +171,7 @@ export class SparkleSpinner extends PureComponent<Props> {
           </g>
           <g>
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="63.4"
@@ -180,7 +180,7 @@ export class SparkleSpinner extends PureComponent<Props> {
               y2="33.3"
             />
             <line
-              className={`sparkle-spinner--stroke sparkle-spinner--stroke-light sparkle-spinner--delay-3 ${
+              className={`cf-sparkle-spinner--stroke cf-sparkle-spinner--stroke-light cf-sparkle-spinner--delay-3 ${
                 this.animationState
               }`}
               x1="63.4"
@@ -190,21 +190,21 @@ export class SparkleSpinner extends PureComponent<Props> {
             />
           </g>
           <path
-            className={`sparkle-spinner--fill-dark sparkle-spinner--delay-1 ${
+            className={`cf-sparkle-spinner--fill-dark cf-sparkle-spinner--delay-1 ${
               this.animationState
             }`}
             d="M101.6,51.6c1.2,0,2.1,1,2.1,2.1s-1,2.1-2.1,2.1s-2.1-1-2.1-2.1S100.5,51.6,101.6,51.6 M101.6,50.2
 		c-1.9,0-3.5,1.6-3.5,3.5c0,1.9,1.6,3.5,3.5,3.5c1.9,0,3.5-1.6,3.5-3.5C105.1,51.8,103.6,50.2,101.6,50.2L101.6,50.2z"
           />
           <path
-            className={`sparkle-spinner--fill-dark sparkle-spinner--delay-2 ${
+            className={`cf-sparkle-spinner--fill-dark cf-sparkle-spinner--delay-2 ${
               this.animationState
             }`}
             d="M64.2,215.2c3.1,0,5.6,2.5,5.6,5.6s-2.5,5.6-5.6,5.6c-3.1,0-5.6-2.5-5.6-5.6S61.1,215.2,64.2,215.2
 		 M64.2,213.9c-3.9,0-7,3.1-7,7s3.1,7,7,7c3.9,0,7-3.1,7-7S68.1,213.9,64.2,213.9L64.2,213.9z"
           />
           <path
-            className={`sparkle-spinner--fill-dark sparkle-spinner--delay-1 ${
+            className={`cf-sparkle-spinner--fill-dark cf-sparkle-spinner--delay-1 ${
               this.animationState
             }`}
             d="M38.8,153.1l8.8,2.7l2.1,9l-6.8,6.3l-8.8-2.7l-2.1-9L38.8,153.1 M38.5,151.6C38.5,151.6,38.5,151.6,38.5,151.6
@@ -214,7 +214,7 @@ export class SparkleSpinner extends PureComponent<Props> {
 		C51.2,165.3,51.2,165.3,51.2,165.3C51.2,165.3,51.2,165.3,51.2,165.3L51.2,165.3z"
           />
           <path
-            className={`sparkle-spinner--fill-medium sparkle-spinner--delay-1 ${
+            className={`cf-sparkle-spinner--fill-medium cf-sparkle-spinner--delay-1 ${
               this.animationState
             }`}
             d="M207.5,72.5l7.2,2.2l1.7,7.3l-5.5,5.1l-7.2-2.2l-1.7-7.3L207.5,72.5 M207.3,71C207.2,71,207.2,71,207.3,71
@@ -231,25 +231,27 @@ export class SparkleSpinner extends PureComponent<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('sparkle-spinner', {[`${className}`]: className})
+    return classnames('cf-sparkle-spinner', {[`${className}`]: className})
   }
 
   private get loadingStatus(): string {
     const {loading} = this.props
-    return classnames('sparkle-spinner--logo', {
-      'sparkle-spinner--fill-medium':
+    return classnames('cf-sparkle-spinner--logo', {
+      'cf-sparkle-spinner--fill-medium':
         loading === RemoteDataState.NotStarted ||
         loading === RemoteDataState.Loading,
-      'sparkle-spinner--animate-sparkle': loading === RemoteDataState.Loading,
-      'sparkle-spinner--fill-error': loading === RemoteDataState.Error,
-      'sparkle-spinner--fill-done': loading === RemoteDataState.Done,
+      'cf-sparkle-spinner--animate-sparkle':
+        loading === RemoteDataState.Loading,
+      'cf-sparkle-spinner--fill-error': loading === RemoteDataState.Error,
+      'cf-sparkle-spinner--fill-done': loading === RemoteDataState.Done,
     })
   }
 
   private get animationState(): string {
     const {loading} = this.props
     return classnames({
-      'sparkle-spinner--animate-sparkle': loading === RemoteDataState.Loading,
+      'cf-sparkle-spinner--animate-sparkle':
+        loading === RemoteDataState.Loading,
     })
   }
 }

--- a/src/Components/Spinners/SpinnerContainer.scss
+++ b/src/Components/Spinners/SpinnerContainer.scss
@@ -3,7 +3,7 @@
   ------------------------------------------------------------------------------
 */
 
-.spinner-container {
+.cf-spinner-container {
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/Components/Spinners/SpinnerContainer.tsx
+++ b/src/Components/Spinners/SpinnerContainer.tsx
@@ -42,6 +42,6 @@ export class SpinnerContainer extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('spinner-container', {[`${className}`]: className})
+    return classnames('cf-spinner-container', {[`${className}`]: className})
   }
 }

--- a/src/Components/Spinners/TechnoSpinner.scss
+++ b/src/Components/Spinners/TechnoSpinner.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-.techno-spinner {
+.cf-techno-spinner {
   border-style: solid;
   border-color: rgba($g5-pepper, 0.4);
   border-left-color: $c-pool;

--- a/src/Components/Spinners/TechnoSpinner.tsx
+++ b/src/Components/Spinners/TechnoSpinner.tsx
@@ -39,7 +39,7 @@ export class TechnoSpinner extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return className ? `techno-spinner ${className}` : 'techno-spinner'
+    return className ? `cf-techno-spinner ${className}` : 'cf-techno-spinner'
   }
 
   private get style(): CSSProperties {

--- a/src/Components/Spinners/WaitingText.scss
+++ b/src/Components/Spinners/WaitingText.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.waiting-text::after {
+.cf-waiting-text::after {
   animation: 2s linear loading-dots infinite;
   content: "..."
 }

--- a/src/Components/Spinners/WaitingText.tsx
+++ b/src/Components/Spinners/WaitingText.tsx
@@ -33,6 +33,6 @@ export class WaitingText extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('waiting-text', {[`${className}`]: className})
+    return classnames('cf-waiting-text', {[`${className}`]: className})
   }
 }

--- a/src/Components/Table/Table.scss
+++ b/src/Components/Table/Table.scss
@@ -9,22 +9,22 @@ $table-row-background: $g3-castle;
   ------------------------------------------------------------------------------
 */
 
-.table {
+.cf-table {
   border-collapse: collapse;
 }
 
-.table--cell {
+.cf-table--cell {
   color: $g11-sidewalk;
   transition: background-color 0.25s ease, color 0.25s ease;
   font-weight: 500;  
 }
 
-.table--header-cell {
+.cf-table--header-cell {
   color: $g15-platinum;
   font-weight: 900;  
 }
 
-.table--row {
+.cf-table--row {
   transition: background-color 0.25s ease;
 }
 
@@ -33,99 +33,99 @@ $table-row-background: $g3-castle;
   ------------------------------------------------------------------------------
 */
 
-.table__borders-none {
-  .table--cell,
-  .table--header-cell {
+.cf-table__borders-none {
+  .cf-table--cell,
+  .cf-table--header-cell {
     border: 0;
   }
 }
 
-.table__borders-all {
-  .table--cell,
-  .table--header-cell {
+.cf-table__borders-all {
+  .cf-table--cell,
+  .cf-table--header-cell {
     border: $cf-border solid $table-border--primary;
   }
 }
 
-.table__borders-horizontal {
-  .table--cell,
-  .table--header-cell {
+.cf-table__borders-horizontal {
+  .cf-table--cell,
+  .cf-table--header-cell {
     border-top: $cf-border solid $table-border--secondary;
     border-bottom: $cf-border solid $table-border--secondary;
   }
 
-  .table--header:first-child .table--row:first-child .table--header-cell {
+  .cf-table--header:first-child .cf-table--row:first-child .cf-table--header-cell {
     border-top: 0;
   }
 
-  .table--footer:last-child .table--row:last-child .table--cell,
-  .table--body:last-child .table--row:last-child .table--cell {
+  .cf-table--footer:last-child .cf-table--row:last-child .cf-table--cell,
+  .cf-table--body:last-child .cf-table--row:last-child .cf-table--cell {
     border-bottom: 0;
   }
 }
 
-.table__borders-vertical {
-  .table--cell,
-  .table--header-cell {
+.cf-table__borders-vertical {
+  .cf-table--cell,
+  .cf-table--header-cell {
     border-left: $cf-border solid $table-border--secondary;
     border-right: $cf-border solid $table-border--secondary;
   }
 
-  .table--header .table--row .table--header-cell:first-child,
-  .table--header .table--row .table--cell:first-child,
-  .table--body .table--row .table--header-cell:first-child,
-  .table--body .table--row .table--cell:first-child,
-  .table--footer .table--row .table--header-cell:first-child,
-  .table--footer .table--row .table--cell:first-child {
+  .cf-table--header .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--header .cf-table--row .cf-table--cell:first-child,
+  .cf-table--body .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--body .cf-table--row .cf-table--cell:first-child,
+  .cf-table--footer .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--footer .cf-table--row .cf-table--cell:first-child {
     border-left: 0;
   }
 
-  .table--header .table--row .table--header-cell:last-child,
-  .table--header .table--row .table--cell:last-child,
-  .table--body .table--row .table--header-cell:last-child,
-  .table--body .table--row .table--cell:last-child,
-  .table--footer .table--row .table--header-cell:last-child,
-  .table--footer .table--row .table--cell:last-child {
+  .cf-table--header .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--header .cf-table--row .cf-table--cell:last-child,
+  .cf-table--body .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--body .cf-table--row .cf-table--cell:last-child,
+  .cf-table--footer .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--footer .cf-table--row .cf-table--cell:last-child {
     border-right: 0;
   }
 }
 
-.table__borders-both {
-  .table--cell,
-  .table--header-cell {
+.cf-table__borders-both {
+  .cf-table--cell,
+  .cf-table--header-cell {
     border: $cf-border solid $table-border--secondary;
   }
 
-  .table--header:first-child .table--row:first-child .table--header-cell {
+  .cf-table--header:first-child .cf-table--row:first-child .cf-table--header-cell {
     border-top: 0;
   }
 
-  .table--footer:last-child .table--row:last-child .table--cell,
-  .table--body:last-child .table--row:last-child .table--cell {
+  .cf-table--footer:last-child .cf-table--row:last-child .cf-table--cell,
+  .cf-table--body:last-child .cf-table--row:last-child .cf-table--cell {
     border-bottom: 0;
   }
 
-  .table--header .table--row .table--header-cell:first-child,
-  .table--header .table--row .table--cell:first-child,
-  .table--body .table--row .table--header-cell:first-child,
-  .table--body .table--row .table--cell:first-child,
-  .table--footer .table--row .table--header-cell:first-child,
-  .table--footer .table--row .table--cell:first-child {
+  .cf-table--header .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--header .cf-table--row .cf-table--cell:first-child,
+  .cf-table--body .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--body .cf-table--row .cf-table--cell:first-child,
+  .cf-table--footer .cf-table--row .cf-table--header-cell:first-child,
+  .cf-table--footer .cf-table--row .cf-table--cell:first-child {
     border-left: 0;
   }
 
-  .table--header .table--row .table--header-cell:last-child,
-  .table--header .table--row .table--cell:last-child,
-  .table--body .table--row .table--header-cell:last-child,
-  .table--body .table--row .table--cell:last-child,
-  .table--footer .table--row .table--header-cell:last-child,
-  .table--footer .table--row .table--cell:last-child {
+  .cf-table--header .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--header .cf-table--row .cf-table--cell:last-child,
+  .cf-table--body .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--body .cf-table--row .cf-table--cell:last-child,
+  .cf-table--footer .cf-table--row .cf-table--header-cell:last-child,
+  .cf-table--footer .cf-table--row .cf-table--cell:last-child {
     border-right: 0;
   }
 }
 
-.table .table__borders-none th.table--header-cell,
-.table th.table--header-cell {
+.cf-table .cf-table__borders-none th.cf-table--header-cell,
+.cf-table th.cf-table--header-cell {
   border-bottom: $cf-border solid $table-border--primary;
 }
 
@@ -135,22 +135,22 @@ $table-row-background: $g3-castle;
 */
 
 @mixin tablePaddingModifier($padding) {
-  .table--cell,
-  .table--header-cell {
+  .cf-table--cell,
+  .cf-table--header-cell {
     padding: $padding;
   }
 }
 
-.table__padding-xs {
+.cf-table__padding-xs {
   @include tablePaddingModifier($form-xs-padding);
 }
-.table__padding-sm {
+.cf-table__padding-sm {
   @include tablePaddingModifier($form-sm-padding);
 }
-.table__padding-md {
+.cf-table__padding-md {
   @include tablePaddingModifier($form-md-padding);
 }
-.table__padding-lg {
+.cf-table__padding-lg {
   @include tablePaddingModifier($form-lg-padding);
 }
 
@@ -160,22 +160,22 @@ $table-row-background: $g3-castle;
 */
 
 @mixin tableFontModifier($fontSize) {
-  .table--cell,
-  .table--header-cell {
+  .cf-table--cell,
+  .cf-table--header-cell {
     font-size: $fontSize;
   }
 }
 
-.table__font-xs {
+.cf-table__font-xs {
   @include tableFontModifier($form-xs-font);
 }
-.table__font-sm {
+.cf-table__font-sm {
   @include tableFontModifier($form-sm-font);
 }
-.table__font-md {
+.cf-table__font-md {
   @include tableFontModifier($form-md-font);
 }
-.table__font-lg {
+.cf-table__font-lg {
   @include tableFontModifier($form-lg-font);
 }
 
@@ -184,7 +184,7 @@ $table-row-background: $g3-castle;
   ------------------------------------------------------------------------------
 */
 
-.table__striped .table--body .table--row:nth-child(odd) {
+.cf-table__striped .cf-table--body .cf-table--row:nth-child(odd) {
   background-color: rgba($table-row-background, 0.7);
 }
 
@@ -193,11 +193,11 @@ $table-row-background: $g3-castle;
   ------------------------------------------------------------------------------
 */
 
-.table__highlight .table--body .table--row:hover {
+.cf-table__highlight .cf-table--body .cf-table--row:hover {
   background-color: $table-row-background;
 }
 
-.table__highlight .table--body .table--row:hover .table--cell {
+.cf-table__highlight .cf-table--body .cf-table--row:hover .cf-table--cell {
   color: $g17-whisper;
 }
 
@@ -207,41 +207,41 @@ $table-row-background: $g3-castle;
 */
 
 @mixin tableColorModifier($background, $backgroundAlt, $backgroundHover, $border, $text) {
-  .table .table--body & .table--cell,
-  .table .table--body & .table--header-cell,
-  .table .table--header & .table--cell,
-  .table .table--header & .table--header-cell,
-  .table .table--footer & .table--cell,
-  .table .table--footer & .table--header-cell {
+  .cf-table .cf-table--body & .cf-table--cell,
+  .cf-table .cf-table--body & .cf-table--header-cell,
+  .cf-table .cf-table--header & .cf-table--cell,
+  .cf-table .cf-table--header & .cf-table--header-cell,
+  .cf-table .cf-table--footer & .cf-table--cell,
+  .cf-table .cf-table--footer & .cf-table--header-cell {
     background-color: $background;
     border-color: $border;
     color: rgba($text, 0.8);
   }
 
-  .table__striped .table--body &:nth-child(odd) .table--cell,
-  .table__striped .table--body &:nth-child(odd) .table--header-cell {
+  .cf-table__striped .cf-table--body &:nth-child(odd) .cf-table--cell,
+  .cf-table__striped .cf-table--body &:nth-child(odd) .cf-table--header-cell {
     background-color: $backgroundAlt;
   }
 
-  .table__highlight .table--body &:hover .table--cell,
-  .table__highlight .table--body &:hover .table--header-cell {
+  .cf-table__highlight .cf-table--body &:hover .cf-table--cell,
+  .cf-table__highlight .cf-table--body &:hover .cf-table--header-cell {
     background-color: $backgroundHover;
     color: $text;
   }
 }
 
-.table--row__primary {
+.cf-table--row__primary {
   @include tableColorModifier($c-sapphire, mix($c-ocean, $c-sapphire, 50%), $c-ocean, $c-pool, $g20-white);
 }
-.table--row__secondary {
+.cf-table--row__secondary {
   @include tableColorModifier($c-void, mix($c-amethyst, $c-void, 50%), $c-amethyst, $c-star, $g20-white);
 }
-.table--row__success {
+.cf-table--row__success {
   @include tableColorModifier($c-emerald, mix($c-viridian, $c-emerald, 50%), $c-viridian, $c-rainforest, $g20-white);
 }
-.table--row__warning {
+.cf-table--row__warning {
   @include tableColorModifier($c-tiger, mix($c-pineapple, $c-tiger, 50%), $c-pineapple, $c-thunder, $g3-castle);
 }
-.table--row__danger {
+.cf-table--row__danger {
   @include tableColorModifier($c-ruby, mix($c-fire, $c-ruby, 50%), $c-fire, $c-dreamsicle, $g20-white);
 }

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -81,12 +81,12 @@ export class Table extends Component<Props> {
       highlight,
     } = this.props
 
-    return classnames('table', {
-      [`table__padding-${cellPadding}`]: cellPadding,
-      [`table__borders-${borders}`]: borders,
-      [`table__font-${fontSize}`]: fontSize,
-      table__striped: striped,
-      table__highlight: highlight,
+    return classnames('cf-table', {
+      [`cf-table__padding-${cellPadding}`]: cellPadding,
+      [`cf-table__borders-${borders}`]: borders,
+      [`cf-table__font-${fontSize}`]: fontSize,
+      'cf-table__striped': striped,
+      'cf-table__highlight': highlight,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableBody.tsx
+++ b/src/Components/Table/TableBody.tsx
@@ -27,7 +27,7 @@ export class TableBody extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('table--body', {
+    return classnames('cf-table--body', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableCell.tsx
+++ b/src/Components/Table/TableCell.tsx
@@ -55,7 +55,7 @@ export class TableCell extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('table--cell', {
+    return classnames('cf-table--cell', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableFooter.tsx
+++ b/src/Components/Table/TableFooter.tsx
@@ -27,7 +27,7 @@ export class TableFooter extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('table--footer', {
+    return classnames('cf-table--footer', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableHeader.tsx
+++ b/src/Components/Table/TableHeader.tsx
@@ -27,7 +27,7 @@ export class TableHeader extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('table--header', {
+    return classnames('cf-table--header', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableHeaderCell.tsx
+++ b/src/Components/Table/TableHeaderCell.tsx
@@ -55,7 +55,7 @@ export class TableHeaderCell extends Component<Props> {
   private get className(): string {
     const {className} = this.props
 
-    return classnames('table--header-cell', {
+    return classnames('cf-table--header-cell', {
       [`${className}`]: className,
     })
   }

--- a/src/Components/Table/TableRow.tsx
+++ b/src/Components/Table/TableRow.tsx
@@ -31,9 +31,9 @@ export class TableRow extends Component<Props> {
   private get className(): string {
     const {className, color} = this.props
 
-    return classnames('table--row', {
+    return classnames('cf-table--row', {
       [`${className}`]: className,
-      [`table--row__${color}`]: color,
+      [`cf-table--row__${color}`]: color,
     })
   }
 }

--- a/src/Styles/_icon.scss
+++ b/src/Styles/_icon.scss
@@ -17,7 +17,7 @@
   font-style: normal;
 }
 
-.icon {
+.cf-icon {
   font-family: 'icomoon' !important;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
Closes #179

### Changes

Prefix all CSS classnames with `cf-` to avoid conflict with older (local) versions of components

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
