### PR TITLE
fix: popover visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.33 (Unreleased)
 
+- [#327](https://github.com/influxdata/clockface/pull/327) Fix rendering issue with "always visible" `Popover`s
 - [#324](https://github.com/influxdata/clockface/pull/324): Convert `DraggableResizer` component family to `FunctionComponent` and wrap with `forwardRef`
 - [#320](https://github.com/influxdata/clockface/pull/320): Convert `DapperScrollbars` component to `FunctionComponent` and update `react-scrollbars-custom` dependency to `4.0.20`
 - [#319](https://github.com/influxdata/clockface/pull/319): Convert `ColorPicker` component family to `FunctionComponent` and wrap with `forwardRef`

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -3,8 +3,8 @@ import React, {
   useState,
   useEffect,
   RefObject,
-  forwardRef,
   MouseEvent,
+  forwardRef,
 } from 'react'
 import {createPortal} from 'react-dom'
 import uuid from 'uuid'
@@ -26,6 +26,7 @@ import {
   PopoverInteraction,
   StandardFunctionProps,
 } from '../../../Types'
+import {PopoverDialogRef} from './PopoverDialog'
 
 export interface PopoverProps extends StandardFunctionProps {
   /** Popover dialog color */
@@ -58,7 +59,7 @@ export interface PopoverProps extends StandardFunctionProps {
   enableDefaultStyles?: boolean
 }
 
-export type PopoverRef = HTMLSpanElement
+export type PopoverRef = PopoverDialogRef
 
 interface CustomMouseEvent extends MouseEvent {
   relatedTarget: Element

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -12,6 +12,9 @@ import uuid from 'uuid'
 // Components
 import {PopoverDialog} from './PopoverDialog'
 
+// Utils
+import {createPortalElement, destroyPortalElement} from '../../../Utils/index'
+
 // Styles
 import './Popover.scss'
 
@@ -61,7 +64,7 @@ interface CustomMouseEvent extends MouseEvent {
   relatedTarget: Element
 }
 
-let uniquePortalID: string = ''
+const popoverPortalName = 'popover'
 
 export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
   (
@@ -88,6 +91,28 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
     ref
   ) => {
     const [expanded, setExpanded] = useState<boolean>(!!visible)
+    const [portalID, setPortalID] = useState<string>('')
+
+    useEffect((): (() => void) => {
+      const newPortalID = `cf-${popoverPortalName}-portal-${uuid.v4()}`
+      !portalID && setPortalID(newPortalID)
+
+      createPortalElement(newPortalID, popoverPortalName)
+      handleAddEventListeners()
+
+      return (): void => {
+        destroyPortalElement(newPortalID)
+        handleRemoveEventListeners()
+      }
+    }, [])
+
+    useEffect(() => {
+      if (visible) {
+        handleShowDialog()
+      } else if (!visible) {
+        handleHideDialog()
+      }
+    }, [visible])
 
     const handleTriggerClick = (e: MouseEvent): void => {
       e.stopPropagation()
@@ -147,27 +172,6 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
       setExpanded(false)
     }
 
-    const handleCreatePortalElement = (): void => {
-      const portalExists = document.getElementById(uniquePortalID)
-      if (portalExists) {
-        return
-      }
-
-      const portalElement = document.createElement('div')
-      portalElement.setAttribute('class', 'cf-popover-portal')
-      portalElement.setAttribute('id', uniquePortalID)
-
-      document.body.appendChild(portalElement)
-    }
-
-    const handleDestroyPortalElement = (): void => {
-      const portalElement = document.getElementById(uniquePortalID)
-
-      if (portalElement) {
-        portalElement.remove()
-      }
-    }
-
     const handleAddEventListeners = (): void => {
       if (!triggerRef.current) {
         return
@@ -203,50 +207,30 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
       )
     }
 
-    useEffect((): (() => void) => {
-      uniquePortalID = `cf-popover-portal-${uuid.v4()}`
-      handleCreatePortalElement()
-      handleAddEventListeners()
-
-      return (): void => {
-        handleRemoveEventListeners()
-        handleDestroyPortalElement()
-      }
-    }, [])
-
-    useEffect(() => {
-      if (visible) {
-        handleShowDialog()
-      } else if (!visible) {
-        handleHideDialog()
-      }
-    }, [visible])
-
-    const portalElement = document.getElementById(uniquePortalID)
+    const portalElement = document.getElementById(portalID)
 
     if (!portalElement || !expanded) {
       return null
     }
 
     const popover = (
-      <span ref={ref}>
-        <PopoverDialog
-          enableDefaultStyles={enableDefaultStyles}
-          distanceFromTrigger={distanceFromTrigger}
-          onClickOutside={handleClickOutside}
-          onMouseLeave={handleDialogMouseLeave}
-          triggerRef={triggerRef}
-          className={className}
-          caretSize={caretSize}
-          position={position}
-          contents={contents(handleHideDialog)}
-          testID={testID}
-          color={color}
-          style={style}
-          type={type}
-          id={id}
-        />
-      </span>
+      <PopoverDialog
+        enableDefaultStyles={enableDefaultStyles}
+        distanceFromTrigger={distanceFromTrigger}
+        onClickOutside={handleClickOutside}
+        onMouseLeave={handleDialogMouseLeave}
+        triggerRef={triggerRef}
+        className={className}
+        caretSize={caretSize}
+        position={position}
+        contents={contents(handleHideDialog)}
+        testID={testID}
+        color={color}
+        style={style}
+        type={type}
+        ref={ref}
+        id={id}
+      />
     )
 
     return createPortal(popover, portalElement)

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -96,7 +96,7 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
 
     useEffect((): (() => void) => {
       const newPortalID = `cf-${popoverPortalName}-portal-${uuid.v4()}`
-      !portalID && setPortalID(newPortalID)
+      setPortalID(newPortalID)
 
       createPortalElement(newPortalID, popoverPortalName)
       handleAddEventListeners()

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -16,12 +16,13 @@ import {jsxDecorator} from 'storybook-addon-jsx'
 import {mapEnumKeys} from '../../../Utils/storybook'
 
 // Components
-import {Popover, PopoverRef} from '..'
+import {Popover, PopoverRef} from '../'
 import {ReflessPopover} from '../Composed/ReflessPopover'
 import {
   QuestionMarkTooltip,
   QuestionMarkTooltipRef,
 } from '../Composed/QuestionMarkTooltip'
+import {SquareButton} from '../../Button/Composed/SquareButton'
 
 // Types
 import {
@@ -29,6 +30,8 @@ import {
   PopoverInteraction,
   PopoverPosition,
   ComponentColor,
+  IconFont,
+  ComponentStatus,
 } from '../../../Types'
 
 // Notes
@@ -55,9 +58,9 @@ const exampleStyle = {
 popoverStories.add(
   'Popover',
   () => {
-    const triggerRefA = React.createRef<HTMLDivElement>()
-    const triggerRefB = React.createRef<HTMLDivElement>()
-    const triggerRefC = React.createRef<HTMLDivElement>()
+    const triggerRefA = createRef<HTMLDivElement>()
+    const triggerRefB = createRef<HTMLDivElement>()
+    const triggerRefC = createRef<HTMLButtonElement>()
     const popover1Ref = createRef<PopoverRef>()
     const popover2Ref = createRef<PopoverRef>()
     const popover3Ref = createRef<PopoverRef>()
@@ -96,9 +99,14 @@ popoverStories.add(
         >
           Hover Me
         </div>
-        <div className="mockComponent mockButton" ref={triggerRefC}>
+        <SquareButton
+          icon={IconFont.Zap}
+          ref={triggerRefC}
+          status={ComponentStatus.Disabled}
+        />
+        {/* <div className="mockComponent mockButton" ref={triggerRefC}>
           Always Visible
-        </div>
+        </div> */}
         <Popover.Popover
           ref={popover1Ref}
           triggerRef={triggerRefA}
@@ -177,7 +185,7 @@ popoverStories.add(
           )}
           showEvent={PopoverInteraction.None}
           hideEvent={PopoverInteraction.None}
-          position={PopoverPosition.Above}
+          position={PopoverPosition.Below}
           color={ComponentColor.Success}
           type={PopoverType.Outline}
         />

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -57,8 +57,10 @@ popoverStories.add(
   () => {
     const triggerRefA = React.createRef<HTMLDivElement>()
     const triggerRefB = React.createRef<HTMLDivElement>()
+    const triggerRefC = React.createRef<HTMLDivElement>()
     const popover1Ref = createRef<PopoverRef>()
     const popover2Ref = createRef<PopoverRef>()
+    const popover3Ref = createRef<PopoverRef>()
 
     const log1Ref = (): void => {
       /* eslint-disable */
@@ -72,6 +74,12 @@ popoverStories.add(
       /* eslint-enable */
     }
 
+    const log3Ref = (): void => {
+      /* eslint-disable */
+      console.log(popover3Ref.current)
+      /* eslint-enable */
+    }
+
     return (
       <div className="story--example">
         <div
@@ -81,13 +89,19 @@ popoverStories.add(
         >
           Click Me
         </div>
-        <div className="mockComponent mockButton" ref={triggerRefB}>
+        <div
+          className="mockComponent mockButton"
+          ref={triggerRefB}
+          style={{marginRight: '60px'}}
+        >
           Hover Me
+        </div>
+        <div className="mockComponent mockButton" ref={triggerRefC}>
+          Always Visible
         </div>
         <Popover.Popover
           ref={popover1Ref}
           triggerRef={triggerRefA}
-          visible={boolean('visible', false)}
           enableDefaultStyles={false}
           contents={(onHide: any) => (
             <>
@@ -141,6 +155,31 @@ popoverStories.add(
           position={PopoverPosition.ToTheRight}
           color={ComponentColor.Secondary}
           type={PopoverType.Solid}
+        />
+        <Popover.Popover
+          ref={popover3Ref}
+          triggerRef={triggerRefC}
+          visible={true}
+          enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          contents={() => (
+            <>
+              <div style={{marginTop: '30px'}}>
+                I'm just a simple popover looking for my
+                <br />
+                place in this <strong>vast and beautiful</strong> world.
+                <br />
+                Will you help me?
+              </div>
+              <div className="story--test-buttons">
+                <button onClick={log3Ref}>Log Ref</button>
+              </div>
+            </>
+          )}
+          showEvent={PopoverInteraction.None}
+          hideEvent={PopoverInteraction.None}
+          position={PopoverPosition.Above}
+          color={ComponentColor.Success}
+          type={PopoverType.Outline}
         />
       </div>
     )

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -104,9 +104,6 @@ popoverStories.add(
           ref={triggerRefC}
           status={ComponentStatus.Disabled}
         />
-        {/* <div className="mockComponent mockButton" ref={triggerRefC}>
-          Always Visible
-        </div> */}
         <Popover.Popover
           ref={popover1Ref}
           triggerRef={triggerRefA}

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -228,3 +228,26 @@ export const getScrollbarColorsFromTheme = (
       }
   }
 }
+
+export const createPortalElement = (id: string, portalName: string): void => {
+  const portalExists = document.getElementById(id)
+  if (portalExists) {
+    return
+  }
+
+  const portalElement = document.createElement('div')
+  portalElement.setAttribute('class', `cf-${portalName}-portal`)
+  portalElement.setAttribute('id', id)
+
+  document.body.appendChild(portalElement)
+}
+
+export const destroyPortalElement = (id: string): void => {
+  const portalElement = document.getElementById(id)
+
+  if (portalElement) {
+    portalElement.remove()
+  } else {
+    console.error('cannot portal find element')
+  }
+}


### PR DESCRIPTION
Closes #326 

### Changes

- Remove `<span />` wrapping chil in `Popover`
- Popover `ref` prop passes through to "contents" element within `PopoverDialog`
- Use `useRef` instead of `createRef`
- Add popover to storybook examples that is visible by default (for testing purposes)
- Extract `createPortal` and `destroyPortal` functions into `/utils`
- Fire `handleUpdateStyles` on `PopoverDialog` initial render

Tested all changes in `influxdata/influxdb`

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
