### PR TITLE
Improve SelectableCard affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.0.33 (Unreleased)
 
+- [#331](https://github.com/influxdata/clockface/pull/331): Improve legiblity of `SelectableCard` default state
 - [#328](https://github.com/influxdata/clockface/pull/328): Convert `IndexList` component family to `FunctionComponent` and wrap with `forwardRef`
 - [#328](https://github.com/influxdata/clockface/pull/328): [Breaking] Prepend `cf-` to all `IndexList` class names
 - [#328](https://github.com/influxdata/clockface/pull/328): Convert `NavMenu` component family to `FunctionComponent` and wrap with `forwardRef`

--- a/src/Components/SelectableCard/Documentation/SelectableCard.stories.tsx
+++ b/src/Components/SelectableCard/Documentation/SelectableCard.stories.tsx
@@ -37,17 +37,22 @@ selectableCardStories.add(
     const selectableCard1Ref: RefObject<SelectableCardRef> = createRef()
     const selectableCard2Ref: RefObject<SelectableCardRef> = createRef()
     const selectableCard3Ref: RefObject<SelectableCardRef> = createRef()
+    const selectableCard4Ref: RefObject<SelectableCardRef> = createRef()
 
     const logRefs = (): void => {
       /* eslint-disable */
       console.log('SelectableCard 1', selectableCard1Ref.current)
       console.log('SelectableCard 2', selectableCard2Ref.current)
       console.log('SelectableCard 3', selectableCard3Ref.current)
+      console.log('SelectableCard 4', selectableCard4Ref.current)
       /* eslint-enable */
     }
 
     return (
       <div className="story--example" style={{height: '400px'}}>
+        <div className="story--test-buttons">
+          <button onClick={logRefs}>Log Refs</button>
+        </div>
         <SelectableCard
           ref={selectableCard1Ref}
           style={object('style', exampleStyle)}
@@ -79,7 +84,7 @@ selectableCardStories.add(
         <SelectableCard
           ref={selectableCard2Ref}
           style={object('style', exampleStyle)}
-          id={text('id', 'Titular Title')}
+          id="selected-card"
           icon={
             IconFont[
               select(
@@ -89,9 +94,39 @@ selectableCardStories.add(
               )
             ]
           }
-          label={text('label', 'Titular Title')}
-          selected={boolean('selected', true)}
-          disabled={boolean('disabled', false)}
+          label="Selected"
+          selected={true}
+          disabled={false}
+          fontSize={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          color={
+            ComponentColor[
+              select('color', mapEnumKeys(ComponentColor), 'Success')
+            ]
+          }
+          onClick={() => {
+            alert('card clicked!')
+          }}
+        >
+          <div className="mockComponent stretch">Image</div>
+        </SelectableCard>
+        <SelectableCard
+          ref={selectableCard2Ref}
+          style={object('style', exampleStyle)}
+          id="selected-disabled-card"
+          icon={
+            IconFont[
+              select(
+                'icon',
+                {None: 'none', ...mapEnumKeys(IconFont)},
+                'Checkmark'
+              )
+            ]
+          }
+          label="Selected + Disabled"
+          selected={true}
+          disabled={true}
           fontSize={
             ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
           }
@@ -109,7 +144,7 @@ selectableCardStories.add(
         <SelectableCard
           ref={selectableCard3Ref}
           style={object('style', exampleStyle)}
-          id={text('id', 'Titular Title')}
+          id="default-card"
           icon={
             IconFont[
               select(
@@ -119,9 +154,9 @@ selectableCardStories.add(
               )
             ]
           }
-          label={text('label', 'Titular Title')}
+          label="Default"
           selected={false}
-          disabled={boolean('disabled', false)}
+          disabled={false}
           fontSize={
             ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
           }
@@ -136,9 +171,36 @@ selectableCardStories.add(
         >
           <div className="mockComponent stretch">Image</div>
         </SelectableCard>
-        <div className="story--test-buttons">
-          <button onClick={logRefs}>Log Refs</button>
-        </div>
+        <SelectableCard
+          ref={selectableCard3Ref}
+          style={object('style', exampleStyle)}
+          id="disabled-card"
+          icon={
+            IconFont[
+              select(
+                'icon',
+                {None: 'none', ...mapEnumKeys(IconFont)},
+                'Checkmark'
+              )
+            ]
+          }
+          label="Disabled"
+          selected={false}
+          disabled={true}
+          fontSize={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          color={
+            ComponentColor[
+              select('color', mapEnumKeys(ComponentColor), 'Success')
+            ]
+          }
+          onClick={() => {
+            alert('card clicked!')
+          }}
+        >
+          <div className="mockComponent stretch">Image</div>
+        </SelectableCard>
       </div>
     )
   },

--- a/src/Components/SelectableCard/Documentation/SelectableCard.stories.tsx
+++ b/src/Components/SelectableCard/Documentation/SelectableCard.stories.tsx
@@ -38,6 +38,7 @@ selectableCardStories.add(
     const selectableCard2Ref: RefObject<SelectableCardRef> = createRef()
     const selectableCard3Ref: RefObject<SelectableCardRef> = createRef()
     const selectableCard4Ref: RefObject<SelectableCardRef> = createRef()
+    const selectableCard5Ref: RefObject<SelectableCardRef> = createRef()
 
     const logRefs = (): void => {
       /* eslint-disable */
@@ -45,6 +46,7 @@ selectableCardStories.add(
       console.log('SelectableCard 2', selectableCard2Ref.current)
       console.log('SelectableCard 3', selectableCard3Ref.current)
       console.log('SelectableCard 4', selectableCard4Ref.current)
+      console.log('SelectableCard 5', selectableCard5Ref.current)
       /* eslint-enable */
     }
 
@@ -112,7 +114,7 @@ selectableCardStories.add(
           <div className="mockComponent stretch">Image</div>
         </SelectableCard>
         <SelectableCard
-          ref={selectableCard2Ref}
+          ref={selectableCard3Ref}
           style={object('style', exampleStyle)}
           id="selected-disabled-card"
           icon={
@@ -142,7 +144,7 @@ selectableCardStories.add(
           <div className="mockComponent stretch">Image</div>
         </SelectableCard>
         <SelectableCard
-          ref={selectableCard3Ref}
+          ref={selectableCard4Ref}
           style={object('style', exampleStyle)}
           id="default-card"
           icon={
@@ -172,7 +174,7 @@ selectableCardStories.add(
           <div className="mockComponent stretch">Image</div>
         </SelectableCard>
         <SelectableCard
-          ref={selectableCard3Ref}
+          ref={selectableCard5Ref}
           style={object('style', exampleStyle)}
           id="disabled-card"
           icon={

--- a/src/Components/SelectableCard/SelectableCard.scss
+++ b/src/Components/SelectableCard/SelectableCard.scss
@@ -5,11 +5,17 @@
   ------------------------------------------------------------------------------
 */
 
-$selectable-card--bg: $g3-castle;
-$selectable-card--body: $g1-raven;
+$selectable-card--bg: $g5-pepper;
+$selectable-card--body: $g2-kevlar;
+$selectable-card--label: $g13-mist;
 
-$selectable-card--bg-hover: $g5-pepper;
-$selectable-card--body-hover: $g2-kevlar;
+$selectable-card--bg-hover: $g7-graphite;
+$selectable-card--body-hover: $g3-castle;
+$selectable-card--label-hover: $g18-cloud;
+
+$selectable-card--bg-disabled: $g4-onyx;
+$selectable-card--body-disabled: $g3-castle;
+$selectable-card--label-disabled: $g8-storm;
 
 .cf-selectable-card {
   width: 100%;
@@ -44,7 +50,7 @@ $selectable-card--body-hover: $g2-kevlar;
   justify-content: center;
   align-items: center;
   background-color: $selectable-card--body;
-  border-radius: $cf-radius;
+  border-radius: $cf-radius - 1px;
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
@@ -67,7 +73,7 @@ $selectable-card--body-hover: $g2-kevlar;
 
 .cf-selectable-card--label {
   cursor: inherit;
-  display: inline-flex;
+  display: inline-block;
   justify-content: center;
   align-items: center;
   text-align: center;
@@ -75,16 +81,15 @@ $selectable-card--body-hover: $g2-kevlar;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: $g11-sidewalk;
+  color: $selectable-card--label;
   transition: color 0.25s ease;
   font-weight: 600;
   position: relative;
-  padding: $cf-marg-e;
 }
 
 .cf-selectable-card:hover {
   .cf-selectable-card--label {
-    color: $g13-mist;
+    color: $selectable-card--label-hover;
   }
 }
 
@@ -105,13 +110,8 @@ $selectable-card--body-hover: $g2-kevlar;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  filter: grayscale(0.5) opacity(30%);
+  filter: grayscale(0) opacity(100%);
   transition: filter 0.2s ease;
-
-  .cf-selectable-card:hover &,
-  .cf-selectable-card__selected & {
-    filter: grayscale(0) opacity(100%);
-  }
 }
 
 /*
@@ -123,21 +123,21 @@ $selectable-card--body-hover: $g2-kevlar;
 .cf-selectable-card__disabled:hover,
 .cf-selectable-card__disabled.cf-selectable-card__selected {
   cursor: default;
-  border-color: $g1-raven;
-  background-color: $g1-raven;
+  border-color: $selectable-card--bg-disabled;
+  background-color: $selectable-card--bg-disabled;
   font-style: italic;
 
   .cf-selectable-card--body,
   .cf-selectable-card--body:hover {
-    background-color: $g1-raven;
+    background-color: $selectable-card--body-disabled;
   }
 
   .cf-selectable-card--children {
-    filter: grayscale(0.75) opacity(15%);
+    filter: grayscale(0.5) opacity(30%);
   }
 
   .cf-selectable-card--label {
-    color: $g9-mountain;
+    color: $selectable-card--label-disabled;
   }
 
   &.cf-selectable-card__selected {
@@ -163,11 +163,11 @@ $selectable-card--body-hover: $g2-kevlar;
   }
 
   &.cf-selectable-card__selected.cf-selectable-card__disabled {
-    border-color: mix($color, $g1-raven, 30%);
-    background-color: mix($color, $g1-raven, 30%);
+    border-color: mix($color, $selectable-card--body, 30%);
+    background-color: mix($color, $selectable-card--body, 30%);
 
     .cf-selectable-card--icon {
-      color: mix($color, $g1-raven, 30%);
+      color: mix($color, $selectable-card--body, 30%);
     }
   }
 }
@@ -198,6 +198,7 @@ $selectable-card--body-hover: $g2-kevlar;
 @mixin selectableCardSizeModifier($fontSize, $padding) {
   .cf-selectable-card--label {
     font-size: ceil($fontSize * 1.25);
+    line-height: ceil($fontSize * 1.25);
     padding: $padding;
   }
 


### PR DESCRIPTION
Closes #330 

### Changes

- Make `inactive` and `disabled` slightly brighter so they don't blend into `Panel` default color
- Make `inactive` image state not greyed out or lower opacity
- Ensure story has all permutations visible at once (for testing purposes)
- Ensure the label truncates with `...` when it is too long

### Screenshots

![Screen Shot 2019-10-14 at 12 34 51 PM](https://user-images.githubusercontent.com/2433762/66778044-70aaa680-ee7f-11e9-88c1-c8fa7a4bb696.png)
![Screen Shot 2019-10-14 at 12 43 51 PM](https://user-images.githubusercontent.com/2433762/66778390-5e7d3800-ee80-11e9-9208-70410ddd0f99.png)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
