### PR TITLE
Bump version to match npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.0.21
+
+- [#198](https://github.com/influxdata/clockface/pull/198): Botched release
+
 ### 0.0.20
 
 - [#193](https://github.com/influxdata/clockface/pull/193): Extend `Dropdowns` to optionally drop up, fix liminal gap in dropdown parent element, and introduce `DropdownItemEmpty` component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Sync repo version to botched npm publish

- [ ] Added entry to top of Changelog with link to PR (not issue)
