### PR TITLE
Fix input padding in color picker component

### DIFF
--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -132,6 +132,7 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
           <Input
             className="cf-color-picker--input"
             placeholder="#000000"
+            inputStyle={{paddingLeft: '29px'}}
             value={color}
             onChange={handleInputChange}
             maxLength={HEX_CODE_CHAR_LENGTH}


### PR DESCRIPTION
Closes #322, influxdata/influxdb#15311

### Changes

Just a very little css fix for the color preview that was hiding the first two characters of the entered text input.

### Screenshots

![Screenshot from 2019-10-04 21-15-47](https://user-images.githubusercontent.com/30473620/66233887-a23ba900-e6ec-11e9-90f4-1cb6020ead5f.png)


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
