### PR TITLE
Refactor TextArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ### 1.0.3 (Unreleased)
 
-- [#342](https://github.com/influxdata/clockface/pull/342): Upgrade typescript, eslint, & storybook dependencies
+- [#352](https://github.com/influxdata/clockface/pull/352): Refactor `TextArea` component to accept customization like `Input`
+- [#352](https://github.com/influxdata/clockface/pull/352): Fix bug causing `TextArea` to be very tiny
 - [#350](https://github.com/influxdata/clockface/pull/350): Added explicit check for `className` in Popover `handleTriggerMouseLeave` method
+- [#342](https://github.com/influxdata/clockface/pull/342): Upgrade typescript, eslint, & storybook dependencies
 
 ### 1.0.2
 

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -51,6 +51,7 @@ import {
 import InputReadme from './Input.md'
 import AutoInputReadme from './AutoInput.md'
 import RangeSliderReadme from './RangeSlider.md'
+import TextAreaReadme from './TextArea.md'
 
 const inputsBaseStories = storiesOf('Components|Inputs/Base', module)
   .addDecorator(withKnobs)
@@ -301,56 +302,173 @@ inputsBaseStories.add(
   }
 )
 
-inputsBaseStories.add('TextArea', () => {
-  const textAreaRef: RefObject<TextAreaRef> = createRef()
-  const textAreaContainerRef: RefObject<TextAreaContainerRef> = createRef()
+inputsBaseStories.add(
+  'TextArea',
+  () => {
+    const textAreaRefDefault: RefObject<TextAreaRef> = createRef()
+    const textAreaRefDisabled: RefObject<TextAreaRef> = createRef()
+    const textAreaRefValid: RefObject<TextAreaRef> = createRef()
+    const textAreaRefError: RefObject<TextAreaRef> = createRef()
+    const textAreaRefLoading: RefObject<TextAreaRef> = createRef()
+    const textAreaContainerRef: RefObject<TextAreaContainerRef> = createRef()
 
-  const handleLogRefs = (): void => {
-    /* eslint-disable */
-    console.log('TextAreaRef', textAreaRef.current)
-    console.log('TextAreaContainerRef', textAreaContainerRef.current)
-    /* eslint-enable */
-  }
+    const handleLogRefs = (): void => {
+      /* eslint-disable */
+      console.log('TextAreaRef (Default)', textAreaRefDefault.current)
+      console.log('TextAreaRef (Disabled)', textAreaRefDisabled.current)
+      console.log('TextAreaRef (Valid)', textAreaRefValid.current)
+      console.log('TextAreaRef (Error)', textAreaRefError.current)
+      console.log('TextAreaRef (Loading)', textAreaRefLoading.current)
+      console.log('TextAreaContainerRef', textAreaContainerRef.current)
+      /* eslint-enable */
+    }
 
-  const exampleTextAreaStyle = {width: '300px'}
+    const exampleTextAreaStyle = {width: '160px', margin: '0 10px'}
 
-  return (
-    <div className="story--example">
-      <TextArea
-        ref={textAreaRef}
-        containerRef={textAreaContainerRef}
-        value={text('value', 'Value Text')}
-        maxLength={number('maxLength', 50)}
-        minLength={number('minLength', 5)}
-        placeholder={text('placeholder', 'Placeholder Text')}
-        onChange={() => {}}
-        autocomplete={
-          AutoComplete[
+    return (
+      <div className="story--example">
+        <div className="story--test-buttons">
+          <button onClick={handleLogRefs}>Log Refs</button>
+        </div>
+        <TextArea
+          ref={textAreaRefDefault}
+          containerRef={textAreaContainerRef}
+          value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
+          maxLength={number('maxLength', 50)}
+          minLength={number('minLength', 5)}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          onChange={() => {}}
+          monospace={boolean('monospace', false)}
+          autocomplete={
+            AutoComplete[
+              radios<AutoComplete>(
+                'autocomplete',
+                mapEnumKeys(AutoComplete),
+                AutoComplete.Off
+              )
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          style={object('style', exampleTextAreaStyle)}
+          cols={number('cols', 20)}
+          rows={number('rows', 10)}
+          status={ComponentStatus.Default}
+        />
+        <TextArea
+          ref={textAreaRefDisabled}
+          containerRef={textAreaContainerRef}
+          value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
+          maxLength={number('maxLength', 50)}
+          minLength={number('minLength', 5)}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          onChange={() => {}}
+          monospace={boolean('monospace', false)}
+          autocomplete={
+            AutoComplete[
             radios<AutoComplete>(
               'autocomplete',
               mapEnumKeys(AutoComplete),
               AutoComplete.Off
             )
-          ]
-        }
-        size={
-          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
-        }
-        style={object('style', exampleTextAreaStyle)}
-        cols={number('cols', 20)}
-        rows={number('rows', 20)}
-        status={
-          ComponentStatus[
-            select('status', mapEnumKeys(ComponentStatus), 'Default')
-          ]
-        }
-      />
-      <div className="story--test-buttons">
-        <button onClick={handleLogRefs}>Log Refs</button>
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          style={object('style', exampleTextAreaStyle)}
+          cols={number('cols', 20)}
+          rows={number('rows', 10)}
+          status={ComponentStatus.Disabled}
+        />
+        <TextArea
+          ref={textAreaRefValid}
+          containerRef={textAreaContainerRef}
+          value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
+          maxLength={number('maxLength', 50)}
+          minLength={number('minLength', 5)}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          onChange={() => {}}
+          monospace={boolean('monospace', false)}
+          autocomplete={
+            AutoComplete[
+            radios<AutoComplete>(
+              'autocomplete',
+              mapEnumKeys(AutoComplete),
+              AutoComplete.Off
+            )
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          style={object('style', exampleTextAreaStyle)}
+          cols={number('cols', 20)}
+          rows={number('rows', 10)}
+          status={ComponentStatus.Valid}
+        />
+        <TextArea
+          ref={textAreaRefError}
+          containerRef={textAreaContainerRef}
+          value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
+          maxLength={number('maxLength', 50)}
+          minLength={number('minLength', 5)}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          onChange={() => {}}
+          monospace={boolean('monospace', false)}
+          autocomplete={
+            AutoComplete[
+            radios<AutoComplete>(
+              'autocomplete',
+              mapEnumKeys(AutoComplete),
+              AutoComplete.Off
+            )
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          style={object('style', exampleTextAreaStyle)}
+          cols={number('cols', 20)}
+          rows={number('rows', 10)}
+          status={ComponentStatus.Error}
+        />
+        <TextArea
+          ref={textAreaRefLoading}
+          containerRef={textAreaContainerRef}
+          value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
+          maxLength={number('maxLength', 50)}
+          minLength={number('minLength', 5)}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          onChange={() => {}}
+          monospace={boolean('monospace', false)}
+          autocomplete={
+            AutoComplete[
+            radios<AutoComplete>(
+              'autocomplete',
+              mapEnumKeys(AutoComplete),
+              AutoComplete.Off
+            )
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          style={object('style', exampleTextAreaStyle)}
+          cols={number('cols', 20)}
+          rows={number('rows', 10)}
+          status={ComponentStatus.Loading}
+        />
       </div>
-    </div>
-  )
-})
+    )
+  },
+  {
+    readme: {
+      content: marked(TextAreaReadme),
+    },
+  }
+)
 
 inputsComposedStories.add(
   'AutoInput',

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -319,7 +319,7 @@ inputsBaseStories.add(
       console.log('TextAreaRef (Valid)', textAreaRefValid.current)
       console.log('TextAreaRef (Error)', textAreaRefError.current)
       console.log('TextAreaRef (Loading)', textAreaRefLoading.current)
-      console.log('TextAreaContainerRef', textAreaContainerRef.current)
+      console.log('TextAreaContainerRef (Default)', textAreaContainerRef.current)
       /* eslint-enable */
     }
 
@@ -358,7 +358,6 @@ inputsBaseStories.add(
         />
         <TextArea
           ref={textAreaRefDisabled}
-          containerRef={textAreaContainerRef}
           value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
           maxLength={number('maxLength', 50)}
           minLength={number('minLength', 5)}
@@ -384,7 +383,6 @@ inputsBaseStories.add(
         />
         <TextArea
           ref={textAreaRefValid}
-          containerRef={textAreaContainerRef}
           value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
           maxLength={number('maxLength', 50)}
           minLength={number('minLength', 5)}
@@ -410,7 +408,6 @@ inputsBaseStories.add(
         />
         <TextArea
           ref={textAreaRefError}
-          containerRef={textAreaContainerRef}
           value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
           maxLength={number('maxLength', 50)}
           minLength={number('minLength', 5)}
@@ -436,7 +433,6 @@ inputsBaseStories.add(
         />
         <TextArea
           ref={textAreaRefLoading}
-          containerRef={textAreaContainerRef}
           value={text('value', 'Example text can be controlled from the Knobs panel on the right')}
           maxLength={number('maxLength', 50)}
           minLength={number('minLength', 5)}

--- a/src/Components/Inputs/Documentation/TextArea.md
+++ b/src/Components/Inputs/Documentation/TextArea.md
@@ -1,0 +1,18 @@
+# TextArea
+
+This is an extension of the standard HTML `<textarea />` element which is best used for multi-line text
+
+### Usage
+```tsx
+import {TextArea} from '@influxdata/clockface'
+```
+
+### Example
+<!-- STORY -->
+
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -5,69 +5,54 @@
   ------------------------------------------------------------------------------
 */
 
-$input-bg: $g2-kevlar;
-$input-disabled-bg: $g3-castle;
-
-$input-text: $g15-platinum;
-$input-border: $g5-pepper;
-$input-hover-text: $g17-whisper;
-$input-hover-border: $g7-graphite;
-$input-focus-text: $g20-white;
-$input-focus-border: $c-pool;
-$input-disabled-text: $g9-mountain;
-$input-disabled-border: $g4-onyx;
-
-$input-field-z: 1;
-$input-shadow-z: $input-field-z + 1;
-$input-status-z: $input-field-z + 2;
-
 .cf-input {
   position: relative;
 }
 
 .cf-input-field {
   position: relative;
-  z-index: $input-field-z;
+  z-index: $cf-input--field-z;
   width: 100%;
   font-weight: 600;
   font-family: $cf-text-font;
-  transition: background-color 0.25s ease, border-color 0.25s ease,
-    box-shadow 0.25s ease, color 0.25s ease;
+  transition: $cf-input--transition;
   outline: none;
   appearance: none;
   border-radius: $cf-radius;
-  background-color: $input-bg;
-  color: $input-text;
-  border: $cf-border solid $input-border;
+  background-color: $cf-input-background--default;
+  color: $cf-input-text--default;
+  border: $cf-border solid $cf-input-border--default;
 
   &:hover {
-    border-color: $input-hover-border;
-    color: $input-hover-text;
+    background-color: $cf-input-background--hover;
+    border-color: $cf-input-border--hover;
+    color: $cf-input-text--hover;
   }
 
   &:focus {
-    color: $input-focus-text;
-    border-color: $input-focus-border;
-    box-shadow: 0 0 6px 0 $input-focus-border;
+    background-color: $cf-input-background--focused;
+    border-color: $cf-input-border--focused;
+    color: $cf-input-text--focused;
+    box-shadow: 0 0 6px 0 $cf-input-border--focused;
   }
 
   &::-webkit-input-placeholder {
-    color: $input-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &::-moz-placeholder {
-    color: $input-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &:-ms-input-placeholder {
-    color: $input-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &:-moz-placeholder {
-    color: $input-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
@@ -77,50 +62,26 @@ $input-status-z: $input-field-z + 2;
   Input Icons (Including Status)
   ------------------------------------------------------------------------------
 */
-.cf-input-icon,
-.cf-input-status {
+.cf-input-icon {
   pointer-events: none;
   top: 50%;
   position: absolute;
-  z-index: $input-status-z;
+  z-index: $cf-input--status-z;
   transition: color 0.25s ease;
   font-size: 1.1em;
 }
 
-.cf-input-status {
-  transform: translate(50%, -50%);
-}
-
 .cf-input-icon {
   transform: translate(-50%, -50%);
-  color: $input-text;
+  color: $cf-input-text--default;
 }
 
 .cf-input-field:hover + .cf-input-icon {
-  color: $input-hover-text;
+  color: $cf-input-text--hover;
 }
 
 .cf-input-field:focus + .cf-input-icon {
-  color: $input-focus-text;
-}
-
-.cf-input-shadow {
-  pointer-events: none;
-  position: absolute;
-  z-index: $input-shadow-z;
-  height: calc(100% - #{$cf-border * 2});
-  top: $cf-border;
-  border-radius: 0 3px 3px 0;
-  @include gradient-h(rgba($input-bg, 0), $input-bg);
-  border-style: solid;
-  border-color: $input-bg;
-  border-width: 0;
-  transition: opacity 0.25s ease;
-  opacity: 0;
-}
-
-.cf-input-status + .cf-input-shadow {
-  opacity: 1;
+  color: $cf-input-text--focused;
 }
 
 /*
@@ -134,9 +95,9 @@ $input-status-z: $input-field-z + 2;
 
 .cf-input--checkbox {
   position: relative;
-  background-color: $g2-kevlar;
+  background-color: $cf-input-background--default;
   border-radius: $cf-radius;
-  border: $cf-border solid $g5-pepper;
+  border: $cf-border solid $cf-input-border--default;
   transition: border-color 0.25s ease, background-color 0.25s ease;
 
   &:after {
@@ -146,7 +107,7 @@ $input-status-z: $input-field-z + 2;
     left: 50%;
     transform: translate(-50%, -50%) scale(1.5,1.5);
     border-radius: 50%;
-    background: $c-pool;
+    background: $cf-input-border--focused;
     z-index: 2;
     opacity: 0;
     transition: opacity 0.25s ease, transform 0.25s ease;
@@ -158,7 +119,8 @@ $input-status-z: $input-field-z + 2;
   }
 
   &:hover {
-    border-color: $g7-graphite;
+    background-color: $cf-input-background--hover;
+    border-color: $cf-input-border--hover;
     cursor: pointer;
   }
 }
@@ -185,24 +147,9 @@ $input-status-z: $input-field-z + 2;
     left: ($height / 2) + $cf-border;
   }
 
-  .cf-input-status {
-    right: $height / 2;
-  }
-
   .cf-input-pseudo {
     height: $height;
     width: $height;
-  }
-
-  .cf-input-shadow {
-    width: $height;
-    right: $padding;
-    border-right-width: $padding;
-  }
-
-  .cf-input-spinner {
-    width: $height / 2;
-    height: $height / 2;
   }
 
   .cf-input--checkbox {
@@ -231,63 +178,20 @@ $input-status-z: $input-field-z + 2;
 }
 
 /*
-  Valid State
-  ------------------------------------------------------------------------------
-*/
-.cf-input__valid {
-  .cf-input-status {
-    color: $c-rainforest;
-  }
-}
-
-/*
   Error State
   ------------------------------------------------------------------------------
 */
 .cf-input__error {
-  .cf-input-status {
-    color: $c-dreamsicle;
-  }
   .cf-input-field {
-    border-color: $c-curacao;
+    border-color: $cf-input-border--error;
   }
   .cf-input-field:hover {
-    border-color: $c-dreamsicle;
+    border-color: $cf-input-border--error-hover;
   }
   .cf-input-field:focus {
-    border-color: $c-dreamsicle;
-    box-shadow: 0 0 6px 0 $c-fire;
+    border-color: $cf-input-border--error-focused;
+    box-shadow: 0 0 6px 0 $cf-input-border--error-focused;
   }
-}
-
-/*
-  Loading State
-  ------------------------------------------------------------------------------
-*/
-.cf-input__loading {
-  .cf-input-status {
-    color: $c-pool;
-  }
-}
-
-@keyframes LoadingSpinner {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-.cf-input-spinner {
-  border-style: solid;
-  border-radius: 50%;
-  animation-duration: 0.85s;
-  animation-name: LoadingSpinner;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  border: $cf-border solid $g5-pepper;
-  border-top-color: $c-pool;
 }
 
 /*
@@ -297,17 +201,17 @@ $input-status-z: $input-field-z + 2;
 .cf-input__disabled {
   .cf-input-icon,
   .cf-input-field:hover + .cf-input-icon {
-    color: $input-disabled-text;
+    color: $cf-input-text--disabled;
   }
   .cf-input--checkbox {
     &,
     &:hover {
       cursor: default;
-      border-color: $input-disabled-border;
-      background-color: $input-disabled-bg;
+      border-color: $cf-input-border--disabled;
+      background-color: $cf-input-background--disabled;
 
       &:after {
-        background-color: $input-disabled-text;
+        background-color: $cf-input-text--disabled;
       }
     }
   }
@@ -316,8 +220,8 @@ $input-status-z: $input-field-z + 2;
 .cf-input-field[disabled],
 .cf-input-field[disabled]:hover {
   cursor: default;
-  border-color: $input-disabled-border;
-  background-color: $input-disabled-bg;
-  color: $input-disabled-text;
+  border-color: $cf-input-border--disabled;
+  background-color: $cf-input-background--disabled;
+  color: $cf-input-text--disabled;
   font-style: italic;
 }

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -5,12 +5,12 @@ import React, {
   KeyboardEvent,
   forwardRef,
   RefObject,
-  FunctionComponent,
 } from 'react'
 import classnames from 'classnames'
 
 // Components
 import {Icon} from '../Icon/Icon'
+import {StatusIndicator} from './StatusIndicator'
 
 // Styles
 import './Input.scss'
@@ -148,6 +148,14 @@ export const Input = forwardRef<InputRef, InputProps>(
 
     return (
       <div className={inputClass} style={style} ref={containerRef}>
+        {type !== InputType.Checkbox && (
+          <StatusIndicator
+            status={status}
+            shadow={true}
+            testID={testID}
+            size={size}
+          />
+        )}
         <input
           id={id}
           ref={ref}
@@ -180,59 +188,9 @@ export const Input = forwardRef<InputRef, InputProps>(
         />
         {type === InputType.Checkbox && <div className={inputCheckboxClass} />}
         {iconElement}
-        {type !== InputType.Checkbox && (
-          <InputStatusIndicator status={status} />
-        )}
       </div>
     )
   }
 )
 
 Input.displayName = 'Input'
-
-interface InputStatusIndicatorProps {
-  status: ComponentStatus
-}
-
-const InputStatusIndicator: FunctionComponent<InputStatusIndicatorProps> = ({
-  status,
-}) => {
-  if (status === ComponentStatus.Loading) {
-    return (
-      <>
-        <div className="cf-input-status">
-          <div className="cf-input-spinner" />
-        </div>
-        <div className="cf-input-shadow" />
-      </>
-    )
-  }
-
-  if (status === ComponentStatus.Error) {
-    return (
-      <>
-        <Icon
-          glyph={IconFont.AlertTriangle}
-          className="cf-input-status"
-          testID="input-error"
-        />
-        <div className="cf-input-shadow" />
-      </>
-    )
-  }
-
-  if (status === ComponentStatus.Valid) {
-    return (
-      <>
-        <Icon
-          glyph={IconFont.Checkmark}
-          className="cf-input-status"
-          testID="input-valid"
-        />
-        <div className="cf-input-shadow" />
-      </>
-    )
-  }
-
-  return <div className="cf-input-shadow" />
-}

--- a/src/Components/Inputs/StatusIndicator.scss
+++ b/src/Components/Inputs/StatusIndicator.scss
@@ -1,0 +1,105 @@
+@import '../../Styles/modules';
+
+/*
+  Status Indicator Styles
+  ------------------------------------------------------------------------------
+*/
+
+.cf-status-indicator {
+  top: 0;
+  right: 0;
+  position: absolute;
+  z-index: $cf-input--status-z;
+  pointer-events: none;
+}
+
+.cf-status-indicator--child {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: $cf-input--status-z;
+}
+
+.cf-status-indicator--shadow {
+  position: absolute;
+  top: $cf-border;
+  right: $cf-border;
+  bottom: $cf-border;
+  border-radius: 0 $cf-radius-sm $cf-radius-sm 0;
+  @include gradient-h(rgba($cf-input-background--default, 0), $cf-input-background--default);
+  transition: opacity 0.25s ease;
+  border-right-color: $cf-input-background--default;
+  border-right-style: solid;
+  opacity: 0;
+
+  .cf-status-indicator__valid &,
+  .cf-status-indicator__error &,
+  .cf-status-indicator__loading & {
+    opacity: 1;
+  }
+}
+
+@keyframes StatusSpinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.cf-status-indicator--spinner {
+  border-style: solid;
+  border-radius: 50%;
+  animation-duration: 0.85s;
+  animation-name: StatusSpinner;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  border: $cf-border solid $cf-input-border--default;
+  border-top-color: $cf-input-border--focused;
+  width: 1.1em;
+  height: 1.1em;
+}
+
+/*
+  Size Modifiers
+  ------------------------------------------------------------------------------
+*/
+
+@mixin statusIndicatorSizeModifier($fontSize, $dimensions) {
+  width: $dimensions;
+  height: $dimensions;
+  font-size: $fontSize;
+
+  .cf-status-indicator--shadow {
+    width: ($dimensions - $cf-border) + $dimensions * 0.6;
+    border-right-width: $dimensions * 0.6;
+  }
+}
+
+.cf-status-indicator__xs {
+  @include statusIndicatorSizeModifier($form-xs-font, $form-xs-height);
+}
+.cf-status-indicator__sm {
+  @include statusIndicatorSizeModifier($form-sm-font, $form-sm-height);
+}
+.cf-status-indicator__md {
+  @include statusIndicatorSizeModifier($form-md-font, $form-md-height);
+}
+.cf-status-indicator__lg {
+  @include statusIndicatorSizeModifier($form-lg-font, $form-lg-height);
+}
+
+/*
+  Status Modifiers
+  ------------------------------------------------------------------------------
+*/
+
+.cf-status-indicator__valid {
+  color: $c-rainforest;
+}
+
+.cf-status-indicator__error {
+  color: $c-dreamsicle;
+}

--- a/src/Components/Inputs/StatusIndicator.tsx
+++ b/src/Components/Inputs/StatusIndicator.tsx
@@ -1,0 +1,95 @@
+// Libraries
+import React, {forwardRef} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {Icon} from '../Icon/Icon'
+
+// Types
+import {
+  StandardFunctionProps,
+  ComponentStatus,
+  IconFont,
+  ComponentSize,
+} from '../../Types'
+
+// Styles
+import './StatusIndicator.scss'
+
+export interface StatusIndicatorProps extends StandardFunctionProps {
+  /** The status to indicate */
+  status: ComponentStatus
+  /** Renders a shadow beneath the indicator for increased legibility */
+  shadow?: boolean
+  /** Controls the size of the indicator, this should match the size of the associated input */
+  size?: ComponentSize
+}
+
+export type StatusIndicatorRef = HTMLDivElement
+
+export const StatusIndicator = forwardRef<
+  StatusIndicatorRef,
+  StatusIndicatorProps
+>(
+  (
+    {
+      id,
+      size = ComponentSize.Small,
+      style,
+      status,
+      testID = 'status-indicator',
+      shadow = true,
+      className,
+    },
+    ref
+  ) => {
+    const statusIndicatorClass = classnames('cf-status-indicator', {
+      [`cf-status-indicator__${status}`]: status,
+      [`cf-status-indicator__${size}`]: size,
+      [`${className}`]: className,
+    })
+
+    let statusElement: JSX.Element = <></>
+    const shadowElement = shadow && <div className="cf-status-indicator--shadow" />
+
+    if (status === ComponentStatus.Loading) {
+      statusElement = (
+        <span
+          className="cf-status-indicator--child"
+        >
+          <div className="cf-status-indicator--spinner" />
+        </span>
+      )
+    }
+
+    if (status === ComponentStatus.Error) {
+      statusElement = (
+        <Icon
+          glyph={IconFont.AlertTriangle}
+          className="cf-status-indicator--child"
+        />
+      )
+    }
+
+    if (status === ComponentStatus.Valid) {
+      statusElement = (
+        <Icon
+          glyph={IconFont.Checkmark}
+          className="cf-status-indicator--child"
+        />
+      )
+    }
+
+    return (
+      <div className={statusIndicatorClass} data-testid={`${testID}--${status}`}
+        ref={ref}
+        id={id}
+        style={style}>
+        {statusElement}
+        {shadowElement}
+      </div>
+    )
+  }
+)
+
+StatusIndicator.displayName = 'StatusIndicator'

--- a/src/Components/Inputs/TextArea.scss
+++ b/src/Components/Inputs/TextArea.scss
@@ -15,8 +15,7 @@
   height: 100%;
   font-weight: 600;
   resize: none;
-  transition: background-color 0.25s ease, border-color 0.25s ease,
-    box-shadow 0.25s ease, color 0.25s ease;
+  transition: $cf-input--transition;
   outline: none;
   appearance: none;
   border-radius: $cf-radius;

--- a/src/Components/Inputs/TextArea.scss
+++ b/src/Components/Inputs/TextArea.scss
@@ -5,82 +5,113 @@
   ------------------------------------------------------------------------------
 */
 
-$text-area-bg: $g2-kevlar;
-$text-area-disabled-bg: $g3-castle;
-
-$text-area-text: $g15-platinum;
-$text-area-border: $g5-pepper;
-$text-area-hover-text: $g17-whisper;
-$text-area-hover-border: $g7-graphite;
-$text-area-focus-text: $g20-white;
-$text-area-focus-border: $c-pool;
-$text-area-disabled-text: $g9-mountain;
-
-$text-area-field-z: 1;
-$text-area-shadow-z: $text-area-field-z + 1;
-$text-area-status-z: $text-area-field-z + 2;
-
-.cf-text-area--container {
-  width: 100%;
-  height: 100%;
-}
 .cf-text-area {
   position: relative;
-  padding: 15px;
-  z-index: $text-area-field-z;
+}
+
+.cf-text-area--input {
+  z-index: $cf-input--field-z;
   width: 100%;
   height: 100%;
   font-weight: 600;
-  font-size: small;
   resize: none;
-  font-family: $cf-text-font;
   transition: background-color 0.25s ease, border-color 0.25s ease,
     box-shadow 0.25s ease, color 0.25s ease;
   outline: none;
   appearance: none;
   border-radius: $cf-radius;
-  background-color: $text-area-bg;
-  color: $text-area-text;
-  border: $cf-border solid $text-area-border;
+  background-color: $cf-input-background--default;
+  border: $cf-border solid $cf-input-border--default;
+  color: $cf-input-text--default;
 
   &:hover {
-    border-color: $text-area-hover-border;
-    color: $text-area-hover-text;
+    background-color: $cf-input-background--hover;
+    border-color: $cf-input-border--hover;
+    color: $cf-input-text--hover;
   }
 
   &:focus {
-    color: $text-area-focus-text;
-    border-color: $text-area-focus-border;
-    box-shadow: 0 0 6px 0 $text-area-focus-border;
+    background-color: $cf-input-background--focused;
+    color: $cf-input-text--focused;
+    border-color: $cf-input-border--focused;
+    box-shadow: 0 0 6px 0 $cf-input-border--focused;
   }
 
   &[disabled],
   &[disabled]:hover {
     cursor: default;
-    border-color: $text-area-border;
-    background-color: $text-area-disabled-bg;
-    color: $text-area-disabled-text;
+    border-color: $cf-input-border--disabled;
+    background-color: $cf-input-background--disabled;
+    color: $cf-input-text--disabled;
     font-style: italic;
   }
 
   &::-webkit-text-area-placeholder {
-    color: $text-area-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &::-moz-placeholder {
-    color: $text-area-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &:-ms-text-area-placeholder {
-    color: $text-area-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
   &:-moz-placeholder {
-    color: $text-area-disabled-text;
+    color: $cf-input--placeholder-text;
     font-weight: 600 !important;
     font-style: italic;
   }
+
+  .cf-text-area__regular-font & {
+    font-family: $cf-text-font;
+  }
+  .cf-text-area__monospace-font & {
+    font-family: $cf-code-font;
+  }
+}
+
+/*
+  Error State
+  ------------------------------------------------------------------------------
+*/
+.cf-text-area__error {
+  .cf-text-area--input {
+    border-color: $cf-input-border--error;
+  }
+  .cf-text-area--input:hover {
+    border-color: $cf-input-border--error-hover;
+  }
+  .cf-text-area--input:focus {
+    border-color: $cf-input-border--error-focused;
+    box-shadow: 0 0 6px 0 $cf-input-border--error-focused;
+  }
+}
+
+/*
+  Size Modifiers
+  ------------------------------------------------------------------------------
+*/
+@mixin textAreaSizeModifier($fontSize, $padding) {
+  .cf-text-area--input {
+    font-size: $fontSize;
+    padding: $padding;
+  }
+}
+
+.cf-text-area__xs {
+  @include textAreaSizeModifier($form-xs-font, $form-xs-padding);
+}
+.cf-text-area__sm {
+  @include textAreaSizeModifier($form-sm-font, $form-sm-padding);
+}
+.cf-text-area__md {
+  @include textAreaSizeModifier($form-md-font, $form-md-padding);
+}
+.cf-text-area__lg {
+  @include textAreaSizeModifier($form-lg-font, $form-lg-padding);
 }

--- a/src/Components/Inputs/TextArea.tsx
+++ b/src/Components/Inputs/TextArea.tsx
@@ -2,8 +2,8 @@
 import React, {ChangeEvent, KeyboardEvent, forwardRef, RefObject} from 'react'
 import classnames from 'classnames'
 
-// Styles
-import './TextArea.scss'
+// Components
+import {StatusIndicator} from './StatusIndicator'
 
 // Types
 import {
@@ -11,13 +11,12 @@ import {
   ComponentSize,
   AutoComplete,
   StandardFunctionProps,
+  Wrap,
 } from '../../Types'
 
-export enum Wrap {
-  Hard = 'hard',
-  Soft = 'soft',
-  Off = 'off',
-}
+
+// Styles
+import './TextArea.scss'
 
 export interface TextAreaProps extends StandardFunctionProps {
   /** TextArea Component size */
@@ -66,6 +65,8 @@ export interface TextAreaProps extends StandardFunctionProps {
   value?: string
   /** Container ref */
   containerRef?: RefObject<TextAreaContainerRef>
+  /** Use a monospace font */
+  monospace?: boolean
 }
 
 export type TextAreaRef = HTMLTextAreaElement
@@ -94,6 +95,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
       className,
       maxLength,
       minLength,
+      monospace = false,
       onKeyDown,
       autoFocus = false,
       spellCheck = false,
@@ -104,13 +106,17 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
     },
     ref
   ) => {
-    const textAreaClass = classnames('cf-text-area--container', {
-      [`cf-input-${size}`]: size,
+    const textAreaClass = classnames('cf-text-area', {
+      [`cf-text-area__${size}`]: size,
+      [`cf-text-area__${status}`]: status,
+      'cf-text-area__monospace-font': monospace,
+      'cf-text-area__regular-font': !monospace,
       [`${className}`]: className,
     })
 
     return (
       <div className={textAreaClass} style={style} ref={containerRef}>
+        <StatusIndicator status={status} size={size} shadow={false} testID={testID} />
         <textarea
           id={id}
           ref={ref}
@@ -127,7 +133,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
           disabled={status === ComponentStatus.Disabled}
           readOnly={readOnly}
           required={required}
-          className="cf-text-area"
+          className="cf-text-area--input"
           autoFocus={autoFocus}
           maxLength={maxLength}
           onKeyDown={onKeyDown}

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -93,7 +93,7 @@ $cf-text-selection-color: $g20-white;
 /*
    Form Element Sizing
    -----------------------------------------------------------------------------
-   These ensure consistent sizing across ]elements such as Buttons, Radio,
+   These ensure consistent sizing across elements such as Buttons, Radio,
    Dropdown, Input, etc.
 */
 
@@ -121,3 +121,37 @@ $form-lg-font: 17px;
 $empty-state-text: $g9-mountain;
 $empty-state-highlight: $g13-mist;
 
+/*
+   Input Styles
+   -----------------------------------------------------------------------------
+   These ensure consistent appearance across different kinds of inputs
+*/
+
+$cf-input--transition: background-color 0.25s ease, border-color 0.25s ease,
+    color 0.25s ease,
+    box-shadow 0.25s ease, color 0.25s ease;
+
+$cf-input-background--default: $g2-kevlar;
+$cf-input-background--focused: $g2-kevlar;
+$cf-input-background--hover: $g2-kevlar;
+$cf-input-background--disabled: $g3-castle;
+
+$cf-input-text--default: $g15-platinum;
+$cf-input-text--focused: $g20-white;
+$cf-input-text--hover: $g17-whisper;
+$cf-input-text--disabled: $g9-mountain;
+
+$cf-input-border--default: $g5-pepper;
+$cf-input-border--focused: $c-pool;
+$cf-input-border--hover: mix($cf-input-border--default, $cf-input-border--focused, 50%);
+$cf-input-border--disabled: $g4-onyx;
+
+$cf-input-border--error: mix($cf-input-border--default, $c-dreamsicle, 70%);
+$cf-input-border--error-hover: $c-dreamsicle;
+$cf-input-border--error-focused: $c-dreamsicle;
+
+$cf-input--field-z: 1;
+$cf-input--shadow-z: $cf-input--field-z + 1;
+$cf-input--status-z: $cf-input--shadow-z + 1;
+
+$cf-input--placeholder-text: $g9-mountain;

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -415,3 +415,9 @@ export enum Method {
   Get = 'get',
   Dialog = 'dialog',
 }
+
+export enum Wrap {
+  Hard = 'hard',
+  Soft = 'soft',
+  Off = 'off',
+}


### PR DESCRIPTION
Closes #351 
Closes #143

### Changes

- Extract out `StatusIndicator` from `Input` so it can be used in both `Input` and `TextArea`
- Create a set of "input" style variables that both `Input` and `TextArea` can share
- Ensure `TextArea` is making use of its `Size` prop
- Redesign error state to be more muted when not focused
- Redesign hover state to have greater contrast
- Fixes a bit (indirectly) that was causing `TextArea` to have a the same fixed height as `Input`

### Screenshots
![Screen Shot 2019-10-24 at 1 23 35 PM](https://user-images.githubusercontent.com/2433762/67522757-2c2ec000-f662-11e9-8322-55f29f698c12.png)
![new-input-hover-styles](https://user-images.githubusercontent.com/2433762/67523656-fab6f400-f663-11e9-9340-c6ab7aaadd2a.gif)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
