### PR TITLE
refactor: make all panel sub-components independently size-able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.29 (Unreleased)
 
+- [#268](https://github.com/influxdata/clockface/pull/268): [Breaking] Remove `size` prop from `Panel` and add `size` prop to `PanelHeader`, `PanelTitle`, `PanelBody`, and `PanelFooter`
 - [#267](https://github.com/influxdata/clockface/pull/267): Scroll to selected `DropdownItem` when `DropdownMenu` is opened
 - [#264](https://github.com/influxdata/clockface/pull/264): Update `SelectableCard` component with top-label design
 

--- a/src/Components/Form/Form.stories.tsx
+++ b/src/Components/Form/Form.stories.tsx
@@ -369,15 +369,15 @@ formExampleStories.add(
   () => (
     <div className="story--example">
       <div style={{width: `${number('Parent width (px)', 500)}px`}}>
-        <Panel
-          size={
-            ComponentSize[
-              select('Panel: size', mapEnumKeys(ComponentSize), 'Small')
-            ]
-          }
-        >
+        <Panel>
           <DismissButton onClick={() => {}} color={ComponentColor.Danger} />
-          <PanelBody>
+          <PanelBody
+            size={
+              ComponentSize[
+                select('Panel: size', mapEnumKeys(ComponentSize), 'Small')
+              ]
+            }
+          >
             <FlexBox
               direction={FlexDirection.Column}
               margin={

--- a/src/Components/Panel/Panel.scss
+++ b/src/Components/Panel/Panel.scss
@@ -30,8 +30,17 @@
 
 .cf-panel--body {
   width: 100%;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
   > *:last-child {
     margin-bottom: 0;
+  }
+
+  .cf-panel--header + & {
+    padding-top: 0;
   }
 }
 
@@ -42,102 +51,78 @@
 }
 
 /*
-  Dismissable Panel
-  ------------------------------------------------------------------------------
-*/
-
-$panel--dismiss-button: 30px;
-
-.cf-panel__dismissable {
-  position: relative;
-
-  > .cf-panel--header {
-    padding-right: 40px;
-  }
-}
-
-.cf-panel--dismiss {
-  position: absolute;
-  background-color: transparent;
-  border: 0;
-  transition: opacity 0.25s ease;
-  opacity: 0.4;
-  outline: none;
-
-  &:before,
-  &:after {
-    content: '';
-    height: $cf-border;
-    border-radius: $cf-border / 2;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-  }
-
-  &:before {
-    transform: translate(-50%, -50%) rotate(45deg);
-  }
-
-  &:after {
-    transform: translate(-50%, -50%) rotate(-45deg);
-  }
-
-  &:hover {
-    cursor: pointer;
-    opacity: 1;
-  }
-}
-
-/*
   Size Modifiers
   ------------------------------------------------------------------------------
 */
-@mixin panelSizeModifier($fontSize, $fontWeight, $padding, $dismissSize) {
-  > .cf-panel--header {
-    padding: $padding * 2;
-  }
-  > .cf-panel--body {
-    font-size: $fontSize;
-    padding: $padding * 2;
-  }
-  > .cf-panel--header + .cf-panel--body {
-    padding-top: 0;
-  }
-  > .cf-panel--header > .cf-panel--title {
-    font-weight: $fontWeight;
-    font-size: $fontSize * 1.5;
-  }
-  > .cf-panel--footer {
-    padding: $padding ($padding * 2);
-  }
-  &.cf-panel__dismissable > .cf-panel--header {
-    padding-right: $dismissSize + $padding;
-  }
-
-  .cf-panel--dismiss {
-    width: $dismissSize - $cf-border;
-    height: $dismissSize - $cf-border;
-    top: ($padding / 2);
-    right: ($padding / 2);
-  }
-
-  .cf-panel--dismiss:before,
-  .cf-panel--dismiss:after {
-    width: $dismissSize * 0.55;
-  }
+@mixin panelHeaderSizeModifier($padding) {
+  padding: $padding * 2;
 }
 
-.cf-panel--xs {
-  @include panelSizeModifier($form-xs-font, 600, $form-xs-padding, $form-xs-height);
+.cf-panel--header__xs {
+  @include panelHeaderSizeModifier($form-xs-padding);
 }
-.cf-panel--sm {
-  @include panelSizeModifier($form-sm-font, 500, $form-sm-padding, $form-sm-height);
+.cf-panel--header__sm {
+  @include panelHeaderSizeModifier($form-sm-padding);
 }
-.cf-panel--md {
-  @include panelSizeModifier($form-md-font, 500, $form-md-padding, $form-md-height);
+.cf-panel--header__md {
+  @include panelHeaderSizeModifier($form-md-padding);
 }
-.cf-panel--lg {
-  @include panelSizeModifier($form-lg-font, 400, $form-lg-padding, $form-md-height);
+.cf-panel--header__lg {
+  @include panelHeaderSizeModifier($form-lg-padding);
+}
+
+@mixin panelBodySizeModifier($padding, $fontSize) {
+  font-size: $fontSize;
+  padding: $padding * 2;
+}
+
+.cf-panel--body__xs {
+  @include panelBodySizeModifier($form-xs-padding, $form-xs-font);
+}
+.cf-panel--body__sm {
+  @include panelBodySizeModifier($form-sm-padding, $form-sm-font);
+}
+.cf-panel--body__md {
+  @include panelBodySizeModifier($form-md-padding, $form-md-font);
+}
+.cf-panel--body__lg {
+  @include panelBodySizeModifier($form-lg-padding, $form-lg-font);
+}
+
+@mixin panelFooterSizeModifier($padding, $fontSize) {
+  padding: $padding ($padding * 2);
+  font-size: ceil($fontSize * 0.75);
+}
+
+.cf-panel--footer__xs {
+  @include panelFooterSizeModifier($form-xs-padding, $form-xs-font);
+}
+.cf-panel--footer__sm {
+  @include panelFooterSizeModifier($form-sm-padding, $form-sm-font);
+}
+.cf-panel--footer__md {
+  @include panelFooterSizeModifier($form-md-padding, $form-md-font);
+}
+.cf-panel--footer__lg {
+  @include panelFooterSizeModifier($form-lg-padding, $form-lg-font);
+}
+
+@mixin panelTitleSizeModifier($fontWeight, $fontSize) {
+  font-weight: $fontWeight;
+  font-size: $fontSize * 1.5;
+}
+
+.cf-panel--title__xs {
+  @include panelTitleSizeModifier($form-xs-padding, $form-xs-font);
+}
+.cf-panel--title__sm {
+  @include panelTitleSizeModifier($form-sm-padding, $form-sm-font);
+}
+.cf-panel--title__md {
+  @include panelTitleSizeModifier($form-md-padding, $form-md-font);
+}
+.cf-panel--title__lg {
+  @include panelTitleSizeModifier($form-lg-padding, $form-lg-font);
 }
 
 /*
@@ -146,30 +131,18 @@ $panel--dismiss-button: 30px;
 */
 
 .cf-panel__dark-text {
-  > .cf-panel--header > .cf-panel--title {
-    color: $g4-onyx;
-  }
-  > .cf-panel--body,
-  > .cf-panel--footer {
-    color: rgba($g4-onyx, 0.75);
-  }
-  > .cf-panel--dismiss:before,
-  > .cf-panel--dismiss:after {
-    background-color: $g4-onyx;
+  .cf-panel--title,
+  .cf-panel--body,
+  .cf-panel--footer {
+    color: rgba($g2-kevlar, 0.75);
   }
 }
 
 .cf-panel__light-text {
-  > .cf-panel--header > .cf-panel--title {
-    color: $g18-cloud;
-  }
-  > .cf-panel--body,
-  > .cf-panel--footer {
-    color: rgba($g18-cloud, 0.75);
-  }
-  > .cf-panel--dismiss:before,
-  > .cf-panel--dismiss:after {
-    background-color: $g18-cloud;
+  .cf-panel--title,
+  .cf-panel--body,
+  .cf-panel--footer {
+    color: rgba($g20-white, 0.75);
   }
 }
 
@@ -181,4 +154,3 @@ $panel--dismiss-button: 30px;
 .cf-panel--body hr {
   margin: $cf-marg-c 0;
 }
-

--- a/src/Components/Panel/Panel.stories.tsx
+++ b/src/Components/Panel/Panel.stories.tsx
@@ -47,9 +47,6 @@ panelStories.add(
           ]
         }
         backgroundColor={color('backgroundColor', `${InfluxColors.Castle}`)}
-        size={
-          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
-        }
       />
     </div>
   ),
@@ -64,8 +61,18 @@ panelStories.add(
   'PanelHeader',
   () => (
     <div className="story--example">
-      <Panel.Header>
-        <Panel.Title>{text('title', 'I am a cool Panel')}</Panel.Title>
+      <Panel.Header
+        size={
+          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+        }
+      >
+        <Panel.Title
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
+          {text('title', 'I am a cool Panel')}
+        </Panel.Title>
       </Panel.Header>
     </div>
   ),
@@ -80,7 +87,11 @@ panelStories.add(
   'PanelBody',
   () => (
     <div className="story--example">
-      <Panel.Body>
+      <Panel.Body
+        size={
+          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+        }
+      >
         <span>{text('children', 'Example paragraph text')}</span>
       </Panel.Body>
     </div>
@@ -96,7 +107,11 @@ panelStories.add(
   'PanelFooter',
   () => (
     <div className="story--example">
-      <Panel.Footer>
+      <Panel.Footer
+        size={
+          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+        }
+      >
         <span>{text('children', 'Example footer text')}</span>
       </Panel.Footer>
     </div>
@@ -113,9 +128,6 @@ panelExampleStories.add(
   () => (
     <div className="story--example">
       <Panel
-        size={
-          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
-        }
         gradient={
           Gradients[
             select(
@@ -127,10 +139,24 @@ panelExampleStories.add(
         }
         onDismiss={() => alert('onDismiss clicked!')}
       >
-        <Panel.Header>
-          <Panel.Title>Welcome!</Panel.Title>
+        <Panel.Header
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
+          <Panel.Title
+            size={
+              ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+            }
+          >
+            Welcome!
+          </Panel.Title>
         </Panel.Header>
-        <Panel.Body>
+        <Panel.Body
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
           <h5>We've built a lot of cool new things to make your life easier</h5>
           <h5>
             <a href="#">Click Here</a> to take the tour
@@ -150,38 +176,43 @@ panelExampleStories.add(
   'Getting Started Panel',
   () => (
     <div className="story--example">
-      <Panel size={ComponentSize.Small}>
-        <Panel.Header>
-          <Panel.Title>Getting started with InfluxDB 2.0</Panel.Title>
+      <Panel>
+        <Panel.Header
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
+          <Panel.Title
+            size={
+              ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+            }
+          >
+            Getting started with InfluxDB 2.0
+          </Panel.Title>
         </Panel.Header>
-        <Panel.Body>
+        <Panel.Body
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
           <Grid>
             <Grid.Row>
               <Grid.Column widthSM={Columns.Four}>
-                <Panel
-                  size={ComponentSize.Small}
-                  backgroundColor={InfluxColors.Onyx}
-                >
+                <Panel backgroundColor={InfluxColors.Onyx}>
                   <Panel.Body>
                     <p>Configure a Data Collector</p>
                   </Panel.Body>
                 </Panel>
               </Grid.Column>
               <Grid.Column widthSM={Columns.Four}>
-                <Panel
-                  size={ComponentSize.Small}
-                  backgroundColor={InfluxColors.Onyx}
-                >
+                <Panel backgroundColor={InfluxColors.Onyx}>
                   <Panel.Body>
                     <p>Build a Monitoring Dashboard</p>
                   </Panel.Body>
                 </Panel>
               </Grid.Column>
               <Grid.Column widthSM={Columns.Four}>
-                <Panel
-                  size={ComponentSize.Small}
-                  backgroundColor={InfluxColors.Onyx}
-                >
+                <Panel backgroundColor={InfluxColors.Onyx}>
                   <Panel.Body>
                     <p>Explore Data with Flux</p>
                   </Panel.Body>
@@ -190,7 +221,11 @@ panelExampleStories.add(
             </Grid.Row>
           </Grid>
         </Panel.Body>
-        <Panel.Footer>
+        <Panel.Footer
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
           <p>
             Check our <a href="#">Documentation Site</a> for more tutorials
           </p>
@@ -209,11 +244,25 @@ panelExampleStories.add(
   'Danger Zone Panel',
   () => (
     <div className="story--example">
-      <Panel size={ComponentSize.Small} gradient={Gradients.DocScott}>
-        <Panel.Header>
-          <Panel.Title>Danger Zone!</Panel.Title>
+      <Panel gradient={Gradients.DocScott}>
+        <Panel.Header
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
+          <Panel.Title
+            size={
+              ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+            }
+          >
+            Danger Zone!
+          </Panel.Title>
         </Panel.Header>
-        <Panel.Body>
+        <Panel.Body
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+        >
           <p>These actions can have unintended wide-reaching consequences</p>
         </Panel.Body>
       </Panel>

--- a/src/Components/Panel/Panel.tsx
+++ b/src/Components/Panel/Panel.tsx
@@ -7,9 +7,9 @@ import chroma from 'chroma-js'
 // Types
 import {
   Gradients,
-  ComponentSize,
   InfluxColors,
   StandardProps,
+  ComponentColor,
 } from '../../Types'
 
 // Constants
@@ -20,6 +20,7 @@ import {PanelHeader} from './PanelHeader'
 import {PanelTitle} from './PanelTitle'
 import {PanelBody} from './PanelBody'
 import {PanelFooter} from './PanelFooter'
+import {DismissButton} from '../Button/Composed/DismissButton'
 
 // Styles
 import './Panel.scss'
@@ -29,19 +30,19 @@ interface Props extends StandardProps {
   gradient?: Gradients
   /** Optional background color of panel */
   backgroundColor: InfluxColors | string
-  /** Controls header font size and padding of Panel */
-  size: ComponentSize
   /** If a function is passed in a dismiss button will appear on the Panel */
   onDismiss?: () => void
+  /** Applies to the dismiss button rendered when onDismiss is present */
+  dismissButtonColor: ComponentColor
 }
 
 export class Panel extends Component<Props> {
   public static readonly displayName = 'Panel'
 
   public static defaultProps = {
-    size: ComponentSize.Small,
     testID: 'panel',
     backgroundColor: InfluxColors.Castle,
+    dismissButtonColor: ComponentColor.Primary,
   }
 
   public static Header = PanelHeader
@@ -66,12 +67,11 @@ export class Panel extends Component<Props> {
   }
 
   private get className(): string {
-    const {className, gradient, size, onDismiss} = this.props
+    const {className, gradient} = this.props
 
-    return classnames(`cf-panel cf-panel--${size}`, {
+    return classnames('cf-panel', {
       [`${className}`]: className,
       'cf-panel__gradient': gradient,
-      'cf-panel__dismissable': onDismiss,
       [`cf-panel__${this.useContrastText}-text`]: this.useContrastText,
     })
   }
@@ -107,16 +107,10 @@ export class Panel extends Component<Props> {
   }
 
   private get dismissButton(): JSX.Element | undefined {
-    const {onDismiss} = this.props
+    const {onDismiss, dismissButtonColor} = this.props
 
     if (onDismiss) {
-      return (
-        <button
-          className="cf-panel--dismiss"
-          type="button"
-          onClick={onDismiss}
-        />
-      )
+      return <DismissButton onClick={onDismiss} color={dismissButtonColor} />
     }
 
     return

--- a/src/Components/Panel/PanelBody.tsx
+++ b/src/Components/Panel/PanelBody.tsx
@@ -3,15 +3,19 @@ import React, {Component} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardProps} from '../../Types'
+import {StandardProps, ComponentSize} from '../../Types'
 
-interface Props extends StandardProps {}
+interface Props extends StandardProps {
+  /** Controls padding */
+  size: ComponentSize
+}
 
 export class PanelBody extends Component<Props> {
   public static readonly displayName = 'PanelBody'
 
   public static defaultProps = {
     testID: 'panel--body',
+    size: ComponentSize.Small,
   }
 
   public render() {
@@ -30,8 +34,11 @@ export class PanelBody extends Component<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, size} = this.props
 
-    return classnames('cf-panel--body', {[`${className}`]: className})
+    return classnames('cf-panel--body', {
+      [`cf-panel--body__${size}`]: size,
+      [`${className}`]: className,
+    })
   }
 }

--- a/src/Components/Panel/PanelFooter.tsx
+++ b/src/Components/Panel/PanelFooter.tsx
@@ -3,15 +3,19 @@ import React, {Component} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardProps} from '../../Types'
+import {StandardProps, ComponentSize} from '../../Types'
 
-interface Props extends StandardProps {}
+interface Props extends StandardProps {
+  /** Controls padding */
+  size: ComponentSize
+}
 
 export class PanelFooter extends Component<Props> {
   public static readonly displayName = 'PanelFooter'
 
   public static defaultProps = {
     testID: 'panel--footer',
+    size: ComponentSize.Small,
   }
 
   public render() {
@@ -30,8 +34,11 @@ export class PanelFooter extends Component<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, size} = this.props
 
-    return classnames('cf-panel--footer', {[`${className}`]: className})
+    return classnames('cf-panel--footer', {
+      [`cf-panel--footer__${size}`]: size,
+      [`${className}`]: className,
+    })
   }
 }

--- a/src/Components/Panel/PanelHeader.tsx
+++ b/src/Components/Panel/PanelHeader.tsx
@@ -23,6 +23,8 @@ interface Props extends StandardProps {
   justifyContent: JustifyContent
   /** Can be FlexStart, FlexEnd, Center, or Stretch */
   alignItems: AlignItems
+  /** Controls padding */
+  size: ComponentSize
 }
 
 export class PanelHeader extends Component<Props> {
@@ -33,6 +35,7 @@ export class PanelHeader extends Component<Props> {
     flexDirection: FlexDirection.Row,
     justifyContent: JustifyContent.SpaceBetween,
     alignItems: AlignItems.Center,
+    size: ComponentSize.Small,
   }
 
   public render() {
@@ -68,8 +71,11 @@ export class PanelHeader extends Component<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, size} = this.props
 
-    return classnames('cf-panel--header', {[`${className}`]: className})
+    return classnames('cf-panel--header', {
+      [`cf-panel--header__${size}`]: size,
+      [`${className}`]: className,
+    })
   }
 }

--- a/src/Components/Panel/PanelTitle.tsx
+++ b/src/Components/Panel/PanelTitle.tsx
@@ -3,9 +3,12 @@ import React, {Component} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardProps} from '../../Types'
+import {StandardProps, ComponentSize} from '../../Types'
 
-interface Props extends StandardProps {}
+interface Props extends StandardProps {
+  /** Controls padding */
+  size: ComponentSize
+}
 
 export class PanelTitle extends Component<Props> {
   public static readonly displayName = 'PanelTitle'
@@ -30,8 +33,11 @@ export class PanelTitle extends Component<Props> {
   }
 
   private get className(): string {
-    const {className} = this.props
+    const {className, size} = this.props
 
-    return classnames('cf-panel--title', {[`${className}`]: className})
+    return classnames('cf-panel--title', {
+      [`cf-panel--title__${size}`]: size,
+      [`${className}`]: className,
+    })
   }
 }


### PR DESCRIPTION
Closes #247

### Changes

- _**BREAKING**_ Remove `size` prop from `Panel`
- Add `size` prop to `PanelHeader`, `PanelBody`, `PanelFooter,` and `PanelTitle`
- Use `DismissButton` component instead of custom dismiss button

### Screenshots

![updated-panel-sizing](https://user-images.githubusercontent.com/2433762/64645715-55550300-d3ca-11e9-9c0e-55275ff91bfa.gif)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
