### PR TITLE
docs: add markdown docs for NavMenu components

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -460,6 +460,10 @@ body.sb-show-main {
       background-color: transparent;
     }
   }
+
+  pre + pre {
+    margin-top: -1em;
+  }
 }
 
 .storybook-readme-story div.markdown-body table {

--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -464,6 +464,28 @@ body.sb-show-main {
   pre + pre {
     margin-top: -1em;
   }
+
+  pre.language-tsx {
+    position: relative;
+
+    &:after {
+      content: 'JSX';
+      display: inline-block;
+      position: absolute;
+      top: 0;
+      right: 0;
+      color: $g8-storm;
+      font-size: 11px;
+      height: 18px;
+      line-height: 18px;
+      padding: 0 6px;
+      white-space: nowrap;
+      font-weight: 600;
+      text-shadow: none;
+      background-color: $g0-obsidian;
+      border-bottom-left-radius: 6px;
+    }
+  }
 }
 
 .storybook-readme-story div.markdown-body table {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.28 (Unreleased)
 
+- [#256](https://github.com/influxdata/clockface/pull/256): Add markdown documentation for `NavMenu` component family
 - [#252](https://github.com/influxdata/clockface/pull/252): Add new colors and gradients from InfluxData Brand guidelines
 - [#251](https://github.com/influxdata/clockface/pull/251): Introduce `Wand`, `WrenchNav`, and `DisksNav` icons to icon font
 

--- a/src/Components/NavMenu/NavMenu.md
+++ b/src/Components/NavMenu/NavMenu.md
@@ -1,0 +1,36 @@
+# NavMenu
+
+This is primary navigation component for Clockface applications. It is intentionally minimalistic to maximize screen space for application features. On small screens it moves to the top.
+
+### Usage
+```tsx
+import {NavMenu} from '@influxdata/clockface'
+```
+```tsx
+<NavMenu>
+  <NavMenu.Item>
+    <NavMenu.SubItem />
+  </NavMenu.Item>
+  <NavMenu.Item />
+</NavMenu>
+```
+
+### As Part of an Application Layout
+
+We recommend using `NavMenu` in combination with `AppWrapper` and `Page` to have all the basics for an application:
+```tsx
+<AppWrapper>
+  <NavMenu />
+  <Page />
+</AppWrapper>
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/NavMenu/NavMenu.stories.tsx
+++ b/src/Components/NavMenu/NavMenu.stories.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import * as React from 'react'
+import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
@@ -14,6 +15,11 @@ import {Icon} from '../../Components/Icon/Icon'
 // Types
 import {IconFont} from '../../Types'
 
+// Notes
+import NavMenuReadme from './NavMenu.md'
+import NavMenuItemReadme from './NavMenuItem.md'
+import NavMenuSubItemReadme from './NavMenuSubItem.md'
+
 const navMenuStories = storiesOf('Components|Navigation/NavMenu', module)
   .addDecorator(withKnobs)
   .addDecorator(jsxDecorator)
@@ -24,138 +30,176 @@ enum NavItems {
   Third = 'Third',
 }
 
-navMenuStories.add('NavMenu', () => (
-  <NavMenu hide={boolean('hide', false)}>
-    <NavMenu.Item
-      titleLink={className => (
-        <a className={className} href="#">
-          {text('1 - title', 'First Item')}
-        </a>
-      )}
-      iconLink={className => (
-        <a className={className} href="#">
-          <Icon
-            glyph={IconFont[select('1 - icon', mapEnumKeys(IconFont), 'Disks')]}
+navMenuStories.add(
+  'NavMenu',
+  () => (
+    <div className="story--example">
+      <NavMenu hide={boolean('hide', false)}>
+        <NavMenu.Item
+          titleLink={className => (
+            <a className={className} href="#">
+              {text('1 - title', 'First Item')}
+            </a>
+          )}
+          iconLink={className => (
+            <a className={className} href="#">
+              <Icon
+                glyph={
+                  IconFont[select('1 - icon', mapEnumKeys(IconFont), 'Disks')]
+                }
+              />
+            </a>
+          )}
+          active={
+            NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
+            NavItems.First
+          }
+        />
+        <NavMenu.Item
+          titleLink={className => (
+            <a className={className} href="#">
+              {text('2 - title', 'Second Item')}
+            </a>
+          )}
+          iconLink={className => (
+            <a className={className} href="#">
+              <Icon
+                glyph={
+                  IconFont[select('2 - icon', mapEnumKeys(IconFont), 'Zap')]
+                }
+              />
+            </a>
+          )}
+          active={
+            NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
+            NavItems.Second
+          }
+        >
+          <NavMenu.SubItem
+            titleLink={className => (
+              <a className={className} href="#">
+                First Sub-Item
+              </a>
+            )}
+            active={false}
           />
-        </a>
-      )}
-      active={
-        NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
-        NavItems.First
-      }
-    />
-    <NavMenu.Item
-      titleLink={className => (
-        <a className={className} href="#">
-          {text('2 - title', 'Second Item')}
-        </a>
-      )}
-      iconLink={className => (
-        <a className={className} href="#">
-          <Icon
-            glyph={IconFont[select('2 - icon', mapEnumKeys(IconFont), 'Zap')]}
+          <NavMenu.SubItem
+            titleLink={className => (
+              <a className={className} href="#">
+                Second Sub-Item
+              </a>
+            )}
+            active={false}
           />
-        </a>
-      )}
-      active={
-        NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
-        NavItems.Second
-      }
-    >
-      <NavMenu.SubItem
-        titleLink={className => (
-          <a className={className} href="#">
-            First Sub-Item
-          </a>
-        )}
-        active={false}
-      />
-      <NavMenu.SubItem
-        titleLink={className => (
-          <a className={className} href="#">
-            Second Sub-Item
-          </a>
-        )}
-        active={false}
-      />
-      <NavMenu.SubItem
-        titleLink={className => (
-          <a className={className} href="#">
-            Third Sub-Item
-          </a>
-        )}
-        active={false}
-      />
-    </NavMenu.Item>
-    <NavMenu.Item
-      titleLink={className => (
-        <a className={className} href="#">
-          {text('3 - title', 'Third Item')}
-        </a>
-      )}
-      iconLink={className => (
-        <a className={className} href="#">
-          <Icon
-            glyph={IconFont[select('3 - icon', mapEnumKeys(IconFont), 'Group')]}
+          <NavMenu.SubItem
+            titleLink={className => (
+              <a className={className} href="#">
+                Third Sub-Item
+              </a>
+            )}
+            active={false}
           />
-        </a>
-      )}
-      active={
-        NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
-        NavItems.Third
-      }
-    />
-  </NavMenu>
-))
+        </NavMenu.Item>
+        <NavMenu.Item
+          titleLink={className => (
+            <a className={className} href="#">
+              {text('3 - title', 'Third Item')}
+            </a>
+          )}
+          iconLink={className => (
+            <a className={className} href="#">
+              <Icon
+                glyph={
+                  IconFont[select('3 - icon', mapEnumKeys(IconFont), 'Group')]
+                }
+              />
+            </a>
+          )}
+          active={
+            NavItems[radios<NavItems>('active item', mapEnumKeys(NavItems))] ==
+            NavItems.Third
+          }
+        />
+      </NavMenu>
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(NavMenuReadme),
+    },
+  }
+)
 
-navMenuStories.add('NavMenuItem', () => (
-  <NavMenu.Item
-    titleLink={className => (
-      <a className={className} href="#">
-        {text('title', 'Item Title')}
-      </a>
-    )}
-    iconLink={className => (
-      <a className={className} href="#">
-        <Icon glyph={IconFont[select('icon', mapEnumKeys(IconFont), 'Star')]} />
-      </a>
-    )}
-    active={boolean('active', false)}
-  >
-    <NavMenu.SubItem
-      titleLink={className => (
-        <a className={className} href="#">
-          First Sub-Item
-        </a>
-      )}
-      active={false}
-    />
-    <NavMenu.SubItem
-      titleLink={className => (
-        <a className={className} href="#">
-          Second Sub-Item
-        </a>
-      )}
-      active={false}
-    />
-    <NavMenu.SubItem
-      titleLink={className => (
-        <a className={className} href="#">
-          Third Sub-Item
-        </a>
-      )}
-      active={false}
-    />
-  </NavMenu.Item>
-))
+navMenuStories.add(
+  'NavMenuItem',
+  () => (
+    <div className="story--example">
+      <NavMenu.Item
+        titleLink={className => (
+          <a className={className} href="#">
+            {text('title', 'Item Title')}
+          </a>
+        )}
+        iconLink={className => (
+          <a className={className} href="#">
+            <Icon
+              glyph={IconFont[select('icon', mapEnumKeys(IconFont), 'Star')]}
+            />
+          </a>
+        )}
+        active={boolean('active', false)}
+      >
+        <NavMenu.SubItem
+          titleLink={className => (
+            <a className={className} href="#">
+              First Sub-Item
+            </a>
+          )}
+          active={false}
+        />
+        <NavMenu.SubItem
+          titleLink={className => (
+            <a className={className} href="#">
+              Second Sub-Item
+            </a>
+          )}
+          active={false}
+        />
+        <NavMenu.SubItem
+          titleLink={className => (
+            <a className={className} href="#">
+              Third Sub-Item
+            </a>
+          )}
+          active={false}
+        />
+      </NavMenu.Item>
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(NavMenuItemReadme),
+    },
+  }
+)
 
-navMenuStories.add('NavMenuSubItem', () => (
-  <NavMenu.SubItem
-    titleLink={className => (
-      <a className={className} href="#">
-        {text('title', 'Sub Item Title')}
-      </a>
-    )}
-    active={boolean('active', false)}
-  />
-))
+navMenuStories.add(
+  'NavMenuSubItem',
+  () => (
+    <div className="story--example">
+      <NavMenu.SubItem
+        titleLink={className => (
+          <a className={className} href="#">
+            {text('title', 'Sub Item Title')}
+          </a>
+        )}
+        active={boolean('active', false)}
+      />
+    </div>
+  ),
+  {
+    readme: {
+      content: marked(NavMenuSubItemReadme),
+    },
+  }
+)

--- a/src/Components/NavMenu/NavMenuItem.md
+++ b/src/Components/NavMenu/NavMenuItem.md
@@ -1,0 +1,49 @@
+# NavMenuItem
+
+The first tier of navigation items. It can optionally contain `NavMenu.SubItem`
+
+### Usage
+```tsx
+import {NavMenu} from '@influxdata/clockface'
+```
+```tsx
+<NavMenu.Item />
+```
+
+### React Router
+
+Becuase we wanted to avoid having React Router as a dependency `NavMenuItem` and `NavMenuSubItem` make use of render props to allow `<Link />` elements to be passed in.
+The `titleLink` and `iconLink` props should be passed the same element to ensure consistency:
+
+```tsx
+// Using anchor tags
+<NavMenu.Item
+  iconLink={className => <a href="http://www.myurl.com" className={className}><Icon /></a>}
+  titleLink={className => <a href="http://www.myurl.com" className={className}>Item Title</a>}
+/>
+```
+```tsx
+// Using a router link
+<NavMenu.Item
+  iconLink={className => <a to="/pages/home" className={className}><Icon /></a>}
+  titleLink={className => <a to="/pages/home" className={className}>Item Title</a>}
+/>
+```
+
+### Creating Sub-Items
+
+Simply pass in `<NavMenu.SubItem />` as children of `<NavMenu.Item />` and they will appear below the title link
+
+### Styling
+
+`<NavMenu.Item />` receives its styles by being a child of `<NavMenu />`
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -6,9 +6,9 @@ import classnames from 'classnames'
 import {StandardProps} from '../../Types'
 
 interface Props extends StandardProps {
-  /** Render prop for linked title text (suggested <a /> or <Link /> ) */
+  /** Render prop for linked title text */
   titleLink: (className: string) => JSX.Element
-  /** Render prop for linked icon component (suggested <a /> or <Link /> ) */
+  /** Render prop for linked icon component */
   iconLink: (className: string) => JSX.Element
   /** Controls highlighting of the menu item */
   active: boolean

--- a/src/Components/NavMenu/NavMenuSubItem.md
+++ b/src/Components/NavMenu/NavMenuSubItem.md
@@ -1,0 +1,39 @@
+# NavMenuSubItem
+
+The second tier of navigation items
+
+### Usage
+```tsx
+import {NavMenu} from '@influxdata/clockface'
+```
+```tsx
+<NavMenu.SubItem />
+```
+
+### React Router
+
+Becuase we wanted to avoid having React Router as a dependency `NavMenuItem` and `NavMenuSubItem` make use of render props to allow `<Link />` elements to be passed in.
+The `titleLink` and `iconLink` props should be passed the same element to ensure consistency:
+
+```tsx
+// Using anchor tags
+<NavMenu.Item titleLink={className => <a href="http://www.myurl.com" className={className}>Item Title</a>} />
+```
+```tsx
+// Using a router link
+<NavMenu.Item titleLink={className => <a to="/pages/home" className={className}>Item Title</a>} />
+```
+
+### Styling
+
+`<NavMenu.SubItem />` receives its styles by being a child of `<NavMenu.Item />`
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->


### PR DESCRIPTION
Closes #145

### Changes

- Add markdown documentation for all `NavMenu` components

### Screenshots

![Screen Shot 2019-08-30 at 9 50 06 AM](https://user-images.githubusercontent.com/2433762/64037875-923c1280-cb0b-11e9-9433-9ec1d6f125b8.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
