### PR TITLE
Add rollup-plugin-includepaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 0.0.30
 
+- [#278](https://github.com/influxdata/clockface/pull/278): Add rollup-plugin-includepaths to handle unresolved paths
 - [#277](https://github.com/influxdata/clockface/pull/277): Fix export paths to be absolute instead of relative
 
 ### 0.0.29

--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "typecheck": "tsc --noEmit --pretty",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "publishStorybook": "storybook-to-ghpages --out=.out"
+  },
+  "dependencies": {
+    "rollup-plugin-includepaths": "^0.2.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve'
+import includePaths from 'rollup-plugin-includepaths'
 import commonjs from 'rollup-plugin-commonjs'
 import sourceMaps from 'rollup-plugin-sourcemaps'
 import {terser} from 'rollup-plugin-terser'
@@ -12,6 +13,7 @@ const isProductionBuild = process.env.NODE_ENV === 'production'
 
 let plugins = [
   resolve(),
+  includePaths({ paths: ["./"] }),
   commonjs({
     namedExports: {
       'react-draggable': ['DraggableCore'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9647,6 +9647,11 @@ rollup-plugin-gzip@^2.2.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-gzip/-/rollup-plugin-gzip-2.2.0.tgz#fd918f925bb5b82f7c80558aee8ff4f61f559814"
   integrity sha512-3DFfB/0zGkvLMrZ3MnTU7L906u20dqepuxWJKXvnFZTji+IY8XwgA9iLvBX2H40C//fA3vWhNmtuPiFMfSzFgQ==
 
+rollup-plugin-includepaths@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-includepaths/-/rollup-plugin-includepaths-0.2.3.tgz#244d21b9669a0debe476d825e4a02ed08c06b258"
+  integrity sha512-4QbSIZPDT+FL4SViEVCRi4cGCA64zQJu7u5qmCkO3ecHy+l9EQBsue15KfCpddfb6Br0q47V/v2+E2YUiqts9g==
+
 rollup-plugin-node-resolve@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.1.0.tgz#49608b6ecaf2b776ab83e317d39b282d65d21b76"


### PR DESCRIPTION
Closes #279

### Changes
Add Include Paths Rollup Plugin to handle unresolved paths.

### Checklist
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
