### PR TITLE
Update publish script

### DIFF
--- a/publish
+++ b/publish
@@ -1,10 +1,28 @@
 #!/bin/bash
 
-set -e
+set -e 
 
 RELEASE_TYPE=${1:-patch}
 
-echo "Installing dependencies from lockfile"
+echo "Fetching git remotes"
+git fetch
+
+if ! git status | grep -q 'On branch master'; then
+  echo "Error! Must be on master branch to publish"
+  exit 1
+fi
+
+if ! git status | grep -q "Your branch is up to date with 'origin/master'."; then
+  echo "Error! Must be up to date with origin/master to publish"
+  exit 1
+fi
+
+if ! git status | grep -q 'working tree clean'; then
+  echo "Error! Cannot publish with dirty working tree"
+  exit 1
+fi
+
+echo "Installing dependencies"
 yarn -s install --frozen-lockfile
 
 echo "Running tests"
@@ -16,7 +34,7 @@ yarn run build
 echo "Tagging and publishing $RELEASE_TYPE release"
 yarn -s publish --$RELEASE_TYPE --access=public
 
-echo "Pushing commit"
+echo "Pushing git commit and tag"
 git push --follow-tags
 
 echo "Publish successful!"


### PR DESCRIPTION
Updates the `./publish` script to run a few checks before publishing:

- On the master branch
- master branch is even with origin/master
- The working tree is clean

This should prevent some issues with publish that Daniel and I worked through this morning.