### PR TITLE
Fix Popover hide bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### 1.0.4 (Unreleased)
+### 1.0.5 (Unreleased)
+
+- [#368](https://github.com/influxdata/clockface/pull/368): Ensure `Popover` visible prop is not overridden by being out of view
+
+### 1.0.4
 
 - [#366](https://github.com/influxdata/clockface/pull/366): Prevent children of `OverlayHeader` from disrupting the position of the dismiss button
 - [#366](https://github.com/influxdata/clockface/pull/366): Allow more customization of `Popover` within `ConfirmationButton`

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -231,6 +231,7 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
         caretSize={caretSize}
         position={position}
         contents={contents(handleHideDialog)}
+        visible={visible}
         testID={testID}
         onHide={handleHideDialog}
         color={color}

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -46,6 +46,8 @@ export interface PopoverDialogProps extends StandardFunctionProps {
   enableDefaultStyles: boolean
   /** Allows the popover to dismiss itself when the trigger is no longer in view */
   onHide: () => void
+  /** This keeps the Popover visible no matter what */
+  visible?: boolean
 }
 
 export type PopoverDialogRef = HTMLDivElement
@@ -59,6 +61,7 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
       color,
       onHide,
       testID,
+      visible,
       contents,
       position,
       className,
@@ -112,6 +115,10 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
     const hidePopoverWhenOutOfView = (
       entries: IntersectionObserverEntry[]
     ): void => {
+      if (visible) {
+        return
+      }
+
       if (!!entries.length && entries[0].isIntersecting === false) {
         onHide()
       }


### PR DESCRIPTION
Closes #367 

### Changes

- Pass `visible` prop into `PopoverDialog` and prevent the intersection hide from firing if `visible` is true

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
