### PR TITLE
refactor: upgrade popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.0.28 (Unreleased)
 
+- [#255](https://github.com/influxdata/clockface/pull/255): Introduce `TextPopover` as a simplified composed version of `Popover`
+- [#255](https://github.com/influxdata/clockface/pull/255): [Breaking] rename `Popover` prop `initiallyVisible` to `visible` (now allows full external control of popover state)
 - [#252](https://github.com/influxdata/clockface/pull/252): Add new colors and gradients from InfluxData Brand guidelines
 - [#251](https://github.com/influxdata/clockface/pull/251): Introduce `Wand`, `WrenchNav`, and `DisksNav` icons to icon font
 

--- a/src/Components/Popover/Popover.md
+++ b/src/Components/Popover/Popover.md
@@ -21,9 +21,6 @@ import {Popover, PopoverPosition, PopoverInteraction} from '@influxdata/clockfac
 
 The popover dialog will initially appear according to the `position` prop, but if for some reason the dialog would go off the viewport it will be intelligently repositioned to appear wholly in the viewport.
 
-### Example
-<!-- STORY -->
-
 ### Customizable Interactions
 
 In most cases `Popover` works great with symmetric hide and show events. However in some cases you make want to have a popover appear with little effort, but demand more attention to dismiss. For example, a tutorial popover may have a "Next" button inside it that dismisses the popover, and queues the next. In order to achieve this you can take advantage of the `Popover`'s `contents` render prop:
@@ -68,7 +65,13 @@ import {Popover, PopoverPosition, PopoverInteraction} from '@influxdata/clockfac
 
 ### Gotchas
 
-The popover dialog makes use of `position: fixed` and `z-index: 9999` to ensure it is never obscured. In order to keep the dialog positioned next to the trigger the component listens for scroll and resize events while the popover is visible. This causes the dialog to re-render more often, which may be troublesome depending on what kind of component you render as the contents.
+- The popover dialog does not add any padding or other styles. This is so you don't have to fight the styles when you are a building your Popover.
+  - This means you need to have some styling on the element you pass in to the `contents` prop in order for the Popover to look decent.
+  - In the example below the `<div />` passed in to `contents` has a bunch of inline styles.
+- The popover dialog makes use of `position: fixed` and `z-index: 9999` to ensure it is never obscured. In order to keep the dialog positioned next to the trigger the component listens for scroll and resize events while the popover is visible. This causes the dialog to re-render more often, which may be troublesome depending on what kind of component you render as the contents.
+
+### Example
+<!-- STORY -->
 
 <!-- STORY HIDE START -->
 

--- a/src/Components/Popover/Popover.scss
+++ b/src/Components/Popover/Popover.scss
@@ -18,6 +18,7 @@ $cf-popover-caret: $cf-marg-b;
 }
 
 .cf-popover--dialog-contents {
+  font-size: $cf-text-base;
   background-color: $g2-kevlar;
   border-radius: $cf-radius + $cf-border;
   position: relative;

--- a/src/Components/Popover/Popover.stories.tsx
+++ b/src/Components/Popover/Popover.stories.tsx
@@ -72,10 +72,10 @@ popoverStories.add(
         }
         color={
           ComponentColor[
-            select('color', mapEnumKeys(ComponentColor), 'Default')
+            select('color', mapEnumKeys(ComponentColor), 'Primary')
           ]
         }
-        type={PopoverType[select('type', mapEnumKeys(PopoverType), 'Solid')]}
+        type={PopoverType[select('type', mapEnumKeys(PopoverType), 'Outline')]}
       >
         <div className="mockComponent mockButton">Popover Trigger Element</div>
       </Popover>
@@ -94,7 +94,7 @@ composedPopoverStories.add(
     <div className="story--example">
       <TextPopover
         visible={boolean('visible', false)}
-        text={text('text', 'Howdy friend!')}
+        text={text('text', 'Yee to the haw!')}
         distanceFromTrigger={number('distanceFromTrigger', 4)}
         showEvent={
           PopoverInteraction[
@@ -113,16 +113,16 @@ composedPopoverStories.add(
         }
         color={
           ComponentColor[
-            select('color', mapEnumKeys(ComponentColor), 'Default')
+            select('color', mapEnumKeys(ComponentColor), 'Primary')
           ]
         }
         dismissButtonColor={
           ComponentColor[
-            select('dismissButtonColor', mapEnumKeys(ComponentColor), 'Default')
+            select('dismissButtonColor', mapEnumKeys(ComponentColor), 'Primary')
           ]
         }
         showDismissButton={boolean('showDismissButton', false)}
-        type={PopoverType[select('type', mapEnumKeys(PopoverType), 'Solid')]}
+        type={PopoverType[select('type', mapEnumKeys(PopoverType), 'Outline')]}
       >
         <div className="mockComponent mockButton">Popover Trigger Element</div>
       </TextPopover>

--- a/src/Components/Popover/Popover.stories.tsx
+++ b/src/Components/Popover/Popover.stories.tsx
@@ -47,7 +47,6 @@ popoverStories.add(
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: '13px',
             }}
           >
             PopoverContents

--- a/src/Components/Popover/Popover.stories.tsx
+++ b/src/Components/Popover/Popover.stories.tsx
@@ -4,12 +4,13 @@ import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, select, number, boolean} from '@storybook/addon-knobs'
+import {withKnobs, select, number, boolean, text} from '@storybook/addon-knobs'
 import {jsxDecorator} from 'storybook-addon-jsx'
 import {mapEnumKeys} from '../../Utils/storybook'
 
 // Components
 import {Popover} from './Popover'
+import {TextPopover} from './TextPopover'
 import {DismissButton} from '../Button/Composed/DismissButton'
 
 // Types
@@ -22,13 +23,18 @@ import {
 
 // Notes
 import PopoverReadme from './Popover.md'
+import TextPopoverReadme from './TextPopover.md'
 
-const tooltipStories = storiesOf('Atomic|Popover', module)
+const popoverStories = storiesOf('Atomic|Popover/Base', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
 
-tooltipStories.add(
-  'Example',
+const composedPopoverStories = storiesOf('Atomic|Popover/Composed', module)
+  .addDecorator(withKnobs)
+  .addDecorator(jsxDecorator)
+
+popoverStories.add(
+  'Popover',
   () => (
     <div className="story--example">
       <Popover
@@ -78,6 +84,53 @@ tooltipStories.add(
   {
     readme: {
       content: marked(PopoverReadme),
+    },
+  }
+)
+
+composedPopoverStories.add(
+  'TextPopover',
+  () => (
+    <div className="story--example">
+      <TextPopover
+        visible={boolean('visible', false)}
+        text={text('text', 'Howdy friend!')}
+        distanceFromTrigger={number('distanceFromTrigger', 4)}
+        showEvent={
+          PopoverInteraction[
+            select('showEvent', mapEnumKeys(PopoverInteraction), 'Click')
+          ]
+        }
+        hideEvent={
+          PopoverInteraction[
+            select('hideEvent', mapEnumKeys(PopoverInteraction), 'Click')
+          ]
+        }
+        position={
+          PopoverPosition[
+            select('position', mapEnumKeys(PopoverPosition), 'Below')
+          ]
+        }
+        color={
+          ComponentColor[
+            select('color', mapEnumKeys(ComponentColor), 'Default')
+          ]
+        }
+        dismissButtonColor={
+          ComponentColor[
+            select('dismissButtonColor', mapEnumKeys(ComponentColor), 'Default')
+          ]
+        }
+        showDismissButton={boolean('showDismissButton', false)}
+        type={PopoverType[select('type', mapEnumKeys(PopoverType), 'Solid')]}
+      >
+        <div className="mockComponent mockButton">Popover Trigger Element</div>
+      </TextPopover>
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(TextPopoverReadme),
     },
   }
 )

--- a/src/Components/Popover/Popover.stories.tsx
+++ b/src/Components/Popover/Popover.stories.tsx
@@ -4,7 +4,7 @@ import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, select, number} from '@storybook/addon-knobs'
+import {withKnobs, select, number, boolean} from '@storybook/addon-knobs'
 import {jsxDecorator} from 'storybook-addon-jsx'
 import {mapEnumKeys} from '../../Utils/storybook'
 
@@ -32,6 +32,7 @@ tooltipStories.add(
   () => (
     <div className="story--example">
       <Popover
+        visible={boolean('visible', false)}
         contents={onHide => (
           <div
             style={{

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -33,8 +33,8 @@ interface Props extends StandardProps {
   position: PopoverPosition
   /** Means of applying color to popover */
   type: PopoverType
-  /** Renders the popover dialog visible initially */
-  initiallyVisible: boolean
+  /** Overrides internal popover expanded state */
+  visible: boolean
   /** Disables the popover's show interaction */
   disabled: boolean
 }
@@ -60,7 +60,7 @@ export class Popover extends Component<Props, State> {
     distanceFromTrigger: 4,
     position: PopoverPosition.Below,
     type: PopoverType.Solid,
-    initiallyVisible: false,
+    visible: false,
     disabled: false,
   }
 
@@ -73,16 +73,26 @@ export class Popover extends Component<Props, State> {
     super(props)
 
     this.state = {
-      expanded: this.props.initiallyVisible,
+      expanded: this.props.visible,
       triggerRect: null,
     }
   }
 
   public componentDidMount() {
-    if (this.props.initiallyVisible) {
+    if (this.props.visible) {
       this.handleShowDialog()
     } else {
       this.handleUpdateTriggerRect()
+    }
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (prevProps.visible !== this.props.visible) {
+      if (this.props.visible) {
+        this.handleShowDialog()
+      } else if (!this.props.visible) {
+        this.handleHideDialog()
+      }
     }
   }
 

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -18,7 +18,7 @@ import {
   PopoverType,
 } from '../../Types'
 
-interface Props extends StandardProps {
+export interface PopoverProps extends StandardProps {
   /** Popover dialog color */
   color: ComponentColor
   /** Popover dialog contents */
@@ -39,6 +39,18 @@ interface Props extends StandardProps {
   disabled: boolean
 }
 
+export const PopoverDefaultProps = {
+  color: ComponentColor.Primary,
+  testID: 'popover',
+  showEvent: PopoverInteraction.Click,
+  hideEvent: PopoverInteraction.Click,
+  distanceFromTrigger: 4,
+  position: PopoverPosition.Below,
+  type: PopoverType.Solid,
+  visible: false,
+  disabled: false,
+}
+
 interface State {
   expanded: boolean
   triggerRect: ClientRect | DOMRect | null
@@ -49,27 +61,17 @@ interface PopoverFlush {
   last: boolean
 }
 
-export class Popover extends Component<Props, State> {
+export class Popover extends Component<PopoverProps, State> {
   public static readonly displayName = 'Popover'
 
-  public static defaultProps = {
-    color: ComponentColor.Primary,
-    testID: 'popover',
-    showEvent: PopoverInteraction.Click,
-    hideEvent: PopoverInteraction.Click,
-    distanceFromTrigger: 4,
-    position: PopoverPosition.Below,
-    type: PopoverType.Solid,
-    visible: false,
-    disabled: false,
-  }
+  public static defaultProps = {...PopoverDefaultProps}
 
   public static DismissButton = DismissButton
 
   private triggerRef = createRef<HTMLDivElement>()
   private dialogRef = createRef<HTMLDivElement>()
 
-  constructor(props: Props) {
+  constructor(props: PopoverProps) {
     super(props)
 
     this.state = {
@@ -86,7 +88,7 @@ export class Popover extends Component<Props, State> {
     }
   }
 
-  public componentDidUpdate(prevProps: Props) {
+  public componentDidUpdate(prevProps: PopoverProps) {
     if (prevProps.visible !== this.props.visible) {
       if (this.props.visible) {
         this.handleShowDialog()

--- a/src/Components/Popover/Popover.tsx
+++ b/src/Components/Popover/Popover.tsx
@@ -46,7 +46,7 @@ export const PopoverDefaultProps = {
   hideEvent: PopoverInteraction.Click,
   distanceFromTrigger: 4,
   position: PopoverPosition.Below,
-  type: PopoverType.Solid,
+  type: PopoverType.Outline,
   visible: false,
   disabled: false,
 }

--- a/src/Components/Popover/TextPopover.md
+++ b/src/Components/Popover/TextPopover.md
@@ -1,0 +1,29 @@
+# Text Popover
+
+This is a simplified version of `Popover` that doesn't require any customization of the `contents` prop and assumes you just want to display plaintext or text elements. See the `Popover` documentation for more detail on implementing this components.
+
+### Usage
+```tsx
+import {TextPopover, PopoverPosition, PopoverInteraction} from '@influxdata/clockface'
+```
+```tsx
+<TextPopover
+  position={PopoverPosition.Above}
+  showEvent={PopoverInteraction.Hover}
+  hideEvent={PopoverInteraction.Hover}
+  text="Howdy friend!"
+>
+  <div>Trigger Element</div>
+</TextPopover>
+```
+
+The popover dialog will initially appear according to the `position` prop, but if for some reason the dialog would go off the viewport it will be intelligently repositioned to appear wholly in the viewport.
+
+### Example
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Popover/TextPopover.scss
+++ b/src/Components/Popover/TextPopover.scss
@@ -8,4 +8,13 @@
 .cf-text-popover {
   padding: $cf-marg-b;
   font-size: $cf-text-base;
+  font-weight: 600;
+
+  strong {
+    font-weight: 900;
+  }
+
+  &__dismissable {
+    padding: $cf-marg-c;
+  }
 }

--- a/src/Components/Popover/TextPopover.scss
+++ b/src/Components/Popover/TextPopover.scss
@@ -1,0 +1,11 @@
+@import '../../Styles/modules';
+
+/*
+  Text Popover Styles
+  ------------------------------------------------------------------------------
+*/
+
+.cf-text-popover {
+  padding: $cf-marg-b;
+  font-size: $cf-text-base;
+}

--- a/src/Components/Popover/TextPopover.tsx
+++ b/src/Components/Popover/TextPopover.tsx
@@ -1,0 +1,82 @@
+// Libraries
+import React, {PureComponent, ReactChild} from 'react'
+
+// Components
+import {DismissButton} from '../Button/Composed/DismissButton'
+import {Popover, PopoverProps, PopoverDefaultProps} from './Popover'
+
+// Styles
+import './TextPopover.scss'
+
+// Types
+import {Omit, ComponentColor} from '../../Types'
+
+interface Props extends Omit<PopoverProps, 'contents'> {
+  /** Text contents of popover dialog */
+  text: ReactChild
+  /** Determines whether to show the dismiss button in the dialog */
+  showDismissButton?: boolean
+  /** Color of dismiss button */
+  dismissButtonColor: ComponentColor
+}
+
+export class TextPopover extends PureComponent<Props> {
+  public static readonly displayName = 'TextPopover'
+
+  public static defaultProps = {
+    ...PopoverDefaultProps,
+    testID: 'text-popover',
+    showDismissButton: false,
+    dismissButtonColor: ComponentColor.Primary,
+  }
+
+  public render() {
+    const {
+      testID,
+      children,
+      id,
+      style,
+      color,
+      showEvent,
+      hideEvent,
+      distanceFromTrigger,
+      position,
+      type,
+      visible,
+      disabled,
+      showDismissButton,
+      dismissButtonColor,
+      text,
+    } = this.props
+
+    return (
+      <Popover
+        testID={testID}
+        id={id}
+        style={style}
+        color={color}
+        showEvent={showEvent}
+        hideEvent={hideEvent}
+        distanceFromTrigger={distanceFromTrigger}
+        position={position}
+        type={type}
+        visible={visible}
+        disabled={disabled}
+        contents={onHide => {
+          if (showDismissButton) {
+            return (
+              <div className="cf-text-popover">
+                <DismissButton onClick={onHide} color={dismissButtonColor} />
+                {text}
+              </div>
+            )
+          }
+
+          return <div className="cf-text-popover">{text}</div>
+        }}
+      >
+        {children}
+      </Popover>
+    )
+  }
+}

--- a/src/Components/Popover/TextPopover.tsx
+++ b/src/Components/Popover/TextPopover.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent, ReactChild} from 'react'
+import classnames from 'classnames'
 
 // Components
 import {DismissButton} from '../Button/Composed/DismissButton'
@@ -65,18 +66,26 @@ export class TextPopover extends PureComponent<Props> {
         contents={onHide => {
           if (showDismissButton) {
             return (
-              <div className="cf-text-popover">
+              <div className={this.className}>
                 <DismissButton onClick={onHide} color={dismissButtonColor} />
                 {text}
               </div>
             )
           }
 
-          return <div className="cf-text-popover">{text}</div>
+          return <div className={this.className}>{text}</div>
         }}
       >
         {children}
       </Popover>
     )
+  }
+
+  private get className(): string {
+    const {showDismissButton} = this.props
+
+    return classnames('cf-text-popover', {
+      'cf-text-popover__dismissable': showDismissButton,
+    })
   }
 }


### PR DESCRIPTION
Closes #250 
Closes #249 

### Changes

- Make `Popover` type `outline` by default
- Introduce `TextPopover` as a composed version of `Popover` that doesn't require any customization
- Improve documentation for `Popover`
- Allow internal `Popover` state to be overridden externally
  - Rename prop `initiallyVisible` to `visible`

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
