### PR TITLE
Fix OverlayHeader and ConfirmationButton bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 1.0.4 (Unreleased)
 
+- [#366](https://github.com/influxdata/clockface/pull/366): Prevent children of `OverlayHeader` from disrupting the position of the dismiss button
+- [#366](https://github.com/influxdata/clockface/pull/366): Allow more customization of `Popover` within `ConfirmationButton`
 - [#365](https://github.com/influxdata/clockface/pull/365): Fix attachment of `Popover` when trigger element is nested in a scrolling element
 
 ### 1.0.3

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { FunctionComponent, useRef, RefObject, CSSProperties} from 'react'
+import React, {FunctionComponent, useRef, RefObject, CSSProperties} from 'react'
 
 // Components
 import {Button, ButtonProps} from './Button'
@@ -91,7 +91,7 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
         testID={`${testID}--popover`}
         disabled={isDisabled}
         triggerRef={triggerRef}
-        />
+      />
       <Button
         className={className}
         placeIconAfterText={placeIconAfterText}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent, useRef, RefObject} from 'react'
+import React, { FunctionComponent, useRef, RefObject, CSSProperties} from 'react'
 
 // Components
 import {Button, ButtonProps} from './Button'
@@ -30,6 +30,10 @@ interface ConfirmationButtonProps
   popoverColor?: ComponentColor
   /** Means of applying color to popover */
   popoverType?: PopoverType
+  /** Allows customization of Popover */
+  popoverClassName?: string
+  /** Allows customization of Popover */
+  popoverStyle?: CSSProperties
   /** Function to call when confirmation is clicked, passes 'value' prop in */
   onConfirm: (returnValue?: any) => void
   /** Optional value to have passed back via onConfirm */
@@ -46,6 +50,8 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
   titleText,
   onConfirm,
   returnValue,
+  popoverStyle,
+  popoverClassName,
   confirmationLabel,
   confirmationButtonText,
   size = ComponentSize.Small,
@@ -66,6 +72,8 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
   return (
     <>
       <Popover
+        className={popoverClassName}
+        style={popoverStyle}
         color={popoverColor}
         type={popoverType}
         enableDefaultStyles={false}
@@ -82,9 +90,8 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
         )}
         testID={`${testID}--popover`}
         disabled={isDisabled}
-        style={style}
         triggerRef={triggerRef}
-      />
+        />
       <Button
         className={className}
         placeIconAfterText={placeIconAfterText}
@@ -94,6 +101,7 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
         ref={triggerRef}
         status={status}
         color={color}
+        style={style}
         shape={shape}
         text={text}
         size={size}

--- a/src/Components/Overlay/Documentation/Overlay.stories.tsx
+++ b/src/Components/Overlay/Documentation/Overlay.stories.tsx
@@ -200,7 +200,9 @@ overlayStories.add(
           onDismiss={() => {
             alert('Dismissed')
           }}
-        />
+        >
+          <div className="mockComponent mockButton">Child Element</div>
+        </OverlayHeader>
       </div>
     )
   },

--- a/src/Components/Overlay/OverlayHeader.tsx
+++ b/src/Components/Overlay/OverlayHeader.tsx
@@ -40,6 +40,7 @@ export const OverlayHeader = forwardRef<OverlayHeaderRef, OverlayHeaderProps>(
         data-testid={testID}
       >
         <div className="cf-overlay--title">{title}</div>
+        {children && children}
         {onDismiss && (
           <button
             className="cf-overlay--dismiss"
@@ -47,7 +48,6 @@ export const OverlayHeader = forwardRef<OverlayHeaderRef, OverlayHeaderProps>(
             type="button"
           />
         )}
-        {children && children}
       </div>
     )
   }

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -50,7 +50,6 @@ const composedPopoverStories = storiesOf(
 
 const testPopoverStories = storiesOf('Atomic|Popover/Tests', module)
   .addDecorator(withKnobs)
-  .addDecorator(jsxDecorator)
 
 const exampleStyle = {
   width: '250px',

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -48,8 +48,10 @@ const composedPopoverStories = storiesOf(
   module
 ).addDecorator(withKnobs)
 
-const testPopoverStories = storiesOf('Atomic|Popover/Tests', module)
-  .addDecorator(withKnobs)
+const testPopoverStories = storiesOf(
+  'Atomic|Popover/Tests',
+  module
+).addDecorator(withKnobs)
 
 const exampleStyle = {
   width: '250px',


### PR DESCRIPTION
Closes #361 
Closes #349 

### Changes

- Rearranged `OverlayHeader` so that the dismiss button is always the last element
- Add `PopoverStyle` and `PopoverClassName` props to `ConfirmationButton`

### Screenshots

<img width="655" alt="Screen Shot 2019-10-30 at 1 54 14 PM" src="https://user-images.githubusercontent.com/2433762/67884786-c9836b80-fb1c-11e9-8472-a6ecbceb349a.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
