### PR TITLE
refactor: Add "style" to StandardProps and implement in all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.0.25 (Unreleased)
 
 - [#219](https://github.com/influxdata/clockface/pull/219): Add `style` prop to all components
+- [#219](https://github.com/influxdata/clockface/pull/219): Ensure `className` prop in `TextArea` is being implemented correctly
 
 ### 0.0.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-### 0.0.25(Unreleased)
+### 0.0.25 (Unreleased)
 
--
+- [#219](https://github.com/influxdata/clockface/pull/219): Add `style` prop to all components
 
 ### 0.0.24
 

--- a/src/Components/Alerts/Alert.tsx
+++ b/src/Components/Alerts/Alert.tsx
@@ -26,10 +26,15 @@ export class Alert extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, icon, id} = this.props
+    const {testID, children, icon, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {!!icon && <Icon glyph={icon} className="cf-alert--icon" />}
         <div className="cf-alert--contents">{children}</div>
       </div>

--- a/src/Components/AppWrapper/AppWrapper.tsx
+++ b/src/Components/AppWrapper/AppWrapper.tsx
@@ -18,10 +18,15 @@ export class AppWrapper extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -61,6 +61,7 @@ export class ButtonBase extends Component<Props> {
       children,
       refObject,
       id,
+      style,
     } = this.props
 
     return (
@@ -73,6 +74,7 @@ export class ButtonBase extends Component<Props> {
         type={type}
         data-testid={testID}
         id={id}
+        style={style}
         ref={refObject}
       >
         {children}

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -77,6 +77,7 @@ export class Button extends Component<Props> {
       text,
       type,
       icon,
+      style,
       size,
       id,
     } = this.props
@@ -99,6 +100,7 @@ export class Button extends Component<Props> {
         shape={shape}
         type={type}
         size={size}
+        style={style}
         id={id}
       >
         {this.iconAndText}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -65,6 +65,7 @@ export class ConfirmationButton extends Component<Props> {
       status,
       color,
       shape,
+      style,
       text,
       icon,
       size,
@@ -88,6 +89,7 @@ export class ConfirmationButton extends Component<Props> {
         )}
         testID={`${testID}--popover`}
         disabled={this.isDisabled}
+        style={style}
       >
         <Button
           placeIconAfterText={placeIconAfterText}

--- a/src/Components/Button/Composed/DismissButton.tsx
+++ b/src/Components/Button/Composed/DismissButton.tsx
@@ -57,6 +57,7 @@ export class DismissButton extends Component<Props> {
       status,
       active,
       type,
+      style,
       refObject,
     } = this.props
 
@@ -72,6 +73,7 @@ export class DismissButton extends Component<Props> {
         status={status}
         active={active}
         type={type}
+        style={style}
         refObject={refObject}
       />
     )

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -69,6 +69,7 @@ export class SquareButton extends Component<Props> {
       color,
       type,
       size,
+      style,
       id,
     } = this.props
 
@@ -86,6 +87,7 @@ export class SquareButton extends Component<Props> {
         shape={ButtonShape.Square}
         type={type}
         size={size}
+        style={style}
         id={id}
       >
         {this.icon}

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -70,10 +70,16 @@ export class ColorPicker extends Component<Props, State> {
       colors,
       swatchesPerRow,
       id,
+      style,
     } = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <div className="cf-color-picker--swatches">
           {colors &&
             colors.map((color, i) => (

--- a/src/Components/ColorPicker/ColorPickerSwatch.tsx
+++ b/src/Components/ColorPicker/ColorPickerSwatch.tsx
@@ -45,10 +45,11 @@ export class ColorPickerSwatch extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {swatchesPerRow} = this.props
+    const {swatchesPerRow, style} = this.props
     const size = `${100 / swatchesPerRow}%`
 
     return {
+      ...style,
       width: size,
       paddingBottom: size,
     }

--- a/src/Components/ComponentSpacer/ComponentSpacer.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacer.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, CSSProperties} from 'react'
+import React, {Component} from 'react'
 import classnames from 'classnames'
 
 // Components

--- a/src/Components/ComponentSpacer/ComponentSpacer.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacer.tsx
@@ -20,8 +20,6 @@ import './ComponentSpacer.scss'
 interface Props extends StandardProps {
   /** Vertical or horizontal flex alignment */
   direction: FlexDirection
-  /** Pass through styles object */
-  style?: CSSProperties
   /** Inserted margin between children */
   margin?: ComponentSize
   /** Can be FlexStart, FlexEnd, Center, SpaceBetween, or SpaceAround */

--- a/src/Components/ComponentSpacer/ComponentSpacerFlexChild.tsx
+++ b/src/Components/ComponentSpacer/ComponentSpacerFlexChild.tsx
@@ -39,13 +39,14 @@ export class ComponentSpacerFlexChild extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {basis, grow, shrink} = this.props
+    const {basis, grow, shrink, style} = this.props
 
     const flexBasis = basis ? `${basis}px` : '0'
     const flexShrink = shrink
     const flexGrow = grow
 
     return {
+      ...style,
       flexGrow,
       flexShrink,
       flexBasis,

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -11,8 +11,6 @@ import './DapperScrollbars.scss'
 import {StandardProps} from '../../Types'
 
 interface Props extends StandardProps {
-  /** Inline CSS styles */
-  style?: CSSProperties
   /** Toggle display of tracks when no scrolling is necessary */
   removeTracksWhenNotUsed: boolean
   /** Toggle display of vertical track when no scrolling is necessary */

--- a/src/Components/DatePicker/Base/DatePicker.tsx
+++ b/src/Components/DatePicker/Base/DatePicker.tsx
@@ -65,12 +65,12 @@ export class DatePicker extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {dateTime, label, testID} = this.props
+    const {dateTime, label, testID, style} = this.props
 
     const date = new Date(dateTime || Date.now())
 
     return (
-      <div className="date-picker" data-testid={testID}>
+      <div className="date-picker" data-testid={testID} style={style}>
         <Form.Element label={label} errorMessage={this.inputErrorMessage}>
           <Input
             size={ComponentSize.Medium}

--- a/src/Components/DatePicker/Composed/DateRangePicker.tsx
+++ b/src/Components/DatePicker/Composed/DateRangePicker.tsx
@@ -42,11 +42,11 @@ export class DateRangePicker extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {testID} = this.props
+    const {testID, style} = this.props
     const {upper, lower} = this.state
 
     return (
-      <ComponentSpacer direction={FlexDirection.Column}>
+      <ComponentSpacer direction={FlexDirection.Column} style={style}>
         <ComponentSpacer direction={FlexDirection.Row} data-testid={testID}>
           <DatePicker
             dateTime={lower}

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -61,7 +61,7 @@ export class DraggableResizer extends Component<Props, State> {
   }
 
   public render() {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
       <div
@@ -69,6 +69,7 @@ export class DraggableResizer extends Component<Props, State> {
         ref={this.containerRef}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {this.children}
       </div>

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -33,7 +33,7 @@ export class DraggableResizerHandle extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
       <div
@@ -41,6 +41,7 @@ export class DraggableResizerHandle extends PureComponent<Props> {
         onMouseDown={this.handleMouseDown}
         title="Drag to resize"
         data-testid={testID}
+        style={style}
         id={id}
       >
         <div

--- a/src/Components/DraggableResizer/DraggableResizerPanel.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerPanel.tsx
@@ -45,12 +45,12 @@ export class DraggableResizerPanel extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {sizePercent, minSizePixels} = this.props
+    const {sizePercent, minSizePixels, style} = this.props
 
     if (sizePercent) {
-      return {flex: `${sizePercent} 0 ${minSizePixels}px`}
+      return {...style, flex: `${sizePercent} 0 ${minSizePixels}px`}
     }
 
-    return
+    return style
   }
 }

--- a/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
@@ -65,6 +65,7 @@ export class MultiSelectDropdown extends Component<Props> {
   public render() {
     const {
       id,
+      style,
       dropUp,
       testID,
       menuTheme,
@@ -82,6 +83,7 @@ export class MultiSelectDropdown extends Component<Props> {
         id={id}
         testID={testID}
         className={className}
+        style={style}
         widthPixels={widthPixels}
         dropUp={dropUp}
         button={(active, onClick) => (

--- a/src/Components/Dropdowns/Composed/SelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/SelectDropdown.tsx
@@ -62,6 +62,7 @@ export class SelectDropdown extends Component<Props> {
   public render() {
     const {
       id,
+      style,
       dropUp,
       testID,
       menuTheme,
@@ -78,6 +79,7 @@ export class SelectDropdown extends Component<Props> {
     return (
       <Dropdown
         id={id}
+        style={style}
         testID={testID}
         widthPixels={widthPixels}
         className={className}

--- a/src/Components/Dropdowns/Family/Dropdown.tsx
+++ b/src/Components/Dropdowns/Family/Dropdown.tsx
@@ -60,7 +60,7 @@ export class Dropdown extends Component<Props, State> {
   }
 
   public render() {
-    const {widthPixels, button, testID, id} = this.props
+    const {widthPixels, button, testID, id, style} = this.props
     const {expanded} = this.state
     const width = widthPixels ? `${widthPixels}px` : '100%'
 
@@ -68,7 +68,7 @@ export class Dropdown extends Component<Props, State> {
       <ClickOutside onClickOutside={this.collapseMenu}>
         <div
           className={this.className}
-          style={{width}}
+          style={{...style, width}}
           data-testid={testID}
           id={id}
         >

--- a/src/Components/Dropdowns/Family/DropdownButton.tsx
+++ b/src/Components/Dropdowns/Family/DropdownButton.tsx
@@ -58,6 +58,7 @@ export class DropdownButton extends Component<Props> {
       size,
       color,
       id,
+      style,
     } = this.props
     return (
       <ButtonBase
@@ -72,6 +73,7 @@ export class DropdownButton extends Component<Props> {
         color={color}
         size={size}
         id={id}
+        style={style}
       >
         {!!icon && <Icon glyph={icon} className="cf-dropdown--icon" />}
         <span className="cf-dropdown--selected">{children}</span>

--- a/src/Components/Dropdowns/Family/DropdownDivider.tsx
+++ b/src/Components/Dropdowns/Family/DropdownDivider.tsx
@@ -18,7 +18,7 @@ export class DropdownDivider extends Component<Props> {
   }
 
   public render() {
-    const {text, testID, className, id} = this.props
+    const {text, testID, className, id, style} = this.props
 
     return (
       <div
@@ -28,6 +28,7 @@ export class DropdownDivider extends Component<Props> {
         })}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {text}
       </div>

--- a/src/Components/Dropdowns/Family/DropdownItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownItem.tsx
@@ -30,7 +30,7 @@ export class DropdownItem extends Component<Props> {
   }
 
   public render(): JSX.Element {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
       <div
@@ -38,6 +38,7 @@ export class DropdownItem extends Component<Props> {
         data-testid={testID}
         onClick={this.handleClick}
         id={id}
+        style={style}
       >
         {this.selectionIndicator}
         {this.childElements}

--- a/src/Components/Dropdowns/Family/DropdownItemEmpty.tsx
+++ b/src/Components/Dropdowns/Family/DropdownItemEmpty.tsx
@@ -22,10 +22,15 @@ export class DropdownItemEmpty extends Component<Props> {
   }
 
   public render(): JSX.Element {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.childElements}
       </div>
     )

--- a/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
+++ b/src/Components/Dropdowns/Family/DropdownLinkItem.tsx
@@ -26,10 +26,15 @@ export class DropdownLinkItem extends Component<Props> {
   }
 
   public render(): JSX.Element {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.selectionIndicator}
         {children}
       </div>

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -89,13 +89,13 @@ export class DropdownMenu extends Component<Props> {
   }
 
   private get containerStyle(): CSSProperties {
-    const {overrideWidth} = this.props
+    const {overrideWidth, style} = this.props
 
     if (overrideWidth) {
-      return {width: `${overrideWidth}px`}
+      return {...style, width: `${overrideWidth}px`}
     }
 
-    return {width: '100%'}
+    return {...style, width: '100%'}
   }
 
   private get thumbColorsFromTheme() {

--- a/src/Components/EmptyState/EmptyState.tsx
+++ b/src/Components/EmptyState/EmptyState.tsx
@@ -29,10 +29,15 @@ export class EmptyState extends Component<Props> {
   public static SubText = EmptyStateSubText
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/EmptyState/EmptyStateSubText.tsx
+++ b/src/Components/EmptyState/EmptyStateSubText.tsx
@@ -17,10 +17,10 @@ export class EmptyStateSubText extends Component<Props> {
   }
 
   render() {
-    const {text, testID, id} = this.props
+    const {text, testID, id, style} = this.props
 
     return (
-      <p className={this.className} data-testid={testID} id={id}>
+      <p className={this.className} data-testid={testID} id={id} style={style}>
         {text}
       </p>
     )

--- a/src/Components/EmptyState/EmptyStateText.tsx
+++ b/src/Components/EmptyState/EmptyStateText.tsx
@@ -44,10 +44,10 @@ export class EmptyStateText extends Component<Props & StandardProps> {
   }
 
   render() {
-    const {text, highlightWords, testID, id} = this.props
+    const {text, highlightWords, testID, id, style} = this.props
 
     return (
-      <h4 className={this.className} data-testid={testID} id={id}>
+      <h4 className={this.className} data-testid={testID} id={id} style={style}>
         {highlighter(text, highlightWords)}
       </h4>
     )

--- a/src/Components/Form/Form.tsx
+++ b/src/Components/Form/Form.tsx
@@ -31,8 +31,6 @@ interface Props extends StandardProps {
   name?: string
   /** Enable or disable form validation */
   noValidate?: boolean
-  /** Inline CSS styles */
-  style?: React.CSSProperties
   /** Function to be called on form submit */
   onSubmit?: (e: React.FormEvent) => void
   /** Context name or keyword */

--- a/src/Components/Form/FormBox.tsx
+++ b/src/Components/Form/FormBox.tsx
@@ -15,10 +15,15 @@ export class FormBox extends Component<Props> {
   }
 
   public render() {
-    const {children, className, testID, id} = this.props
+    const {children, className, testID, id, style} = this.props
 
     return (
-      <div className={`cf-form--box ${className}`} data-testid={testID} id={id}>
+      <div
+        className={`cf-form--box ${className}`}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Form/FormDivider.tsx
+++ b/src/Components/Form/FormDivider.tsx
@@ -40,14 +40,15 @@ export class FormDivider extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {lineColor} = this.props
+    const {lineColor, style} = this.props
 
     if (lineColor) {
       return {
+        ...style,
         backgroundColor: lineColor,
       }
     }
 
-    return
+    return style
   }
 }

--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -31,10 +31,15 @@ export class FormElement extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.label}
         {children}
         {this.errorMessage}

--- a/src/Components/Form/FormElementError.tsx
+++ b/src/Components/Form/FormElementError.tsx
@@ -17,10 +17,15 @@ export class FormElementError extends Component<Props> {
   }
 
   public render() {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
-      <span className={this.className} data-testid={testID} id={id}>
+      <span
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.message}
       </span>
     )

--- a/src/Components/Form/FormFooter.tsx
+++ b/src/Components/Form/FormFooter.tsx
@@ -15,10 +15,15 @@ export class FormFooter extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Form/FormHelpText.tsx
+++ b/src/Components/Form/FormHelpText.tsx
@@ -17,10 +17,15 @@ export class FormHelpText extends Component<Props> {
   }
 
   public render() {
-    const {text, testID, id} = this.props
+    const {text, testID, id, style} = this.props
 
     return (
-      <span className={this.className} data-testid={testID} id={id}>
+      <span
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {text}
       </span>
     )

--- a/src/Components/Form/FormLabel.tsx
+++ b/src/Components/Form/FormLabel.tsx
@@ -19,10 +19,15 @@ export class FormLabel extends Component<Props> {
   }
 
   public render() {
-    const {label, children, testID, id} = this.props
+    const {label, children, testID, id, style} = this.props
 
     return (
-      <label className={this.className} data-testid={testID} id={id}>
+      <label
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <span>
           {label}
           {this.requiredIndicator}

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -69,10 +69,15 @@ export class FormValidationElement extends Component<Props, State> {
   }
 
   public render() {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.label}
         {this.children}
         {this.errorMessage}

--- a/src/Components/GridLayout/Grid.tsx
+++ b/src/Components/GridLayout/Grid.tsx
@@ -25,10 +25,15 @@ export class Grid extends Component<Props> {
   public static Column = GridColumn
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/GridLayout/GridColumn.tsx
+++ b/src/Components/GridLayout/GridColumn.tsx
@@ -33,10 +33,15 @@ export class GridColumn extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/GridLayout/GridRow.tsx
+++ b/src/Components/GridLayout/GridRow.tsx
@@ -15,10 +15,15 @@ export class GridRow extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Icon/Icon.stories.tsx
+++ b/src/Components/Icon/Icon.stories.tsx
@@ -1,10 +1,10 @@
 // Libraries
-import * as React from 'react'
+import React, {CSSProperties} from 'react'
 import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, select, color, number} from '@storybook/addon-knobs'
+import {withKnobs, select, number, object} from '@storybook/addon-knobs'
 import {mapEnumKeys} from '../../Utils/storybook'
 import {jsxDecorator} from 'storybook-addon-jsx'
 
@@ -21,6 +21,8 @@ const iconStories = storiesOf('Atomic|Icon', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
 
+const iconStyleExample: CSSProperties = {color: '#6BDFFF'}
+
 iconStories.add(
   'Example',
   () => (
@@ -30,7 +32,7 @@ iconStories.add(
     >
       <Icon
         glyph={IconFont[select('glyph', mapEnumKeys(IconFont), 'Bell')]}
-        color={color('color', '')}
+        style={object('style', iconStyleExample)}
       />
     </div>
   ),

--- a/src/Components/Icon/Icon.tsx
+++ b/src/Components/Icon/Icon.tsx
@@ -1,14 +1,12 @@
 // Libraries
-import React, {Component, CSSProperties} from 'react'
+import React, {Component} from 'react'
 
 // Types
-import {IconFont, InfluxColors, StandardProps} from '../../Types'
+import {IconFont, StandardProps} from '../../Types'
 
 interface Props extends StandardProps {
   /** Icon to display */
   glyph: IconFont | string
-  /** Optional color string, can use InfluxColors enum or pass in your own value */
-  color?: InfluxColors | string
 }
 
 export class Icon extends Component<Props> {
@@ -19,29 +17,14 @@ export class Icon extends Component<Props> {
   }
 
   render() {
-    const {glyph, testID, id} = this.props
+    const {glyph, testID, id, style} = this.props
 
     const className = this.props.className
       ? `cf-icon ${glyph} ${this.props.className}`
       : `cf-icon ${glyph}`
 
     return (
-      <span
-        className={className}
-        data-testid={testID}
-        style={this.style}
-        id={id}
-      />
+      <span className={className} data-testid={testID} style={style} id={id} />
     )
-  }
-
-  private get style(): CSSProperties | undefined {
-    const {color} = this.props
-
-    if (color) {
-      return {color}
-    }
-
-    return
   }
 }

--- a/src/Components/IndexList/IndexList.tsx
+++ b/src/Components/IndexList/IndexList.tsx
@@ -30,10 +30,15 @@ export class IndexList extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <table className={this.className} data-testid={testID} id={id}>
+      <table
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </table>
     )

--- a/src/Components/IndexList/IndexListBody.tsx
+++ b/src/Components/IndexList/IndexListBody.tsx
@@ -19,11 +19,16 @@ export class IndexListBody extends Component<Props> {
   }
 
   public render() {
-    const {children, columnCount, emptyState, testID, id} = this.props
+    const {children, columnCount, emptyState, testID, id, style} = this.props
 
     if (React.Children.count(children)) {
       return (
-        <tbody className={this.className} data-testid={testID} id={id}>
+        <tbody
+          className={this.className}
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
           {children}
         </tbody>
       )

--- a/src/Components/IndexList/IndexListHeader.tsx
+++ b/src/Components/IndexList/IndexListHeader.tsx
@@ -14,10 +14,15 @@ export class IndexListHeader extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <thead className={this.className} data-testid={testID} id={id}>
+      <thead
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <tr>{children}</tr>
       </thead>
     )

--- a/src/Components/IndexList/IndexListHeaderCell.tsx
+++ b/src/Components/IndexList/IndexListHeaderCell.tsx
@@ -32,12 +32,12 @@ export class IndexListHeaderCell extends Component<Props> {
   }
 
   public render() {
-    const {columnName, width, testID, id} = this.props
+    const {columnName, width, testID, id, style} = this.props
 
     return (
       <th
         className={this.className}
-        style={{width}}
+        style={{...style, width}}
         onClick={this.handleClick}
         data-testid={testID}
         id={id}

--- a/src/Components/IndexList/IndexListRow.tsx
+++ b/src/Components/IndexList/IndexListRow.tsx
@@ -19,10 +19,10 @@ export class IndexListRow extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <tr data-testid={testID} className={this.className} id={id}>
+      <tr data-testid={testID} className={this.className} id={id} style={style}>
         {children}
       </tr>
     )

--- a/src/Components/IndexList/IndexListRowCell.tsx
+++ b/src/Components/IndexList/IndexListRowCell.tsx
@@ -22,11 +22,16 @@ export class IndexListRowCell extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
       <td className={this.className}>
-        <div className="index-list--cell" data-testid={testID} id={id}>
+        <div
+          className="index-list--cell"
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
           {children}
         </div>
       </td>

--- a/src/Components/Inputs/AutoInput.tsx
+++ b/src/Components/Inputs/AutoInput.tsx
@@ -41,10 +41,15 @@ export class AutoInput extends Component<Props> {
   }
 
   public render() {
-    const {testID, id, size, color, mode, onChangeMode} = this.props
+    const {testID, id, size, color, mode, onChangeMode, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <div className="auto-input--radio">
           <Radio shape={ButtonShape.StretchToFit} size={size} color={color}>
             <Radio.Button

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -114,7 +114,6 @@ export class Input extends Component<Props> {
       autocomplete,
       tabIndex,
       testID,
-      style,
     } = this.props
 
     return (
@@ -143,7 +142,6 @@ export class Input extends Component<Props> {
           maxLength={maxLength}
           tabIndex={tabIndex}
           data-testid={testID}
-          style={style}
         />
         {this.checkbox}
         {this.icon}
@@ -257,16 +255,16 @@ export class Input extends Component<Props> {
   }
 
   private get containerStyle(): CSSProperties {
-    const {widthPixels, type} = this.props
+    const {widthPixels, type, style} = this.props
 
     if (widthPixels) {
-      return {width: `${widthPixels}px`}
+      return {...style, width: `${widthPixels}px`}
     }
 
     if (type === InputType.Checkbox) {
-      return {}
+      return {...style}
     }
 
-    return {width: '100%'}
+    return {...style, width: '100%'}
   }
 }

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -114,6 +114,7 @@ export class Input extends Component<Props> {
       autocomplete,
       tabIndex,
       testID,
+      style,
     } = this.props
 
     return (
@@ -142,6 +143,7 @@ export class Input extends Component<Props> {
           maxLength={maxLength}
           tabIndex={tabIndex}
           data-testid={testID}
+          style={style}
         />
         {this.checkbox}
         {this.icon}

--- a/src/Components/Inputs/TextArea.tsx
+++ b/src/Components/Inputs/TextArea.tsx
@@ -156,17 +156,17 @@ export class TextArea extends Component<Props> {
 
     return classnames('cf-text-area--container', {
       [`cf-input-${size}`]: size,
-      [`className`]: className,
+      [`${className}`]: className,
     })
   }
 
   private get containerStyle(): CSSProperties {
-    const {widthPixels} = this.props
+    const {widthPixels, style} = this.props
 
     if (widthPixels) {
-      return {width: `${widthPixels}px`}
+      return {...style, width: `${widthPixels}px`}
     }
 
-    return {width: '100%'}
+    return {...style, width: '100%'}
   }
 }

--- a/src/Components/Label/Label.tsx
+++ b/src/Components/Label/Label.tsx
@@ -154,7 +154,7 @@ export class Label extends Component<Props, State> {
 
   private get style(): CSSProperties {
     const {isMouseOver} = this.state
-    const {color, onClick} = this.props
+    const {color, onClick, style} = this.props
 
     let backgroundColor = color
 
@@ -163,6 +163,7 @@ export class Label extends Component<Props, State> {
     }
 
     return {
+      ...style,
       backgroundColor: `${backgroundColor}`,
       color: this.textColor,
     }

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -33,7 +33,7 @@ export class NavMenu extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID, hide, id} = this.props
+    const {children, testID, hide, id, style} = this.props
 
     if (hide) {
       return
@@ -44,7 +44,7 @@ export class NavMenu extends PureComponent<Props> {
     })
 
     return (
-      <nav className={className} data-testid={testID} id={id}>
+      <nav className={className} data-testid={testID} id={id} style={style}>
         {children}
       </nav>
     )

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -30,6 +30,7 @@ export class NavMenuItem extends PureComponent<Props> {
       titleLink,
       iconLink,
       id,
+      style,
     } = this.props
 
     return (
@@ -40,6 +41,7 @@ export class NavMenuItem extends PureComponent<Props> {
         })}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {iconLink('cf-nav--item-icon')}
         <div className="cf-nav--item-menu">

--- a/src/Components/NavMenu/NavMenuSubItem.tsx
+++ b/src/Components/NavMenu/NavMenuSubItem.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import {PureComponent} from 'react'
+import {PureComponent, CSSProperties} from 'react'
 import classnames from 'classnames'
 
 // Types
@@ -9,7 +9,11 @@ interface Props extends StandardProps {
   /** Controls highlighting of the menu item */
   active: boolean
   /** Render prop for linked title text (suggested <a /> or <Link /> ) */
-  titleLink: (className: string, testID?: string) => JSX.Element
+  titleLink: (
+    className: string,
+    testID?: string,
+    style?: CSSProperties
+  ) => JSX.Element
 }
 
 export class NavMenuSubItem extends PureComponent<Props> {
@@ -20,13 +24,13 @@ export class NavMenuSubItem extends PureComponent<Props> {
   }
 
   public render() {
-    const {active, className, titleLink, testID} = this.props
+    const {active, className, titleLink, testID, style} = this.props
 
     const titleClass = classnames('cf-nav--sub-item', {
       active,
       [`${className}`]: className,
     })
 
-    return titleLink(titleClass, testID)
+    return titleLink(titleClass, testID, style)
   }
 }

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -85,7 +85,7 @@ export class Overlay extends Component<Props, State> {
   }
 
   private get childContainer(): JSX.Element {
-    const {children, testID} = this.props
+    const {children, testID, style} = this.props
     const {showChildren} = this.state
 
     if (showChildren) {
@@ -93,6 +93,7 @@ export class Overlay extends Component<Props, State> {
         <div
           className="cf-overlay--transition"
           data-testid={`${testID}--children`}
+          style={style}
         >
           {children}
         </div>
@@ -103,6 +104,7 @@ export class Overlay extends Component<Props, State> {
       <div
         className="cf-overlay--transition"
         data-testid={`${testID}--children`}
+        style={style}
       />
     )
   }

--- a/src/Components/Overlay/OverlayBody.tsx
+++ b/src/Components/Overlay/OverlayBody.tsx
@@ -15,14 +15,14 @@ export class OverlayBody extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, className, testID, id} = this.props
+    const {children, className, testID, id, style} = this.props
 
     const classname = classnames('cf-overlay--body', {
       [`${className}`]: className,
     })
 
     return (
-      <div className={classname} data-testid={testID} id={id}>
+      <div className={classname} data-testid={testID} id={id} style={style}>
         {children}
       </div>
     )

--- a/src/Components/Overlay/OverlayContainer.tsx
+++ b/src/Components/Overlay/OverlayContainer.tsx
@@ -36,8 +36,8 @@ export class OverlayContainer extends PureComponent<Props> {
   }
 
   private get style(): CSSProperties {
-    const {maxWidth} = this.props
+    const {maxWidth, style} = this.props
 
-    return {maxWidth: `${maxWidth}px`}
+    return {...style, maxWidth: `${maxWidth}px`}
   }
 }

--- a/src/Components/Overlay/OverlayFooter.tsx
+++ b/src/Components/Overlay/OverlayFooter.tsx
@@ -24,14 +24,14 @@ export class OverlayFooter extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, className, testID, id} = this.props
+    const {children, className, testID, id, style} = this.props
 
     const classname = classnames('cf-overlay--footer', {
       [`${className}`]: className,
     })
 
     return (
-      <div className={classname} data-testid={testID} id={id}>
+      <div className={classname} data-testid={testID} id={id} style={style}>
         <ComponentSpacer
           margin={ComponentSize.Small}
           direction={FlexDirection.Row}

--- a/src/Components/Overlay/OverlayHeader.tsx
+++ b/src/Components/Overlay/OverlayHeader.tsx
@@ -24,14 +24,22 @@ export class OverlayHeader extends PureComponent<Props> {
   }
 
   public render() {
-    const {title, onDismiss, children, testID, className, id} = this.props
+    const {
+      title,
+      onDismiss,
+      children,
+      testID,
+      className,
+      id,
+      style,
+    } = this.props
 
     const classname = classnames('cf-overlay--header', {
       [`${className}`]: className,
     })
 
     return (
-      <div className={classname} data-testid={testID} id={id}>
+      <div className={classname} data-testid={testID} id={id} style={style}>
         <div className="cf-overlay--title">{title}</div>
         {onDismiss && (
           <button

--- a/src/Components/Overlay/OverlayMask.tsx
+++ b/src/Components/Overlay/OverlayMask.tsx
@@ -34,22 +34,23 @@ export class OverlayMask extends PureComponent<Props> {
       <div
         className={classname}
         data-testid={testID}
-        style={this.styles}
+        style={this.style}
         id={id}
       />
     )
   }
 
-  private get styles(): CSSProperties {
-    const {backgroundColor, gradient} = this.props
+  private get style(): CSSProperties {
+    const {backgroundColor, gradient, style} = this.props
 
     if (backgroundColor) {
-      return {backgroundColor}
+      return {...style, backgroundColor}
     }
 
     const colors = getColorsFromGradient(gradient)
 
     return {
+      ...style,
       background: `linear-gradient(45deg,  ${colors.start} 0%,${
         colors.stop
       } 100%)`,

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -44,10 +44,15 @@ export class Page extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -27,7 +27,7 @@ export class PageContents extends Component<Props> {
   }
 
   public render() {
-    const {scrollable, testID, id} = this.props
+    const {scrollable, testID, id, style} = this.props
 
     if (scrollable) {
       return (
@@ -36,6 +36,7 @@ export class PageContents extends Component<Props> {
           autoHide={false}
           testID={testID}
           id={id}
+          style={style}
         >
           <div className="cf-page-contents--padding">{this.children}</div>
         </DapperScrollbars>

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -31,14 +31,19 @@ export class PageHeader extends Component<Props> {
   public static Right = PageHeaderRight
 
   public render() {
-    const {hide, testID, id} = this.props
+    const {hide, testID, id, style} = this.props
 
     if (hide) {
       return null
     }
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <div className="cf-page-header--container">
           {this.childrenWithCorrectWidths}
         </div>

--- a/src/Components/Page/PageHeaderCenter.tsx
+++ b/src/Components/Page/PageHeaderCenter.tsx
@@ -44,9 +44,10 @@ export class PageHeaderCenter extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {widthPixels} = this.props
+    const {widthPixels, style} = this.props
 
     return {
+      ...style,
       flex: `1 0 ${widthPixels}px`,
     }
   }

--- a/src/Components/Page/PageHeaderLeft.tsx
+++ b/src/Components/Page/PageHeaderLeft.tsx
@@ -44,13 +44,14 @@ export class PageHeaderLeft extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {offsetPixels} = this.props
+    const {offsetPixels, style} = this.props
 
     if (offsetPixels === DEFAULT_OFFSET) {
-      return
+      return style
     }
 
     return {
+      ...style,
       flex: `1 0 calc(50% - ${offsetPixels}px)`,
     }
   }

--- a/src/Components/Page/PageHeaderRight.tsx
+++ b/src/Components/Page/PageHeaderRight.tsx
@@ -44,13 +44,14 @@ export class PageHeaderRight extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {offsetPixels} = this.props
+    const {offsetPixels, style} = this.props
 
     if (offsetPixels === DEFAULT_OFFSET) {
-      return
+      return style
     }
 
     return {
+      ...style,
       flex: `1 0 calc(50% - ${offsetPixels}px)`,
     }
   }

--- a/src/Components/Page/PageTitle.tsx
+++ b/src/Components/Page/PageTitle.tsx
@@ -19,7 +19,7 @@ export class PageTitle extends PureComponent<Props> {
   }
 
   public render() {
-    const {title, altText, testID, id} = this.props
+    const {title, altText, testID, id, style} = this.props
 
     return (
       <h1
@@ -27,6 +27,7 @@ export class PageTitle extends PureComponent<Props> {
         title={altText}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {title}
       </h1>

--- a/src/Components/Panel/Panel.tsx
+++ b/src/Components/Panel/Panel.tsx
@@ -75,19 +75,20 @@ export class Panel extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {gradient, backgroundColor} = this.props
+    const {gradient, backgroundColor, style} = this.props
 
     if (gradient) {
       const colors = getColorsFromGradient(gradient)
 
       return {
+        ...style,
         background: `linear-gradient(45deg,  ${colors.start} 0%,${
           colors.stop
         } 100%)`,
       }
     }
 
-    return {backgroundColor}
+    return {...style, backgroundColor}
   }
 
   private get useContrastText(): string {

--- a/src/Components/Panel/PanelBody.tsx
+++ b/src/Components/Panel/PanelBody.tsx
@@ -15,10 +15,15 @@ export class PanelBody extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Panel/PanelFooter.tsx
+++ b/src/Components/Panel/PanelFooter.tsx
@@ -15,10 +15,15 @@ export class PanelFooter extends Component<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Panel/PanelHeader.tsx
+++ b/src/Components/Panel/PanelHeader.tsx
@@ -26,10 +26,15 @@ export class PanelHeader extends Component<Props> {
   }
 
   public render() {
-    const {children, title, testID, id} = this.props
+    const {children, title, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <div className="cf-panel--title">{title}</div>
         <div className="cf-panel--controls">
           <ComponentSpacer

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -92,11 +92,16 @@ export class Popover extends Component<Props, State> {
   }
 
   public render() {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
       <ClickOutside onClickOutside={this.handleClickOutside}>
-        <div className={this.className} data-testid={testID} id={id}>
+        <div
+          className={this.className}
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
           <div
             className="cf-popover--trigger"
             ref={this.triggerRef}

--- a/src/Components/Radio/Radio.tsx
+++ b/src/Components/Radio/Radio.tsx
@@ -38,10 +38,15 @@ export class Radio extends Component<Props> {
   public static Button = RadioButton
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.containerClassName} data-testid={testID} id={id}>
+      <div
+        className={this.containerClassName}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/Radio/RadioButton.tsx
+++ b/src/Components/Radio/RadioButton.tsx
@@ -30,7 +30,7 @@ export class RadioButton extends Component<Props> {
   }
 
   public render() {
-    const {children, disabled, testID, id} = this.props
+    const {children, disabled, testID, id, style} = this.props
 
     return (
       <button
@@ -41,6 +41,7 @@ export class RadioButton extends Component<Props> {
         title={this.title}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {children}
       </button>

--- a/src/Components/ResourceList/Card/ResourceCard.tsx
+++ b/src/Components/ResourceList/Card/ResourceCard.tsx
@@ -44,10 +44,15 @@ export class ResourceCard extends PureComponent<Props> {
   public static EditableDescription = ResourceCardEditableDescription
 
   public render() {
-    const {description, labels, children, testID, name, id} = this.props
+    const {description, labels, children, testID, name, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.toggle}
         <div className="resource-card--contents">
           <div className="resource-card--row">{name}</div>

--- a/src/Components/ResourceList/Card/ResourceCardDescription.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardDescription.tsx
@@ -21,10 +21,15 @@ export class ResourceCardDescription extends Component<Props> {
   }
 
   public render() {
-    const {description, testID, id} = this.props
+    const {description, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <div className={this.previewClassName}>
           {description || 'No description'}
         </div>

--- a/src/Components/ResourceList/Card/ResourceCardEditableDescription.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableDescription.tsx
@@ -45,12 +45,17 @@ export class ResourceCardEditableDescription extends Component<Props, State> {
   }
 
   public render() {
-    const {description, testID, id} = this.props
+    const {description, testID, id, style} = this.props
     const {isEditing} = this.state
 
     if (isEditing) {
       return (
-        <div className={this.className} data-testid={testID} id={id}>
+        <div
+          className={this.className}
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
           <ClickOutside onClickOutside={this.handleStopEditing}>
             {this.input}
           </ClickOutside>

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -57,10 +57,15 @@ export class ResourceCardEditableName extends Component<Props, State> {
   }
 
   public render() {
-    const {name, noNameString, testID, buttonTestID, id} = this.props
+    const {name, noNameString, testID, buttonTestID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         <SpinnerContainer
           loading={this.state.loading}
           spinnerComponent={<TechnoSpinner diameterPixels={20} />}

--- a/src/Components/ResourceList/Card/ResourceCardName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardName.tsx
@@ -22,10 +22,10 @@ export class ResourceCardName extends Component<Props> {
   }
 
   public render() {
-    const {name, testID, id} = this.props
+    const {name, testID, id, style} = this.props
 
     return (
-      <div className="resource-name" data-testid={testID} id={id}>
+      <div className="resource-name" data-testid={testID} id={id} style={style}>
         <span className="resource-name--link" onClick={this.handleClick}>
           <span>{name}</span>
         </span>

--- a/src/Components/ResourceList/List/ResourceList.tsx
+++ b/src/Components/ResourceList/List/ResourceList.tsx
@@ -27,10 +27,15 @@ export class ResourceList extends PureComponent<Props> {
   public static Body = ResourceListBody
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </div>
     )

--- a/src/Components/ResourceList/List/ResourceListBody.tsx
+++ b/src/Components/ResourceList/List/ResourceListBody.tsx
@@ -18,10 +18,15 @@ export class ResourceListBody extends PureComponent<Props> {
   }
 
   public render() {
-    const {testID, id} = this.props
+    const {testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.children}
       </div>
     )

--- a/src/Components/ResourceList/List/ResourceListHeader.tsx
+++ b/src/Components/ResourceList/List/ResourceListHeader.tsx
@@ -18,10 +18,15 @@ export class ResourceListHeader extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID, id} = this.props
+    const {children, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {this.filter}
         <div className="resource-list--sorting">{children}</div>
       </div>

--- a/src/Components/ResourceList/List/ResourceListSorter.tsx
+++ b/src/Components/ResourceList/List/ResourceListSorter.tsx
@@ -24,7 +24,7 @@ export class ResourceListSorter extends PureComponent<Props> {
   }
 
   public render() {
-    const {name, testID, id} = this.props
+    const {name, testID, id, style} = this.props
 
     return (
       <div
@@ -33,6 +33,7 @@ export class ResourceListSorter extends PureComponent<Props> {
         title={this.title}
         data-testid={testID}
         id={id}
+        style={style}
       >
         {name}
         {this.sortIndicator}

--- a/src/Components/SlideToggle/SlideToggle.tsx
+++ b/src/Components/SlideToggle/SlideToggle.tsx
@@ -40,7 +40,7 @@ export class SlideToggle extends Component<Props> {
   }
 
   public render() {
-    const {tooltipText, testID, id} = this.props
+    const {tooltipText, testID, id, style} = this.props
 
     return (
       <div
@@ -49,6 +49,7 @@ export class SlideToggle extends Component<Props> {
         title={tooltipText}
         data-testid={testID}
         id={id}
+        style={style}
       >
         <div className="cf-slide-toggle--knob" />
       </div>

--- a/src/Components/SlideToggle/SlideToggleLabel.tsx
+++ b/src/Components/SlideToggle/SlideToggleLabel.tsx
@@ -27,10 +27,15 @@ export class SlideToggleLabel extends Component<Props> {
   }
 
   public render() {
-    const {text, testID, id} = this.props
+    const {text, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {text}
       </div>
     )

--- a/src/Components/Spinners/SparkleSpinner.tsx
+++ b/src/Components/Spinners/SparkleSpinner.tsx
@@ -28,6 +28,7 @@ export class SparkleSpinner extends PureComponent<Props> {
     const {testID, sizePixels, id} = this.props
 
     const style = {
+      ...this.props.style,
       width: `${sizePixels}px`,
       height: `${sizePixels}px`,
     }

--- a/src/Components/Spinners/SpinnerContainer.tsx
+++ b/src/Components/Spinners/SpinnerContainer.tsx
@@ -23,14 +23,19 @@ export class SpinnerContainer extends Component<Props> {
   }
 
   public render() {
-    const {loading, children, spinnerComponent, testID, id} = this.props
+    const {loading, children, spinnerComponent, testID, id, style} = this.props
 
     if (
       loading === RemoteDataState.Loading ||
       loading === RemoteDataState.NotStarted
     ) {
       return (
-        <div className={this.className} data-testid={testID} id={id}>
+        <div
+          className={this.className}
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
           {spinnerComponent}
         </div>
       )

--- a/src/Components/Spinners/TechnoSpinner.tsx
+++ b/src/Components/Spinners/TechnoSpinner.tsx
@@ -43,13 +43,13 @@ export class TechnoSpinner extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {diameterPixels} = this.props
+    const {diameterPixels, style} = this.props
 
     const borderWidth = `${this.strokeWidth}px`
     const width = `${diameterPixels}px`
     const height = `${diameterPixels}px`
 
-    return {width, height, borderWidth}
+    return {...style, width, height, borderWidth}
   }
 
   private get strokeWidth(): number {

--- a/src/Components/Spinners/WaitingText.tsx
+++ b/src/Components/Spinners/WaitingText.tsx
@@ -21,10 +21,15 @@ export class WaitingText extends Component<Props> {
   }
 
   public render() {
-    const {text, testID, id} = this.props
+    const {text, testID, id, style} = this.props
 
     return (
-      <div className={this.className} data-testid={testID} id={id}>
+      <div
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {text}
       </div>
     )

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -66,9 +66,9 @@ export class Table extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {width} = this.props
+    const {width, style} = this.props
 
-    return {width}
+    return {...style, width}
   }
 
   private get className(): string {

--- a/src/Components/Table/TableBody.tsx
+++ b/src/Components/Table/TableBody.tsx
@@ -15,10 +15,15 @@ export class TableBody extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
-      <tbody className={this.className} data-testid={testID} id={id}>
+      <tbody
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </tbody>
     )

--- a/src/Components/Table/TableCell.tsx
+++ b/src/Components/Table/TableCell.tsx
@@ -43,9 +43,10 @@ export class TableCell extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {horizontalAlignment, verticalAlignment, width} = this.props
+    const {horizontalAlignment, verticalAlignment, width, style} = this.props
 
     return {
+      ...style,
       textAlign: horizontalAlignment,
       verticalAlign: verticalAlignment,
       width,

--- a/src/Components/Table/TableFooter.tsx
+++ b/src/Components/Table/TableFooter.tsx
@@ -15,10 +15,15 @@ export class TableFooter extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
-      <tfoot className={this.className} data-testid={testID} id={id}>
+      <tfoot
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </tfoot>
     )

--- a/src/Components/Table/TableHeader.tsx
+++ b/src/Components/Table/TableHeader.tsx
@@ -15,10 +15,15 @@ export class TableHeader extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
-      <thead className={this.className} data-testid={testID} id={id}>
+      <thead
+        className={this.className}
+        data-testid={testID}
+        id={id}
+        style={style}
+      >
         {children}
       </thead>
     )

--- a/src/Components/Table/TableHeaderCell.tsx
+++ b/src/Components/Table/TableHeaderCell.tsx
@@ -43,9 +43,10 @@ export class TableHeaderCell extends Component<Props> {
   }
 
   private get style(): CSSProperties {
-    const {horizontalAlignment, verticalAlignment, width} = this.props
+    const {horizontalAlignment, verticalAlignment, width, style} = this.props
 
     return {
+      ...style,
       textAlign: horizontalAlignment,
       verticalAlign: verticalAlignment,
       width,

--- a/src/Components/Table/TableRow.tsx
+++ b/src/Components/Table/TableRow.tsx
@@ -19,10 +19,10 @@ export class TableRow extends Component<Props> {
   }
 
   public render() {
-    const {testID, children, id} = this.props
+    const {testID, children, id, style} = this.props
 
     return (
-      <tr className={this.className} data-testid={testID} id={id}>
+      <tr className={this.className} data-testid={testID} id={id} style={style}>
         {children}
       </tr>
     )

--- a/src/Components/TextBlock/TextBlock.stories.tsx
+++ b/src/Components/TextBlock/TextBlock.stories.tsx
@@ -1,11 +1,18 @@
 // Libraries
-import React from 'react'
+import React, {CSSProperties} from 'react'
 import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
 import {jsxDecorator} from 'storybook-addon-jsx'
-import {withKnobs, text, select, color, boolean} from '@storybook/addon-knobs'
+import {
+  withKnobs,
+  text,
+  select,
+  color,
+  boolean,
+  object,
+} from '@storybook/addon-knobs'
 import {mapEnumKeys} from '../../Utils/storybook'
 
 // Components
@@ -21,20 +28,26 @@ const textBlockStories = storiesOf('Atomic|TextBlock', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
 
+const customTextBlockStyles: CSSProperties = {
+  backgroundImage: 'linear-gradient(90deg, #ff0054 0%, rgba(0,212,255,1) 100%)',
+  width: '200px',
+  textAlign: 'center',
+}
+
 textBlockStories.add(
   'Example',
   () => (
     <div className="story--example">
-      <div style={{margin: '30px'}}>
+      <div style={{margin: '15px'}}>
         <TextBlock
-          text="TextBlock without backgroundColor or textColor"
+          text="No backgroundColor or textColor"
           size={
             ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
           }
           monospace={boolean('monospace', false)}
         />
       </div>
-      <div style={{margin: '30px'}}>
+      <div style={{margin: '15px'}}>
         <TextBlock
           text={text('text', 'I am customizable!')}
           size={
@@ -44,7 +57,7 @@ textBlockStories.add(
           monospace={boolean('monospace', false)}
         />
       </div>
-      <div style={{margin: '30px'}}>
+      <div style={{margin: '15px'}}>
         <TextBlock
           text={text('text', 'I am customizable!')}
           size={
@@ -53,6 +66,18 @@ textBlockStories.add(
           backgroundColor={color('backgroundColor', `${InfluxColors.Amethyst}`)}
           textColor={color('textColor', `${InfluxColors.Krypton}`)}
           monospace={boolean('monospace', false)}
+        />
+      </div>
+      <div style={{margin: '15px'}}>
+        <TextBlock
+          text="I can be styled"
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          backgroundColor={color('backgroundColor', `${InfluxColors.Amethyst}`)}
+          textColor={color('textColor', `${InfluxColors.Krypton}`)}
+          monospace={boolean('monospace', false)}
+          style={object('style', customTextBlockStyles)}
         />
       </div>
     </div>

--- a/src/Components/TextBlock/TextBlock.tsx
+++ b/src/Components/TextBlock/TextBlock.tsx
@@ -47,10 +47,10 @@ export class TextBlock extends Component<Props> {
   }
 
   private get style(): CSSProperties | undefined {
-    const {backgroundColor, textColor} = this.props
+    const {backgroundColor, textColor, style} = this.props
 
     if (!backgroundColor) {
-      return
+      return style
     }
 
     const darkContrast = chroma.contrast(
@@ -74,7 +74,7 @@ export class TextBlock extends Component<Props> {
       color = `${textColor}`
     }
 
-    return {backgroundColor, color}
+    return {...style, backgroundColor, color}
   }
 
   private get className(): string {

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -1,14 +1,18 @@
+import {CSSProperties} from 'react'
+
 // Utilities
 export type Omit<K, V> = Pick<K, Exclude<keyof K, V>>
 
 // Shared Data Types
 export interface StandardProps {
-  /** Useful for overriding styles of the component */
+  /** Useful for overriding styles of the component and its constituent elements */
   className?: string
   /** ID for Integration Tests */
   testID: string
   /** Unique identifier for getting an element */
   id?: string
+  /** Useful for setting common attributes like width or height */
+  style?: CSSProperties
 }
 
 export enum ComponentColor {


### PR DESCRIPTION
Closes #217
Closes #213 

### Changes

- Add `style` to `StandardProps`
- Ensure `style` prop was being passed into the outermost element (in most cases)
- Ensure `className` prop was being passed through correctly in `TextArea`
- Update docs for `TextBlock` and `Icon` components to expose `style` prop

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
