### PR TITLE
feat: Introduce ConfirmationButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.22 (Unreleased)
 
+- [#204](https://github.com/influxdata/clockface/pull/204): Introduce `ConfirmationButton` composed component
 - [#202](https://github.com/influxdata/clockface/pull/202): Introduce standardized `Popover` component
 - [#197](https://github.com/influxdata/clockface/pull/197): Port `AutoInput` component from InfluxDB and add to `Input` family
 

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -48,7 +48,7 @@ export class ButtonBase extends Component<Props> {
     status: ComponentStatus.Default,
     active: false,
     type: ButtonType.Button,
-    testID: ButtonType.Button,
+    testID: 'button-base',
   }
 
   public render() {

--- a/src/Components/Button/Button.stories.tsx
+++ b/src/Components/Button/Button.stories.tsx
@@ -11,10 +11,12 @@ import {mapEnumKeys} from '../../Utils/storybook'
 // Components
 import {Button} from './Composed/Button'
 import {SquareButton} from './Composed/SquareButton'
+import {ConfirmationButton} from './Composed/ConfirmationButton'
 import {ButtonBase} from './Base/ButtonBase'
 
 // Types
 import {
+  PopoverType,
   ComponentColor,
   ComponentSize,
   IconFont,
@@ -27,6 +29,7 @@ import {
 import ButtonBaseReadme from './Base/ButtonBase.md'
 import ButtonReadme from './Composed/Button.md'
 import SquareButtonReadme from './Composed/SquareButton.md'
+import ConfirmationButtonReadme from './Composed/ConfirmationButton.md'
 
 const buttonBaseStories = storiesOf('Components|Buttons/Base', module)
   .addDecorator(withKnobs)
@@ -37,7 +40,7 @@ const buttonComposedStories = storiesOf('Components|Buttons/Composed', module)
   .addDecorator(jsxDecorator)
 
 buttonComposedStories.add(
-  'Standard Button',
+  'StandardButton',
   () => (
     <div className="story--example">
       <Button
@@ -79,7 +82,7 @@ buttonComposedStories.add(
 )
 
 buttonComposedStories.add(
-  'Square Button (Icon Only)',
+  'SquareButton',
   () => (
     <div className="story--example">
       <SquareButton
@@ -107,6 +110,61 @@ buttonComposedStories.add(
   {
     readme: {
       content: marked(SquareButtonReadme),
+    },
+  }
+)
+
+buttonComposedStories.add(
+  'ConfirmationButton',
+  () => (
+    <div className="story--example">
+      <ConfirmationButton
+        confirmationButtonText={text(
+          'confirmationButtonText',
+          'Yes, Delete it'
+        )}
+        confirmationButtonColor={
+          ComponentColor[
+            select('confirmationColor', mapEnumKeys(ComponentColor), 'Danger')
+          ]
+        }
+        confirmationLabel={text(
+          'confirmationLabel',
+          'Really delete your soul?'
+        )}
+        popoverColor={
+          ComponentColor[
+            select('popoverColor', mapEnumKeys(ComponentColor), 'Default')
+          ]
+        }
+        popoverType={
+          PopoverType[select('popoverType', mapEnumKeys(PopoverType), 'Solid')]
+        }
+        onConfirm={value => alert(`returnValue: ${value}`)}
+        returnValue={text('returnValue', '')}
+        icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Trash')]}
+        titleText={text('titleText', 'Title Text')}
+        color={
+          ComponentColor[select('color', mapEnumKeys(ComponentColor), 'Danger')]
+        }
+        size={
+          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+        }
+        shape={
+          ButtonShape[select('shape', mapEnumKeys(ButtonShape), 'Default')]
+        }
+        text={text('text', 'Delete Soul')}
+        status={
+          ComponentStatus[
+            select('status', mapEnumKeys(ComponentStatus), 'Default')
+          ]
+        }
+      />
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(ConfirmationButtonReadme),
     },
   }
 )

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -19,7 +19,7 @@ import {
   StandardProps,
 } from '../../../Types'
 
-interface Props extends StandardProps {
+export interface Props extends StandardProps {
   /** Text to be displayed on button */
   text?: string
   /** Function to be called on button click */
@@ -58,7 +58,7 @@ export class Button extends Component<Props> {
     status: ComponentStatus.Default,
     active: false,
     type: ButtonType.Button,
-    testID: ButtonType.Button,
+    testID: 'button',
     placeIconAfterText: false,
   }
 

--- a/src/Components/Button/Composed/ConfirmationButton.md
+++ b/src/Components/Button/Composed/ConfirmationButton.md
@@ -1,0 +1,20 @@
+# ConfirmationButton
+
+This is a composed combination of `Button` and `Popover` that offers a standardized way of having the user confirm a potentially dangerous action. By requiring a second click, and having the second click target offset from the base button, the user is highly unlikely to go through with the action accidentally.
+
+### Usage
+```tsx
+import {ConfirmationButton} from '@influxdata/clockface'
+```
+```tsx
+<ConfirmationButton />
+```
+
+### Example
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Button/Composed/ConfirmationButton.scss
+++ b/src/Components/Button/Composed/ConfirmationButton.scss
@@ -1,0 +1,24 @@
+@import '../../../Styles/modules';
+
+/*
+  Confirmation Button Styles
+  ------------------------------------------------------------------------------
+*/
+
+.cf-confirmation-button.cf-confirmation-button__stretch {
+  width: 100%;
+}
+
+.cf-confirmation-button--container {
+  display: flex;
+  align-items: center;
+  padding: $cf-marg-b;
+}
+
+.cf-confirmation-button--label {
+  margin: 0 $cf-marg-b;
+  white-space: nowrap;
+  font-weight: 500;
+  user-select: none;
+  font-size: $form-md-font;
+}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -94,6 +94,7 @@ export class ConfirmationButton extends Component<Props> {
           </div>
         )}
         testID={`${testID}--popover`}
+        disabled={this.isDisabled}
       >
         <Button
           placeIconAfterText={placeIconAfterText}
@@ -111,6 +112,19 @@ export class ConfirmationButton extends Component<Props> {
         />
       </Popover>
     )
+  }
+
+  private get isDisabled(): boolean {
+    const {status} = this.props
+
+    if (
+      status === ComponentStatus.Disabled ||
+      status === ComponentStatus.Loading
+    ) {
+      return true
+    }
+
+    return false
   }
 
   private get className(): string {

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -1,0 +1,130 @@
+// Libraries
+import React, {Component} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {Button} from './Button'
+import {Popover} from '../../Popover/Popover'
+
+// Styles
+import './ConfirmationButton.scss'
+
+// Types
+import {Props as ButtonProps} from './Button'
+import {
+  Omit,
+  ComponentSize,
+  ButtonShape,
+  ComponentStatus,
+  ComponentColor,
+  PopoverType,
+} from '../../../Types'
+
+interface Props extends Omit<ButtonProps, 'onClick' | 'active' | 'type'> {
+  /** Text to appear in confirmation popover */
+  confirmationLabel: string
+  /** Text to appear in confirmation button */
+  confirmationButtonText: string
+  /** Color of confirmation button */
+  confirmationButtonColor: ComponentColor
+  /** Popover dialog color */
+  popoverColor: ComponentColor
+  /** Means of applying color to popover */
+  popoverType: PopoverType
+  /** Function to call when confirmation is clicked, passes 'value' prop in */
+  onConfirm: (returnValue?: any) => void
+  /** Optional value to have passed back via onConfirm */
+  returnValue?: any
+}
+
+export class ConfirmationButton extends Component<Props> {
+  public static readonly displayName = 'ConfirmationButton'
+
+  public static defaultProps = {
+    confirmationButtonColor: ComponentColor.Danger,
+    testID: 'confirmation-button',
+    color: ComponentColor.Default,
+    size: ComponentSize.Small,
+    shape: ButtonShape.Default,
+    status: ComponentStatus.Default,
+    placeIconAfterText: false,
+    popoverColor: ComponentColor.Default,
+    popoverType: PopoverType.Solid,
+  }
+
+  public render() {
+    const {
+      confirmationButtonText,
+      confirmationButtonColor,
+      placeIconAfterText,
+      confirmationLabel,
+      popoverColor,
+      popoverType,
+      titleText,
+      refObject,
+      tabIndex,
+      testID,
+      status,
+      color,
+      shape,
+      text,
+      icon,
+      size,
+      id,
+    } = this.props
+
+    return (
+      <Popover
+        color={popoverColor}
+        type={popoverType}
+        className={this.className}
+        contents={() => (
+          <div className="cf-confirmation-button--container">
+            {confirmationLabel && (
+              <span className="cf-confirmation-button--label">
+                {confirmationLabel}
+              </span>
+            )}
+            <Button
+              onClick={this.handleConfirmClick}
+              text={confirmationButtonText}
+              color={confirmationButtonColor}
+              size={size}
+            />
+          </div>
+        )}
+        testID={`${testID}--popover`}
+      >
+        <Button
+          placeIconAfterText={placeIconAfterText}
+          titleText={titleText || text}
+          refObject={refObject}
+          tabIndex={tabIndex}
+          testID={`${testID}--button`}
+          status={status}
+          color={color}
+          shape={shape}
+          text={text}
+          size={size}
+          icon={icon}
+          id={id}
+        />
+      </Popover>
+    )
+  }
+
+  private get className(): string {
+    const {className, shape} = this.props
+
+    return classnames('cf-confirmation-button', {
+      'cf-confirmation-button__stretch': shape === ButtonShape.StretchToFit,
+      [`${className}`]: className,
+    })
+  }
+
+  private handleConfirmClick = (): void => {
+    const {returnValue, onConfirm} = this.props
+
+    onConfirm(returnValue)
+  }
+}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -54,8 +54,6 @@ export class ConfirmationButton extends Component<Props> {
 
   public render() {
     const {
-      confirmationButtonText,
-      confirmationButtonColor,
       placeIconAfterText,
       confirmationLabel,
       popoverColor,
@@ -78,19 +76,14 @@ export class ConfirmationButton extends Component<Props> {
         color={popoverColor}
         type={popoverType}
         className={this.className}
-        contents={() => (
+        contents={onHide => (
           <div className="cf-confirmation-button--container">
             {confirmationLabel && (
               <span className="cf-confirmation-button--label">
                 {confirmationLabel}
               </span>
             )}
-            <Button
-              onClick={this.handleConfirmClick}
-              text={confirmationButtonText}
-              color={confirmationButtonColor}
-              size={size}
-            />
+            {this.renderConfirm(onHide)}
           </div>
         )}
         testID={`${testID}--popover`}
@@ -136,9 +129,27 @@ export class ConfirmationButton extends Component<Props> {
     })
   }
 
-  private handleConfirmClick = (): void => {
-    const {returnValue, onConfirm} = this.props
+  private renderConfirm = (onHide: (() => void) | undefined): JSX.Element => {
+    const {
+      confirmationButtonText,
+      confirmationButtonColor,
+      returnValue,
+      onConfirm,
+      size,
+    } = this.props
 
-    onConfirm(returnValue)
+    const handleClick = (): void => {
+      onConfirm(returnValue)
+      onHide && onHide()
+    }
+
+    return (
+      <Button
+        onClick={handleClick}
+        text={confirmationButtonText}
+        color={confirmationButtonColor}
+        size={size}
+      />
+    )
   }
 }

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -51,7 +51,7 @@ export class SquareButton extends Component<Props> {
     status: ComponentStatus.Default,
     active: false,
     type: ButtonType.Button,
-    testID: ButtonType.Button,
+    testID: 'square-button',
   }
 
   public ref: RefObject<HTMLButtonElement> = React.createRef()

--- a/src/Components/Popover/Popover.scss
+++ b/src/Components/Popover/Popover.scss
@@ -53,10 +53,11 @@ $cf-popover-caret: $cf-marg-b;
   Color Modifiers
   ------------------------------------------------------------------------------
 */
-@mixin popoverColorModifier($solidColor, $outlineColor, $glowColor) {
+@mixin popoverColorModifier($solidColor, $outlineColor, $glowColor, $textColor) {
   // Solid Type
   &.cf-popover__solid .cf-popover--dialog-contents {
     background-color: $solidColor;
+    color: $textColor;
   }
   &.cf-popover__solid .cf-popover--caret {
     &__above {
@@ -94,22 +95,22 @@ $cf-popover-caret: $cf-marg-b;
 }
 
 .cf-popover__default {
-  @include popoverColorModifier($g6-smoke, $g11-sidewalk, $g8-storm);
+  @include popoverColorModifier($g6-smoke, $g11-sidewalk, $g8-storm, $g15-platinum);
 }
 .cf-popover__primary {
-  @include popoverColorModifier($c-pool, $c-pool, $c-ocean);
+  @include popoverColorModifier($c-pool, $c-pool, $c-ocean, $g20-white);
 }
 .cf-popover__secondary {
-  @include popoverColorModifier($c-star, $c-comet, $c-star);
+  @include popoverColorModifier($c-star, $c-comet, $c-star, $g20-white);
 }
 .cf-popover__success {
-  @include popoverColorModifier($c-rainforest, $c-honeydew, $c-rainforest);
+  @include popoverColorModifier($c-rainforest, $c-honeydew, $c-rainforest, $g20-white);
 }
 .cf-popover__warning {
-  @include popoverColorModifier($c-pineapple, $c-thunder, $c-tiger);
+  @include popoverColorModifier($c-pineapple, $c-thunder, $c-tiger, $g3-castle);
 }
 .cf-popover__danger {
-  @include popoverColorModifier($c-curacao, $c-dreamsicle, $c-fire);
+  @include popoverColorModifier($c-curacao, $c-dreamsicle, $c-fire, $g20-white);
 }
 
 

--- a/src/Components/Popover/Popover.scss
+++ b/src/Components/Popover/Popover.scss
@@ -7,7 +7,8 @@
 
 $cf-popover-caret: $cf-marg-b;
 
-.cf-popover {
+.cf-popover,
+.cf-popover--trigger {
   font-size: 0;
 }
 

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, ReactChild, createRef, CSSProperties} from 'react'
+import React, {Component, createRef, CSSProperties} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -22,7 +22,7 @@ interface Props extends StandardProps {
   /** Popover dialog color */
   color: ComponentColor
   /** Popover dialog contents */
-  contents: (onHide?: () => void) => ReactChild
+  contents: (onHide: () => void) => JSX.Element | (() => JSX.Element)
   /** Type of interaction to show the popover dialog */
   showEvent: PopoverInteraction
   /** Type of interaction to hide the popover dialog */
@@ -96,16 +96,16 @@ export class Popover extends Component<Props, State> {
 
     return (
       <ClickOutside onClickOutside={this.handleClickOutside}>
-        <div
-          className={this.className}
-          data-testid={testID}
-          id={id}
-          onClick={this.handleTriggerClick}
-          onMouseOver={this.handleTriggerMouseOver}
-          onMouseOut={this.handleTriggerMouseOut}
-          ref={this.triggerRef}
-        >
-          {children}
+        <div className={this.className} data-testid={testID} id={id}>
+          <div
+            className="cf-popover--trigger"
+            ref={this.triggerRef}
+            onClick={this.handleTriggerClick}
+            onMouseOver={this.handleTriggerMouseOver}
+            onMouseOut={this.handleTriggerMouseOut}
+          >
+            {children}
+          </div>
           {this.dialog}
         </div>
       </ClickOutside>

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -35,6 +35,8 @@ interface Props extends StandardProps {
   type: PopoverType
   /** Renders the popover dialog visible initially */
   initiallyVisible: boolean
+  /** Disables the popover's show interaction */
+  disabled: boolean
 }
 
 interface State {
@@ -59,6 +61,7 @@ export class Popover extends Component<Props, State> {
     position: PopoverPosition.Below,
     type: PopoverType.Solid,
     initiallyVisible: false,
+    disabled: false,
   }
 
   public static DismissButton = PopoverDismissButton
@@ -422,7 +425,11 @@ export class Popover extends Component<Props, State> {
   }
 
   private handleTriggerClick = (): void => {
-    const {showEvent} = this.props
+    const {showEvent, disabled} = this.props
+
+    if (disabled) {
+      return
+    }
 
     if (showEvent === PopoverInteraction.Click) {
       this.handleShowDialog()

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -1,3 +1,7 @@
+// Utilities
+export type Omit<K, V> = Pick<K, Exclude<keyof K, V>>
+
+// Shared Data Types
 export interface StandardProps {
   /** Useful for overriding styles of the component */
   className?: string


### PR DESCRIPTION
Closes #172

Rather than porting the component of the same name as defined in InfluxDB, I have recreated the functionality using a combination of `Button` and `Popover`.

### Changes

- Combine `Button` and `Popover` into a composed button called `ConfirmationButton`
- Offers more customizability than the existing `ConfirmationButton`
- Port over the `Omit` typescript interface from InfluxDB (mimics the omit feature in the latest ts)

### Screenshots

![confirmation-button](https://user-images.githubusercontent.com/2433762/62338661-258f1300-b48e-11e9-96e8-099ddeb0e3c8.gif)
![Screen Shot 2019-08-01 at 6 59 34 PM](https://user-images.githubusercontent.com/2433762/62338798-a2ba8800-b48e-11e9-9619-43be297cefc7.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
