### PR TITLE
Fix Color Picker Bugs

### DIFF
--- a/src/Components/ColorPicker/ColorPicker.scss
+++ b/src/Components/ColorPicker/ColorPicker.scss
@@ -11,8 +11,6 @@ $color-picker--margin: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  width: 100%;
-  min-width: 160px;
 }
 
 .cf-color-picker--swatches {

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -23,7 +23,11 @@ import {
 } from '../../Types'
 
 // Utils
-import {validateHexCode, VALID_HEX_LENGTH} from '../../Utils/hexCodeValidation'
+import {
+  validateHexCode,
+  VALID_HEX_LENGTH,
+  invalidHexCharacters,
+} from '../../Utils/hexCodeValidation'
 
 // Styles
 import './ColorPicker.scss'
@@ -41,6 +45,8 @@ interface ColorPickerProps extends StandardFunctionProps {
   swatchesPerRow?: number
   /** Enforces hexcode format by defult, pass in your own function to customize */
   validationFunc?: ValidationFunction
+  /** Characters matching this expression will be stripped out of the value before being passed into onChange */
+  invalidChars?: RegExp
 }
 
 export type ColorPickerRef = HTMLDivElement
@@ -58,6 +64,7 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
       testID = 'color-picker',
       maintainInputFocus = false,
       validationFunc = validateHexCode,
+      invalidChars = invalidHexCharacters,
     },
     ref
   ) => {
@@ -76,7 +83,16 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
     }
 
     const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
-      const nextColor = e.target.value.trim()
+      let nextColor = e.target.value
+
+      if (invalidChars) {
+        nextColor = e.target.value.replace(invalidChars, '')
+      }
+
+      // This is not using the inputStatus variable becuase that information
+      // is stale and this outgoing information needs to be fresh in order
+      // for the stateful parent to correctly make decisions
+
       const nextStatus = !!validationFunc(nextColor)
         ? ComponentStatus.Error
         : ComponentStatus.Valid

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -76,7 +76,12 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
     }
 
     const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
-      onChange(e.target.value, inputStatus)
+      const nextColor = e.target.value.trim()
+      const nextStatus = !!validationFunc(nextColor)
+        ? ComponentStatus.Error
+        : ComponentStatus.Valid
+
+      onChange(nextColor, nextStatus)
     }
 
     const handleInputBlur = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -49,7 +49,7 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
   (
     {
       id,
-      style,
+      style = {width: '100%'},
       color,
       onChange,
       className,

--- a/src/Components/ColorPicker/Documentation/ColorPicker.stories.tsx
+++ b/src/Components/ColorPicker/Documentation/ColorPicker.stories.tsx
@@ -46,18 +46,19 @@ colorPickerStories.add(
       /* eslint-enable */
     }
 
+    const defaultStyle = {width: '400px'}
+
     return (
       <div className="story--example">
-        <div style={{width: `${number('Parent Width (px)', 300)}`}}>
-          <ColorPicker
-            ref={colorPickerRef}
-            color={text('color', `${InfluxColors.Honeydew}`)}
-            onChange={color => {
-              alert(`Swatch selected: ${color}`)
-            }}
-            maintainInputFocus={boolean('maintainInputFocus', false)}
-          />
-        </div>
+        <ColorPicker
+          ref={colorPickerRef}
+          style={object('style', defaultStyle)}
+          color={text('color', `${InfluxColors.Honeydew}`)}
+          onChange={(color, status) => {
+            alert(`Color: ${color}, Status: ${status}`)
+          }}
+          maintainInputFocus={boolean('maintainInputFocus', false)}
+        />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>
         </div>

--- a/src/Utils/hexCodeValidation.ts
+++ b/src/Utils/hexCodeValidation.ts
@@ -28,7 +28,7 @@ export const validateHexCode: ValidationFunction = (
   }
 
   // Cannot contain invalid characters
-  const invalidChars = color.replace(/[#abcdefABCDEF123456790]/g, '')
+  const invalidChars = color.replace(/[#abcdefABCDEF0123456789]/g, '')
   if (invalidChars.length) {
     return 'Invalid hexcode'
   }

--- a/src/Utils/hexCodeValidation.ts
+++ b/src/Utils/hexCodeValidation.ts
@@ -28,7 +28,7 @@ export const validateHexCode: ValidationFunction = (
   }
 
   // Cannot contain invalid characters
-  const invalidChars = color.replace(/[#abcdefABCDEF0123456789]/g, '')
+  const invalidChars = color.replace(/[abcdefgABCDEFG#0123456789]/g, '')
   if (invalidChars.length) {
     return 'Invalid hexcode'
   }
@@ -36,3 +36,5 @@ export const validateHexCode: ValidationFunction = (
   // Valid hexcode exists
   return null
 }
+
+export const invalidHexCharacters = /[^abcdefgABCDEFG#0123456789]/g


### PR DESCRIPTION
Fixes some oversight from #340 

### Changes

- Include `8` in list of accepted hexcode characters
- Send validation status of input event value not stale value
  - This prevents the problem of the picker always returning `error`
- Allow for optional control over input value cleaning before it is passed in to `onChange`
  - By default this blocks the user from typing invalid hexcode characters

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
