### PR TITLE
feat: upgrade page components

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -133,6 +133,18 @@
   }
 }
 
+.appWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+@media screen and (min-width: $nav-menu--breakpoint) {
+  .appWrapper {
+    flex-direction: row;
+  }
+}
+
 .mockOverlay {
   position: absolute;
   width: 100%;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 0.0.28 (Unreleased)
 
+- [#254](https://github.com/influxdata/clockface/pull/254): Add markdown documentation for `Page` components
+- [#254](https://github.com/influxdata/clockface/pull/254): [Breaking] Simplify how "Presentation Mode" is handled
+- [#254](https://github.com/influxdata/clockface/pull/254): Fix style bug in `Page` components that prevented `PageHeader` and `PageContents` from aligning properly
 - [#252](https://github.com/influxdata/clockface/pull/252): Add new colors and gradients from InfluxData Brand guidelines
 - [#251](https://github.com/influxdata/clockface/pull/251): Introduce `Wand`, `WrenchNav`, and `DisksNav` icons to icon font
 

--- a/src/Components/AppWrapper/AppWrapper.scss
+++ b/src/Components/AppWrapper/AppWrapper.scss
@@ -23,3 +23,22 @@
     flex-direction: row;
   }
 }
+
+/*
+   Presentation Mode
+   -----------------------------------------------------------------------------
+*/
+
+.clockface--app-wrapper__presentation-mode {
+  .cf-nav, 
+  .cf-page-header {
+    display: none;
+  }
+
+  .cf-page-contents__fixed,
+  .cf-page-contents__fluid,
+  .cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fluid,
+  .cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fixed {
+    padding: $page--gutter-small;
+  }
+}

--- a/src/Components/AppWrapper/AppWrapper.tsx
+++ b/src/Components/AppWrapper/AppWrapper.tsx
@@ -8,13 +8,17 @@ import './AppWrapper.scss'
 // Types
 import {StandardProps} from '../../Types'
 
-interface Props extends StandardProps {}
+interface Props extends StandardProps {
+  /** Hides the page header and nav menu so that the contents can take up the whole screen */
+  presentationMode: boolean
+}
 
 export class AppWrapper extends PureComponent<Props> {
   public static readonly displayName = 'AppWrapper'
 
   public static defaultProps = {
     testID: 'app-wrapper',
+    presentationMode: false,
   }
 
   public render() {
@@ -33,8 +37,11 @@ export class AppWrapper extends PureComponent<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, presentationMode} = this.props
 
-    return classnames('clockface--app-wrapper', {[`${className}`]: className})
+    return classnames('clockface--app-wrapper', {
+      'clockface--app-wrapper__presentation-mode': presentationMode,
+      [`${className}`]: className,
+    })
   }
 }

--- a/src/Components/NavMenu/NavMenu.stories.tsx
+++ b/src/Components/NavMenu/NavMenu.stories.tsx
@@ -25,7 +25,7 @@ enum NavItems {
 }
 
 navMenuStories.add('NavMenu', () => (
-  <NavMenu hide={boolean('hide', false)}>
+  <NavMenu>
     <NavMenu.Item
       titleLink={className => (
         <a className={className} href="#">

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -13,10 +13,7 @@ import {StandardProps} from '../../Types'
 // Styles
 import './NavMenu.scss'
 
-interface Props extends StandardProps {
-  /** Prevents NavMenu from rendering (used in presentation mode) */
-  hide?: boolean
-}
+interface Props extends StandardProps {}
 
 export class NavMenu extends PureComponent<Props> {
   public static readonly displayName = 'NavMenu'
@@ -33,11 +30,7 @@ export class NavMenu extends PureComponent<Props> {
   }
 
   public render() {
-    const {children, testID, hide, id, style} = this.props
-
-    if (hide) {
-      return
-    }
+    const {children, testID, id, style} = this.props
 
     const className = classnames('cf-nav', {
       [`${this.props.className}`]: this.props.className,

--- a/src/Components/NavMenu/NavMenu.tsx
+++ b/src/Components/NavMenu/NavMenu.tsx
@@ -13,7 +13,7 @@ import {StandardProps} from '../../Types'
 // Styles
 import './NavMenu.scss'
 
-interface Props extends StandardProps {}
+type Props = StandardProps
 
 export class NavMenu extends PureComponent<Props> {
   public static readonly displayName = 'NavMenu'

--- a/src/Components/Page/FullPage.md
+++ b/src/Components/Page/FullPage.md
@@ -1,0 +1,26 @@
+# Full Page Example
+
+This an example of all the `Page` components working together.
+
+### Usage
+```tsx
+import {Page} from '@influxdata/clockface'
+```
+```tsx
+<Page>
+  <Page.Header fullWidth={true} />
+  <Page.Contents fullWidth={true}>
+    // Contents go here
+  </Page.Contents>
+</Page>
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Page/Page.md
+++ b/src/Components/Page/Page.md
@@ -1,0 +1,31 @@
+# Page
+
+The `Page` component family is for laying out pages, hence the name. It is best used in combination with `AppWrapper` and `NavMenu`. *NOTE:* `Page` components used outside of `AppWrapper` may not appear as expected.
+
+### Usage
+```tsx
+import {Page} from '@influxdata/clockface'
+```
+In combination with `AppWrapper` and `NavMenu`:
+
+```tsx
+<AppWrapper>
+  <NavMenu />
+  <Page>
+    <Page.Header />
+    <Page.Contents>
+      // Contents go here
+    </Page.Contents>
+  </Page>
+</AppWrapper>
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Page/Page.scss
+++ b/src/Components/Page/Page.scss
@@ -7,34 +7,62 @@
 
 .cf-page {
   width: 100%;
-  flex: 1 0 calc(100% - #{$nav-menu--size});
+  flex: 1 0 100%;
   display: flex;
   flex-direction: column;
   align-items: stretch;
+
+  .cf-nav + & {
+    flex: 1 0 calc(100% - #{$nav-menu--size});
+  }
 }
 
 @media screen and (min-width: $nav-menu--breakpoint) {
   .cf-page {
     width: auto;
     height: 100%;
+    flex: 1 0 100%;
   }
 }
 
+/*
+   Gutters & Max Width
+   -----------------------------------------------------------------------------
+*/
+
+.cf-page-header--fluid,
+.cf-page-header--fixed,
+.cf-page-contents__fluid,
+.cf-page-contents__fixed {
+  width: 100%;
+  padding: 0 $page--gutter-small;
+}
+
+.cf-page-header--fixed,
+.cf-page-contents__fixed {
+  margin: 0 auto;
+  max-width: $page--max-width;
+}
+
+/*
+   Page Header
+   -----------------------------------------------------------------------------
+*/
+
 .cf-page-header {
-  height: $page--header-size;
+  width: 100%;
+  flex: 0 0 $page--header-size;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.cf-page-header--container {
+.cf-page-header--fluid,
+.cf-page-header--fixed {
   display: flex;
-  padding: 0 $page--gutter-small;
   align-items: center;
   justify-content: space-between;
   flex-wrap: nowrap;
-  width: 100%;
-  max-width: $page--max-width;
 }
 
 .cf-page-header--left,
@@ -77,10 +105,15 @@
   cursor: default;
 }
 
+/*
+  Page Contents
+  ------------------------------------------------------------------------------
+*/
+
 .cf-page-contents {
   width: 100%;
   position: relative;
-  height: calc(100% - #{$page--header-size}) !important;
+  flex: 1 0 calc(100% - #{$page--header-size});
   overflow: hidden;
 
   & > .cf-dapper-scrollbars--track-y {
@@ -92,32 +125,12 @@
   }
 }
 
-.cf-page-contents--padding {
+.cf-page-contents__fluid {
   min-height: 100%;
-  padding: $page--gutter-small;
-  padding-top: 0;
 }
 
-.cf-page-contents--container {
+.cf-page-contents__fixed {
   margin: 0 auto;
-  max-width: $page--max-width;
-}
-
-/*
-  Full Width Page
-  ------------------------------------------------------------------------------
-*/
-
-.cf-page-contents.full-width .cf-page-contents--padding {
-  padding: 0 $page--gutter-small;
-}
-
-.cf-page-contents--container.full-width {
-  max-width: 100%;
-}
-
-.cf-page-header.full-width .cf-page-header--container {
-  max-width: 100%;
 }
 
 /*
@@ -125,25 +138,23 @@
   ------------------------------------------------------------------------------
 */
 
-.cf-page-contents.cf-dapper-scrollbars > .cf-page-contents--padding {
+.cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fluid,
+.cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fixed {
   padding-bottom: $page--gutter-small;
 }
 
 /*
-  Full Height Mode
+  Non-Scrollable Page
   ------------------------------------------------------------------------------
 */
 
-.cf-page-contents.full-height {
-  height: 100% !important;
-}
+.cf-page-contents__no-scroll {
+  display: flex;
 
-.cf-page-contents.full-height .cf-page-contents--padding {
-  padding: $cf-marg-b;
-}
-
-.cf-page-contents.full-height.cf-dapper-scrollbars .cf-page-contents--padding {
-  padding-right: $cf-marg-c;
+  .cf-page-contents__fluid,
+  .cf-page-contents__fixed {
+    height: 100%;
+  }
 }
 
 /*
@@ -152,17 +163,21 @@
 */
 
 @media screen and (min-width: $nav-menu--breakpoint) {
-  .cf-page-header--container {
+  .cf-page-header--fluid,
+  .cf-page-header--fixed,
+  .cf-page-contents__fluid,
+  .cf-page-contents__fixed {
     padding: 0 $page--gutter;
   }
-  .cf-page-contents--padding {
-    padding: $page--gutter;
-    padding-top: 0;
-  }
-  .cf-page-contents.full-width .cf-page-contents--padding {
-    padding: 0 $page--gutter;
-  }
-  .cf-page-contents.cf-dapper-scrollbars > .cf-page-contents--padding {
+  
+  .cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fluid,
+  .cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fixed {
     padding-bottom: $page--gutter;
   }
 }
+
+/*
+  PresentationMode
+  ------------------------------------------------------------------------------
+*/
+

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -16,8 +16,6 @@ import './Page.scss'
 interface Props extends StandardProps {
   /** Use this prop to update document.title when the page first renders &  on subsequent updates */
   titleTag?: string
-  /** Hides the page header and nav menu so that the contents can take up the whole screen */
-  presentationMode: boolean
 }
 
 export class Page extends Component<Props> {
@@ -62,10 +60,9 @@ export class Page extends Component<Props> {
   }
 
   private get className(): string {
-    const {className, presentationMode} = this.props
+    const {className} = this.props
 
     return classnames('cf-page', {
-      'cf-page__presentation-mode': presentationMode,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Page/Page.tsx
+++ b/src/Components/Page/Page.tsx
@@ -16,6 +16,8 @@ import './Page.scss'
 interface Props extends StandardProps {
   /** Use this prop to update document.title when the page first renders &  on subsequent updates */
   titleTag?: string
+  /** Hides the page header and nav menu so that the contents can take up the whole screen */
+  presentationMode: boolean
 }
 
 export class Page extends Component<Props> {
@@ -23,6 +25,7 @@ export class Page extends Component<Props> {
 
   public static defaultProps = {
     testID: 'page',
+    presentationMode: false,
   }
 
   public static Header = PageHeader
@@ -59,9 +62,10 @@ export class Page extends Component<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, presentationMode} = this.props
 
     return classnames('cf-page', {
+      'cf-page__presentation-mode': presentationMode,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Page/PageContents.md
+++ b/src/Components/Page/PageContents.md
@@ -1,0 +1,23 @@
+# Page Contents
+
+Used alongside `<Page.Header />` to layout  page, this component is for containing the body of the page.
+
+### Usage
+```tsx
+import {Page} from '@influxdata/clockface'
+```
+```tsx
+<Page.Contents>
+  // Contents go here
+</Page.Contents>
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, ReactNode} from 'react'
+import React, {Component} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -15,6 +15,8 @@ interface Props extends StandardProps {
   fullHeight?: boolean
   /** Allows contents to scroll on overflow */
   scrollable: boolean
+  /** If scrollable is true, this toggles whether the scrollbar is always visible */
+  autoHideScrollbar: boolean
 }
 
 export class PageContents extends Component<Props> {
@@ -24,49 +26,63 @@ export class PageContents extends Component<Props> {
     fullHeight: false,
     scrollable: false,
     testID: 'page-contents',
+    autoHideScrollbar: false,
   }
 
   public render() {
-    const {scrollable, testID, id, style} = this.props
+    const {
+      scrollable,
+      testID,
+      id,
+      style,
+      children,
+      fullWidth,
+      autoHideScrollbar,
+    } = this.props
+
+    let kids = children
+
+    if (fullWidth) {
+      kids = <div className="cf-page-contents__fluid">{kids}</div>
+    } else {
+      kids = <div className="cf-page-contents__fixed">{kids}</div>
+    }
 
     if (scrollable) {
-      return (
+      kids = (
         <DapperScrollbars
           className={this.className}
-          autoHide={false}
+          autoHide={autoHideScrollbar}
           testID={testID}
           id={id}
           style={style}
         >
-          <div className="cf-page-contents--padding">{this.children}</div>
+          {kids}
         </DapperScrollbars>
+      )
+    } else {
+      kids = (
+        <div
+          className={this.className}
+          data-testid={testID}
+          id={id}
+          style={style}
+        >
+          {kids}
+        </div>
       )
     }
 
-    return (
-      <div className={this.className} data-testid={testID}>
-        <div className="cf-page-contents--padding">{this.children}</div>
-      </div>
-    )
+    return kids
   }
 
   private get className(): string {
-    const {fullWidth, fullHeight, className} = this.props
+    const {fullHeight, className, scrollable} = this.props
 
     return classnames('cf-page-contents', {
-      'full-width': fullWidth,
+      'cf-page-contents__no-scroll': !scrollable,
       'full-height': fullHeight,
       [`${className}`]: className,
     })
-  }
-
-  private get children(): JSX.Element | JSX.Element[] | ReactNode {
-    const {fullWidth, children} = this.props
-
-    if (fullWidth) {
-      return children
-    }
-
-    return <div className="cf-page-contents--container">{children}</div>
   }
 }

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -11,8 +11,6 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {
   /** Allows the page contents to fill the width of the screen */
   fullWidth: boolean
-  /** Allows contents to fill the full height of the screen (used in presentation mode) */
-  fullHeight?: boolean
   /** Allows contents to scroll on overflow */
   scrollable: boolean
   /** If scrollable is true, this toggles whether the scrollbar is always visible */
@@ -77,11 +75,10 @@ export class PageContents extends Component<Props> {
   }
 
   private get className(): string {
-    const {fullHeight, className, scrollable} = this.props
+    const {className, scrollable} = this.props
 
     return classnames('cf-page-contents', {
       'cf-page-contents__no-scroll': !scrollable,
-      'full-height': fullHeight,
       [`${className}`]: className,
     })
   }

--- a/src/Components/Page/PageHeader.md
+++ b/src/Components/Page/PageHeader.md
@@ -1,0 +1,28 @@
+# Page Header
+
+Used alongside `<Page.Contents />` to layout  page, this component is for containing the header of the page.
+
+### Usage
+```tsx
+import {Page} from '@influxdata/clockface'
+```
+```tsx
+<Page.Header>
+  // Should always have left & right children, center is optional
+  <Page.Header.Left />
+  <Page.Header.Center />
+  <Page.Header.Right />
+</Page.Header>
+```
+
+If you are planning to use `<Page.Header.Center />` keep in mind it requires a fixed pixel width to be specified. The pixel width is used to ensure the center is actually centered.
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -14,8 +14,6 @@ import {StandardProps} from '../../Types'
 interface Props extends StandardProps {
   /** Allows the page header to fill the width of the screen */
   fullWidth: boolean
-  /** Prevents NavMenu from rendering (used in presentation mode) */
-  hide: boolean
 }
 
 export class PageHeader extends Component<Props> {
@@ -31,11 +29,7 @@ export class PageHeader extends Component<Props> {
   public static Right = PageHeaderRight
 
   public render() {
-    const {hide, testID, id, style} = this.props
-
-    if (hide) {
-      return null
-    }
+    const {testID, id, style} = this.props
 
     return (
       <div

--- a/src/Components/Page/PageHeader.tsx
+++ b/src/Components/Page/PageHeader.tsx
@@ -44,7 +44,7 @@ export class PageHeader extends Component<Props> {
         id={id}
         style={style}
       >
-        <div className="cf-page-header--container">
+        <div className={this.containerClassName}>
           {this.childrenWithCorrectWidths}
         </div>
       </div>
@@ -52,12 +52,17 @@ export class PageHeader extends Component<Props> {
   }
 
   private get className(): string {
-    const {fullWidth, className} = this.props
+    const {className} = this.props
 
     return classnames('cf-page-header', {
-      'full-width': fullWidth,
       [`${className}`]: className,
     })
+  }
+
+  private get containerClassName(): string {
+    const {fullWidth} = this.props
+
+    return fullWidth ? 'cf-page-header--fluid' : 'cf-page-header--fixed'
   }
 
   private get childrenWithCorrectWidths(): ReactNode[] | ReactNode | undefined {

--- a/src/Components/Page/PageTitle.md
+++ b/src/Components/Page/PageTitle.md
@@ -1,0 +1,21 @@
+# Page Title
+
+Used primarily within `<Page.Header.Left />` as the title of a page, hence the name.
+
+### Usage
+```tsx
+import {Page} from '@influxdata/clockface'
+```
+```tsx
+<Page.Title />
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Page/page.stories.tsx
+++ b/src/Components/Page/page.stories.tsx
@@ -178,8 +178,8 @@ const layoutStories = storiesOf('Examples|Application Layout', module)
 
 layoutStories.add('AppWrapper + Nav + Page', () => (
   <div className="mockPage">
-    <AppWrapper>
-      <NavMenu hide={boolean('presentationMode', false)}>
+    <AppWrapper presentationMode={boolean('presentationMode', false)}>
+      <NavMenu>
         <NavMenu.Item
           titleLink={className => (
             <a className={className} href="#">
@@ -246,10 +246,7 @@ layoutStories.add('AppWrapper + Nav + Page', () => (
         />
       </NavMenu>
       <Page titleTag="bloop">
-        <Page.Header
-          fullWidth={boolean('fullWidth', false)}
-          hide={boolean('presentationMode', false)}
-        >
+        <Page.Header fullWidth={boolean('fullWidth', false)}>
           <Page.Header.Left>
             <Page.Title title={text('PageTitle title', 'Page Title')} />
           </Page.Header.Left>
@@ -257,7 +254,6 @@ layoutStories.add('AppWrapper + Nav + Page', () => (
         </Page.Header>
         <Page.Contents
           fullWidth={boolean('fullWidth', false)}
-          fullHeight={boolean('presentationMode', false)}
           scrollable={boolean('scrollable', true)}
         >
           <div

--- a/src/Components/Page/page.stories.tsx
+++ b/src/Components/Page/page.stories.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import * as React from 'react'
+import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
@@ -17,103 +18,159 @@ import {Icon} from '../Icon/Icon'
 // Types
 import {IconFont, ComponentColor, ButtonShape} from '../../Types'
 
-const pageStories = storiesOf('Components|Page/Family', module)
+// Notes
+import FullPageReadme from './FullPage.md'
+import PageReadme from './Page.md'
+import PageHeaderReadme from './PageHeader.md'
+import PageContentsReadme from './PageContents.md'
+import PageTitleReadme from './PageTitle.md'
+
+const pageStories = storiesOf('Layout|Page/Family', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
 
-const pageExampleStories = storiesOf('Components|Page/Examples', module)
+const pageExampleStories = storiesOf('Layout|Page/Examples', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
 
-pageStories.add('Page', () => (
-  <div className="mockPage">
-    <Page />
-  </div>
-))
+pageStories.add(
+  'Page',
+  () => (
+    <div className="story--example">
+      <Page />
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(PageReadme),
+    },
+  }
+)
 
-pageStories.add('PageHeader', () => (
-  <div className="mockPage">
-    <Page.Header fullWidth={boolean('fullWidth', false)}>
-      <Page.Header.Left>
-        <div className="mockComponent" style={{width: '100%'}}>
-          Left
-        </div>
-      </Page.Header.Left>
-      <Page.Header.Center widthPixels={number('widthPixels (center)', 200)}>
-        <div className="mockComponent" style={{width: '100%'}}>
-          Center
-        </div>
-      </Page.Header.Center>
-      <Page.Header.Right>
-        <div className="mockComponent" style={{width: '100%'}}>
-          Right
-        </div>
-      </Page.Header.Right>
-    </Page.Header>
-  </div>
-))
-
-pageStories.add('PageContents', () => (
-  <div className="mockPage">
-    <Page.Contents
-      fullWidth={boolean('fullWidth', false)}
-      scrollable={boolean('scrollable', false)}
-    >
-      <div
-        className="mockComponent pageContents"
-        style={{height: `${number('mock contents height', 1200)}px`}}
-      />
-    </Page.Contents>
-  </div>
-))
-
-pageStories.add('PageTitle', () => (
-  <Page.Title title={text('title', 'I am a page title!')} />
-))
-
-pageExampleStories.add('Full Width Page', () => (
-  <div className="mockPage">
-    <Page>
-      <Page.Header fullWidth={true}>
+pageStories.add(
+  'PageHeader',
+  () => (
+    <div className="story--example">
+      <Page.Header fullWidth={boolean('fullWidth', false)}>
         <Page.Header.Left>
-          <Page.Title title="Markdown Editor" />
+          <div className="mockComponent" style={{width: '100%'}}>
+            Left
+          </div>
         </Page.Header.Left>
-        <Page.Header.Center widthPixels={300}>
-          <Radio shape={ButtonShape.StretchToFit}>
-            <Radio.Button
-              id="mode--write"
-              titleText="Write Mode"
-              active={true}
-              value="write"
-              onClick={() => {}}
-            >
-              Write
-            </Radio.Button>
-            <Radio.Button
-              id="mode--preview"
-              titleText="Preview Mode"
-              active={false}
-              value="preview"
-              onClick={() => {}}
-            >
-              Preview
-            </Radio.Button>
-          </Radio>
+        <Page.Header.Center widthPixels={number('widthPixels (center)', 200)}>
+          <div className="mockComponent" style={{width: '100%'}}>
+            Center
+          </div>
         </Page.Header.Center>
         <Page.Header.Right>
-          <SquareButton icon={IconFont.Remove} />
-          <SquareButton
-            icon={IconFont.Checkmark}
-            color={ComponentColor.Success}
-          />
+          <div className="mockComponent" style={{width: '100%'}}>
+            Right
+          </div>
         </Page.Header.Right>
       </Page.Header>
-      <Page.Contents fullWidth={true} scrollable={false}>
-        <div className="mockComponent stretch" style={{height: '514px'}} />
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(PageHeaderReadme),
+    },
+  }
+)
+
+pageStories.add(
+  'PageContents',
+  () => (
+    <div className="story--example">
+      <Page.Contents
+        fullWidth={boolean('fullWidth', false)}
+        scrollable={boolean('scrollable', false)}
+      >
+        <div
+          className="mockComponent pageContents"
+          style={{height: `${number('mock contents height', 1200)}px`}}
+        />
       </Page.Contents>
-    </Page>
-  </div>
-))
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(PageContentsReadme),
+    },
+  }
+)
+
+pageStories.add(
+  'PageTitle',
+  () => (
+    <div className="story--example">
+      <Page.Title title={text('title', 'I am a page title!')} />
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(PageTitleReadme),
+    },
+  }
+)
+
+pageExampleStories.add(
+  'Full Page',
+  () => (
+    <div className="mockPage appWrapper">
+      <Page>
+        <Page.Header fullWidth={boolean('fullWidth', false)}>
+          <Page.Header.Left>
+            <Page.Title title="Markdown Editor" />
+          </Page.Header.Left>
+          <Page.Header.Center widthPixels={300}>
+            <Radio shape={ButtonShape.StretchToFit}>
+              <Radio.Button
+                id="mode--write"
+                titleText="Write Mode"
+                active={true}
+                value="write"
+                onClick={() => {}}
+              >
+                Write
+              </Radio.Button>
+              <Radio.Button
+                id="mode--preview"
+                titleText="Preview Mode"
+                active={false}
+                value="preview"
+                onClick={() => {}}
+              >
+                Preview
+              </Radio.Button>
+            </Radio>
+          </Page.Header.Center>
+          <Page.Header.Right>
+            <SquareButton icon={IconFont.Remove} />
+            <SquareButton
+              icon={IconFont.Checkmark}
+              color={ComponentColor.Success}
+            />
+          </Page.Header.Right>
+        </Page.Header>
+        <Page.Contents
+          fullWidth={boolean('fullWidth', false)}
+          scrollable={boolean('scrollable', false)}
+          autoHideScrollbar={boolean('autoHideScrollbar', false)}
+        >
+          <div
+            className="mockComponent stretch"
+            style={{height: `${text('contents height', '100%')}`}}
+          />
+        </Page.Contents>
+      </Page>
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(FullPageReadme),
+    },
+  }
+)
 
 const layoutStories = storiesOf('Examples|Application Layout', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
Closes #253 
Closes #147 

### Changes

- Fix styles such that `PageHeader` and `PageContents` margins line up vertically
- Simplify and consolidate styles between `PageHeader` and `PageContents`
- Add markdown documentation for `Page` components
- Improve how presentation mode is handled between `Page`, `AppWrapper`, and `NavMenu` (*Breaking*)

### Screenshots

![Screen Shot 2019-08-29 at 4 04 07 PM](https://user-images.githubusercontent.com/2433762/63982240-a7b32d00-ca76-11e9-8b5f-9033f879972b.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
