### PR TITLE
Scroll to selected when DropdownMenu is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.29 (Unreleased)
 
+- [#267](https://github.com/influxdata/clockface/pull/267): Scroll to selected `DropdownItem` when `DropdownMenu` is opened
 - [#264](https://github.com/influxdata/clockface/pull/264): Update `SelectableCard` component with top-label design
 
 ### 0.0.28

--- a/src/Components/DapperScrollbars/DapperScrollbars.stories.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.stories.tsx
@@ -4,7 +4,7 @@ import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, boolean, color, object, text} from '@storybook/addon-knobs'
+import {withKnobs, boolean, color, object, text, number} from '@storybook/addon-knobs'
 import {jsxDecorator} from 'storybook-addon-jsx'
 
 // Components
@@ -20,9 +20,12 @@ const scrollbarStories = storiesOf('Utilities|Scrollbars', module)
 
 const fixedDefaultStyle = {width: '300px', height: '180px'}
 const autoSizeDefaultStyle = {width: '300px', maxHeight: '300px'}
+const contentStyle = {width: '600px'}
 const exampleTextDefault =
-  'Try modifying this text to see how scrolling is affected! Lorem ipsum dolor amet bitters normcore godard ethical blog single-origin coffee pickled hella master cleanse. Artisan hell of photo booth cardigan pok pok post-ironic ethical readymade poutine flexitarian brooklyn cronut semiotics. Poutine kinfolk hot chicken tofu deep v yr bespoke copper mug blog whatever street art beard affogato. Meditation unicorn kogi sartorial, quinoa raclette neutra bushwick. Copper mug sartorial prism readymade hella asymmetrical swag scenester cray venmo humblebrag messenger bag lumbersexual biodiesel.'
-
+`Try modifying this text to see how scrolling is affected! Distillery raclette swag, actually selfies cred neutra put a bird on it mlkshk hexagon fam. Iceland man braid echo park succulents flexitarian occupy. Organic health goth activated charcoal helvetica poke beard swag tacos drinking vinegar pop-up kickstarter wolf normcore lyft chillwave. Microdosing migas blog intelligentsia air plant typewriter, echo park mumblecore kombucha yuccie wayfarers poutine actually locavore distillery.
+Blue bottle four loko kogi woke activated charcoal forage tote bag sartorial. Hammock normcore lo-fi tbh trust fund man bun post-ironic locavore DIY plaid wolf tumeric. Poutine cred microdosing, typewriter jianbing marfa vegan. Kombucha four dollar toast organic bespoke af cred freegan meditation biodiesel tilde chia. Tofu microdosing retro lo-fi, DIY raclette kitsch. 
+Art party ramps vice master cleanse ethical scenester. Knausgaard kombucha williamsburg chambray asymmetrical, wolf seitan vaporware swag selfies. Single-origin coffee cloud bread vaporware, authentic sartorial food truck echo park ugh letterpress. IPhone pickled banh mi, lomo fingerstache crucifix letterpress offal lo-fi whatever pok pok chartreuse kitsch banjo.
+Keytar celiac copper mug chia typewriter. Umami crucifix tumblr mixtape taxidermy succulents hammock cardigan narwhal. Vegan four loko disrupt gastropub, pop-up drinking vinegar pinterest semiotics photo booth unicorn ugh pork belly before they sold out scenester. Waistcoat disrupt hashtag vice, raclette flannel farm-to-table butcher iPhone biodiesel. Locavore godard brunch hammock bicycle rights flannel letterpress pabst distillery mixtape jean shorts af chartreuse shoreditch small batch. Banh mi slow-carb brooklyn thundercats, helvetica shoreditch locavore.`
 scrollbarStories.add(
   'Fixed Example',
   () => (
@@ -40,8 +43,10 @@ scrollbarStories.add(
           autoSize={false}
           thumbStartColor={color('thumbStartColor', '#00C9FF')}
           thumbStopColor={color('thumbStopColor', '#9394FF')}
+          scrollTop={number('scrollTop', 0)}
+          scrollLeft={number('scrollLeft', 0)}
         >
-          <p>{text('Text Content', exampleTextDefault)}</p>
+          <p style={object('content style', contentStyle)}>{text('Text Content', exampleTextDefault)}</p>
         </DapperScrollbars>
       </div>
     </div>

--- a/src/Components/DapperScrollbars/DapperScrollbars.stories.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.stories.tsx
@@ -4,7 +4,14 @@ import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, boolean, color, object, text, number} from '@storybook/addon-knobs'
+import {
+  withKnobs,
+  boolean,
+  color,
+  object,
+  text,
+  number,
+} from '@storybook/addon-knobs'
 import {jsxDecorator} from 'storybook-addon-jsx'
 
 // Components
@@ -21,8 +28,7 @@ const scrollbarStories = storiesOf('Utilities|Scrollbars', module)
 const fixedDefaultStyle = {width: '300px', height: '180px'}
 const autoSizeDefaultStyle = {width: '300px', maxHeight: '300px'}
 const contentStyle = {width: '600px'}
-const exampleTextDefault =
-`Try modifying this text to see how scrolling is affected! Distillery raclette swag, actually selfies cred neutra put a bird on it mlkshk hexagon fam. Iceland man braid echo park succulents flexitarian occupy. Organic health goth activated charcoal helvetica poke beard swag tacos drinking vinegar pop-up kickstarter wolf normcore lyft chillwave. Microdosing migas blog intelligentsia air plant typewriter, echo park mumblecore kombucha yuccie wayfarers poutine actually locavore distillery.
+const exampleTextDefault = `Try modifying this text to see how scrolling is affected! Distillery raclette swag, actually selfies cred neutra put a bird on it mlkshk hexagon fam. Iceland man braid echo park succulents flexitarian occupy. Organic health goth activated charcoal helvetica poke beard swag tacos drinking vinegar pop-up kickstarter wolf normcore lyft chillwave. Microdosing migas blog intelligentsia air plant typewriter, echo park mumblecore kombucha yuccie wayfarers poutine actually locavore distillery.
 Blue bottle four loko kogi woke activated charcoal forage tote bag sartorial. Hammock normcore lo-fi tbh trust fund man bun post-ironic locavore DIY plaid wolf tumeric. Poutine cred microdosing, typewriter jianbing marfa vegan. Kombucha four dollar toast organic bespoke af cred freegan meditation biodiesel tilde chia. Tofu microdosing retro lo-fi, DIY raclette kitsch. 
 Art party ramps vice master cleanse ethical scenester. Knausgaard kombucha williamsburg chambray asymmetrical, wolf seitan vaporware swag selfies. Single-origin coffee cloud bread vaporware, authentic sartorial food truck echo park ugh letterpress. IPhone pickled banh mi, lomo fingerstache crucifix letterpress offal lo-fi whatever pok pok chartreuse kitsch banjo.
 Keytar celiac copper mug chia typewriter. Umami crucifix tumblr mixtape taxidermy succulents hammock cardigan narwhal. Vegan four loko disrupt gastropub, pop-up drinking vinegar pinterest semiotics photo booth unicorn ugh pork belly before they sold out scenester. Waistcoat disrupt hashtag vice, raclette flannel farm-to-table butcher iPhone biodiesel. Locavore godard brunch hammock bicycle rights flannel letterpress pabst distillery mixtape jean shorts af chartreuse shoreditch small batch. Banh mi slow-carb brooklyn thundercats, helvetica shoreditch locavore.`
@@ -46,7 +52,9 @@ scrollbarStories.add(
           scrollTop={number('scrollTop', 0)}
           scrollLeft={number('scrollLeft', 0)}
         >
-          <p style={object('content style', contentStyle)}>{text('Text Content', exampleTextDefault)}</p>
+          <p style={object('content style', contentStyle)}>
+            {text('Text Content', exampleTextDefault)}
+          </p>
         </DapperScrollbars>
       </div>
     </div>

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -35,6 +35,10 @@ interface Props extends StandardProps {
   autoSizeWidth: boolean
   /** Scroll container will grow to fit the content height */
   autoSizeHeight: boolean
+  /** Scroll top position in pixels */
+  scrollTop: number
+  /** Scroll left position in pixels */
+  scrollLeft: number;
 }
 
 export class DapperScrollbars extends Component<Props> {
@@ -53,6 +57,8 @@ export class DapperScrollbars extends Component<Props> {
     autoSize: false,
     autoSizeWidth: false,
     autoSizeHeight: false,
+    scrollTop: 0,
+    scrollLeft: 0,
     testID: 'dapper-scrollbars',
   }
 
@@ -69,6 +75,8 @@ export class DapperScrollbars extends Component<Props> {
       autoSizeHeight,
       autoSizeWidth,
       noScroll,
+      scrollTop,
+      scrollLeft,
       children,
       testID,
       style,
@@ -107,6 +115,8 @@ export class DapperScrollbars extends Component<Props> {
           style: this.thumbYStyle,
           className: 'cf-dapper-scrollbars--thumb-y',
         }}
+        scrollTop={scrollTop}
+        scrollLeft={scrollLeft}
         id={id}
         download={null}
         inlist={null}

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -35,9 +35,9 @@ interface Props extends StandardProps {
   autoSizeWidth: boolean
   /** Scroll container will grow to fit the content height */
   autoSizeHeight: boolean
-  /** Scroll top position in pixels */
+  /** Vertical scroll position in pixels */
   scrollTop: number
-  /** Scroll left position in pixels */
+  /** Horizontal scroll position in pixels */
   scrollLeft: number;
 }
 

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -38,7 +38,7 @@ interface Props extends StandardProps {
   /** Vertical scroll position in pixels */
   scrollTop: number
   /** Horizontal scroll position in pixels */
-  scrollLeft: number;
+  scrollLeft: number
 }
 
 export class DapperScrollbars extends Component<Props> {

--- a/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MultiSelectDropdown.tsx
@@ -122,12 +122,12 @@ export class MultiSelectDropdown extends Component<Props> {
 
     return options.map(o => {
       if (o === DROPDOWN_DIVIDER_SHORTCODE) {
-        return <DropdownDivider key="o" />
+        return <DropdownDivider key={o} />
       }
 
       if (o.includes(DROPDOWN_DIVIDER_SHORTCODE)) {
         const dividerText = o.replace(DROPDOWN_DIVIDER_SHORTCODE, '')
-        return <DropdownDivider key="o" text={dividerText} />
+        return <DropdownDivider key={o} text={dividerText} />
       }
 
       return (

--- a/src/Components/Dropdowns/Composed/SelectDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/SelectDropdown.tsx
@@ -114,12 +114,12 @@ export class SelectDropdown extends Component<Props> {
 
     return options.map(o => {
       if (o === DROPDOWN_DIVIDER_SHORTCODE) {
-        return <DropdownDivider key="o" />
+        return <DropdownDivider key={o} />
       }
 
       if (o.includes(DROPDOWN_DIVIDER_SHORTCODE)) {
         const dividerText = o.replace(DROPDOWN_DIVIDER_SHORTCODE, '')
-        return <DropdownDivider key="o" text={dividerText} />
+        return <DropdownDivider key={o} text={dividerText} />
       }
 
       return (

--- a/src/Components/Dropdowns/Dropdown.stories.tsx
+++ b/src/Components/Dropdowns/Dropdown.stories.tsx
@@ -232,6 +232,7 @@ dropdownFamilyStories.add(
           maxHeight={number('maxHeight', 250)}
           noScrollX={boolean('noScrollX', true)}
           noScrollY={boolean('noScrollY', false)}
+          scrollToSelected={boolean('scrollToSelected', true)}
         >
           <DropdownDivider text="Domestic Fruits" />
           <DropdownItem
@@ -257,6 +258,18 @@ dropdownFamilyStories.add(
             }
           >
             Kiwi
+          </DropdownItem>
+          <DropdownItem
+            wrapText={boolean('item wrapText', false)}
+            value="Lemon"
+            selected={false}
+            type={
+              DropdownItemType[
+                select('item type', mapEnumKeys(DropdownItemType), 'None')
+              ]
+            }
+          >
+            Lemon
           </DropdownItem>
           <DropdownItem
             wrapText={boolean('item wrapText', false)}
@@ -345,6 +358,30 @@ dropdownFamilyStories.add(
           </DropdownItem>
           <DropdownItem
             wrapText={boolean('item wrapText', false)}
+            value="Mango"
+            selected={false}
+            type={
+              DropdownItemType[
+                select('item type', mapEnumKeys(DropdownItemType), 'None')
+              ]
+            }
+          >
+            Mango
+          </DropdownItem>
+          <DropdownItem
+            wrapText={boolean('item wrapText', false)}
+            value="Lychee"
+            selected={false}
+            type={
+              DropdownItemType[
+                select('item type', mapEnumKeys(DropdownItemType), 'None')
+              ]
+            }
+          >
+            Lychee
+          </DropdownItem>
+          <DropdownItem
+            wrapText={boolean('item wrapText', false)}
             value="Passionfruit"
             selected={false}
             type={
@@ -383,14 +420,19 @@ const selectDropdownOptions = [
   'Celery',
   'Carrot',
   'Potato',
-  'Onion',
-  'Tomato',
-  'Spinach',
+  'Corn',
+  'Bok Choy',
   '---Fruits',
   'Apple',
   'Peach',
+  'Tomato',
   'Grape',
   'Orange',
+  'Lemon',
+  'Watermelon',
+  'Kiwi',
+  'Banana',
+  'Strawberry',
 ]
 
 const selectDropdownSelectedOption = 'Celery'

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {Component, CSSProperties} from 'react'
 import classnames from 'classnames'
+import _ from 'lodash'
 
 // Components
 import {DapperScrollbars} from '../../DapperScrollbars/DapperScrollbars'
@@ -19,6 +20,8 @@ interface Props extends StandardProps {
   noScrollX: boolean
   /** Disable scrolling vertically */
   noScrollY: boolean
+  /** Automatically scroll to selected item when dropdown is opened */
+  scrollToSelected: boolean
   /** Function to handle closing the menu when a child item is clicked */
   onCollapse?: () => void
 }
@@ -31,6 +34,7 @@ export class DropdownMenu extends Component<Props> {
     testID: 'dropdown-menu',
     noScrollX: true,
     noScrollY: false,
+    scrollToSelected: true,
     maxHeight: 250,
   }
 
@@ -66,6 +70,7 @@ export class DropdownMenu extends Component<Props> {
           thumbStopColor={thumbStopColor}
           noScrollX={noScrollX}
           noScrollY={noScrollY}
+          scrollTop={this.selectedPosition}
         >
           <div
             className="cf-dropdown-menu--contents"
@@ -77,6 +82,21 @@ export class DropdownMenu extends Component<Props> {
         </DapperScrollbars>
       </div>
     )
+  }
+
+  private get selectedPosition(): number {
+    const {scrollToSelected, children} = this.props
+
+    if (!children || !scrollToSelected) {
+      return 0
+    }
+
+    const itemHeight = 24
+    const items = React.Children.map(children, child => _.get(child, 'props.selected', false))
+    const itemIndex = items.findIndex(item => item === true)
+
+    return itemHeight * itemIndex
+    
   }
 
   private get containerClass(): string {

--- a/src/Components/Dropdowns/Family/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/Family/DropdownMenu.tsx
@@ -92,11 +92,12 @@ export class DropdownMenu extends Component<Props> {
     }
 
     const itemHeight = 24
-    const items = React.Children.map(children, child => _.get(child, 'props.selected', false))
+    const items = React.Children.map(children, child =>
+      _.get(child, 'props.selected', false)
+    )
     const itemIndex = items.findIndex(item => item === true)
 
     return itemHeight * itemIndex
-    
   }
 
   private get containerClass(): string {


### PR DESCRIPTION
Closes #110

### Changes
- Expose `scrollTop` & `scrollLeft` props on `DapperScrollbars
- Add `scrollToSelected` prop to `DropdownMenu`
- Add default behavior to scroll to selected item when dropdown menu is opened

### Screenshots
![scrollToSelected](https://user-images.githubusercontent.com/11937365/64553885-1aca6800-d2ef-11e9-8954-fc5cca29497a.gif)


### Checklist
- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
