### PR TITLE
Improve Button components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 1.0.5 (Unreleased)
 
+- [#375](https://github.com/influxdata/clockface/pull/375): Add `onMouseEnter`, `onMouseLeave`, `onMouseOver`, and `onMouseOut` to all button components
+- [#375](https://github.com/influxdata/clockface/pull/375): Ensure all button component prop interfaces are extending `ButtonBaseProps`
 - [#373](https://github.com/influxdata/clockface/pull/373): Handle NaN appropriately in numeric Inputs by updating value, type, and status
 - [#368](https://github.com/influxdata/clockface/pull/368): Ensure `Popover` visible prop is not overridden by being out of view
 

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -31,17 +31,17 @@ export interface ButtonBaseProps extends StandardFunctionProps {
   /** Keyboard control tab order  */
   tabIndex?: number
   /** Button color */
-  color: ComponentColor
+  color?: ComponentColor
   /** Button size */
-  size: ComponentSize
+  size?: ComponentSize
   /** Square or rectangle */
-  shape: ButtonShape
+  shape?: ButtonShape
   /** Button status state default, loading, or disabled */
-  status: ComponentStatus
+  status?: ComponentStatus
   /** Toggles button highlighted active state */
-  active: boolean
+  active?: boolean
   /** Button type of 'button' or 'submit' */
-  type: ButtonType
+  type?: ButtonType
 }
 
 export type ButtonBaseRef = HTMLButtonElement

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -15,9 +15,17 @@ import {
   StandardFunctionProps,
 } from '../../../Types'
 
-interface ButtonBaseProps extends StandardFunctionProps {
+export interface ButtonBaseProps extends StandardFunctionProps {
   /** Function to be called on button click */
   onClick?: (e?: MouseEvent<HTMLButtonElement>) => void
+  /** Function to be called on mouse over */
+  onMouseOver?: (e?: MouseEvent<HTMLButtonElement>) => void
+  /** Function to be called on mouse out */
+  onMouseOut?: (e?: MouseEvent<HTMLButtonElement>) => void
+  /** Function to be called on mouse enter */
+  onMouseEnter?: (e?: MouseEvent<HTMLButtonElement>) => void
+  /** Function to be called on mouse leave */
+  onMouseLeave?: (e?: MouseEvent<HTMLButtonElement>) => void
   /** Text to be displayed on hover tooltip */
   titleText?: string
   /** Keyboard control tab order  */
@@ -48,6 +56,10 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
       tabIndex,
       titleText,
       className,
+      onMouseOut,
+      onMouseOver,
+      onMouseEnter,
+      onMouseLeave,
       active = false,
       testID = 'button-base',
       type = ButtonType.Button,
@@ -78,6 +90,10 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
         className={buttonBaseClass}
         disabled={disabled}
         onClick={onClick}
+        onMouseOut={onMouseOut}
+        onMouseOver={onMouseOver}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         title={titleText}
         tabIndex={!!tabIndex ? tabIndex : 0}
         type={type}

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {MouseEvent, forwardRef, FunctionComponent} from 'react'
+import React, {forwardRef, FunctionComponent} from 'react'
 
 // Components
 import {ButtonBase, ButtonBaseRef} from '../Base/ButtonBase'
@@ -16,32 +16,14 @@ import {
   ComponentSize,
   ComponentColor,
   ComponentStatus,
-  StandardFunctionProps,
 } from '../../../Types'
+import {ButtonBaseProps} from '../Base/ButtonBase'
 
-export interface ButtonProps extends StandardFunctionProps {
+export interface ButtonProps extends ButtonBaseProps {
   /** Text to be displayed on button */
   text?: string
-  /** Function to be called on button click */
-  onClick?: (e?: MouseEvent<HTMLButtonElement>) => void
   /** Icon to be displayed to the left of text or in place of text */
   icon?: IconFont
-  /** Text to be displayed on hover tooltip */
-  titleText?: string
-  /** Keyboard control tab order  */
-  tabIndex?: number
-  /** Button color */
-  color?: ComponentColor
-  /** Button size */
-  size?: ComponentSize
-  /** Square or rectangle */
-  shape?: ButtonShape
-  /** Button status state default, loading, or disabled */
-  status?: ComponentStatus
-  /** Toggles button highlighted active state */
-  active?: boolean
-  /** Button type of 'button' or 'submit' */
-  type?: ButtonType
   /** Reverse ordering of text and icon */
   placeIconAfterText?: boolean
 }
@@ -58,6 +40,10 @@ export const Button = forwardRef<ButtonRef, ButtonProps>(
       tabIndex,
       titleText,
       className,
+      onMouseOut,
+      onMouseOver,
+      onMouseEnter,
+      onMouseLeave,
       icon = '',
       active = false,
       testID = 'button',
@@ -87,6 +73,10 @@ export const Button = forwardRef<ButtonRef, ButtonProps>(
         status={status}
         testID={testID}
         onClick={onClick}
+        onMouseOut={onMouseOut}
+        onMouseOver={onMouseOver}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={className}
         titleText={titleText || text}
         tabIndex={!!tabIndex ? tabIndex : 0}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -18,8 +18,17 @@ import {
   PopoverType,
 } from '../../../Types'
 
-interface ConfirmationButtonProps
-  extends Omit<ButtonProps, 'onClick' | 'active' | 'type'> {
+export interface ConfirmationButtonProps
+  extends Omit<
+    ButtonProps,
+    | 'onClick'
+    | 'active'
+    | 'type'
+    | 'onMouseEnter'
+    | 'onMouseLeave'
+    | 'onMouseOver'
+    | 'onMouseOut'
+  > {
   /** Text to appear in confirmation popover */
   confirmationLabel: string
   /** Text to appear in confirmation button */

--- a/src/Components/Button/Composed/DismissButton.tsx
+++ b/src/Components/Button/Composed/DismissButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef, MouseEvent} from 'react'
+import React, {forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -10,28 +10,15 @@ import './DismissButton.scss'
 
 // Types
 import {
-  StandardFunctionProps,
   ComponentStatus,
   ComponentColor,
   IconFont,
   ComponentSize,
   ButtonType,
 } from '../../../Types'
+import {ButtonBaseProps} from '../Base/ButtonBase'
 
-export interface DismissButtonProps extends StandardFunctionProps {
-  /** Function to be called on button click */
-  onClick?: (e?: MouseEvent<HTMLButtonElement>) => void
-  /** Button color */
-  color?: ComponentColor
-  /** Button size */
-  size?: ComponentSize
-  /** Button status state default, loading, or disabled */
-  status?: ComponentStatus
-  /** Toggles button highlighted active state */
-  active?: boolean
-  /** Button type of 'button' or 'submit' */
-  type?: ButtonType
-}
+export interface DismissButtonProps extends ButtonBaseProps {}
 
 export type DismissButtonRef = SquareButtonRef
 
@@ -41,7 +28,13 @@ export const DismissButton = forwardRef<DismissButtonRef, DismissButtonProps>(
       id,
       style,
       onClick,
+      tabIndex,
+      titleText,
       className,
+      onMouseOut,
+      onMouseOver,
+      onMouseEnter,
+      onMouseLeave,
       active = false,
       type = ButtonType.Button,
       testID = 'dismiss-button',
@@ -57,6 +50,8 @@ export const DismissButton = forwardRef<DismissButtonRef, DismissButtonProps>(
 
     return (
       <SquareButton
+        tabIndex={tabIndex}
+        titleText={titleText}
         icon={IconFont.Remove}
         color={color}
         className={SquareButtonClass}
@@ -64,6 +59,10 @@ export const DismissButton = forwardRef<DismissButtonRef, DismissButtonProps>(
         id={id}
         size={size}
         onClick={onClick}
+        onMouseOut={onMouseOut}
+        onMouseOver={onMouseOver}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         status={status}
         active={active}
         type={type}

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef, MouseEvent} from 'react'
+import React, {forwardRef} from 'react'
 
 // Components
 import {ButtonBase, ButtonBaseRef} from '../Base/ButtonBase'
@@ -10,34 +10,19 @@ import '../Button.scss'
 
 // Types
 import {
+  Omit,
   ComponentStatus,
   ComponentColor,
   ComponentSize,
   ButtonShape,
   IconFont,
   ButtonType,
-  StandardFunctionProps,
 } from '../../../Types'
+import {ButtonBaseProps} from '../Base/ButtonBase'
 
-interface SquareButtonProps extends StandardFunctionProps {
-  /** Function to be called on button click */
-  onClick?: (e?: MouseEvent<HTMLButtonElement>) => void
+export interface SquareButtonProps extends Omit<ButtonBaseProps, 'Shape'> {
   /** Icon to be displayed to the left of text or in place of text */
   icon: IconFont
-  /** Text to be displayed on hover tooltip */
-  titleText?: string
-  /** Keyboard control tab order  */
-  tabIndex?: number
-  /** Button color */
-  color?: ComponentColor
-  /** Button size */
-  size?: ComponentSize
-  /** Button status state default, loading, or disabled */
-  status?: ComponentStatus
-  /** Toggles button highlighted active state */
-  active?: boolean
-  /** Button type of 'button' or 'submit' */
-  type?: ButtonType
 }
 
 export type SquareButtonRef = ButtonBaseRef
@@ -58,6 +43,10 @@ export const SquareButton = forwardRef<SquareButtonRef, SquareButtonProps>(
       active = false,
       type = ButtonType.Button,
       testID = 'square-button',
+      onMouseOut,
+      onMouseOver,
+      onMouseEnter,
+      onMouseLeave,
     },
     ref
   ) => {
@@ -68,6 +57,10 @@ export const SquareButton = forwardRef<SquareButtonRef, SquareButtonProps>(
         ref={ref}
         tabIndex={!!tabIndex ? tabIndex : 0}
         onClick={onClick}
+        onMouseOut={onMouseOut}
+        onMouseOver={onMouseOver}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         testID={testID}
         status={status}
         active={active}


### PR DESCRIPTION
Closes #374 

Aiming to tighten the button component set a bit. This change enables button base changes to trickle down into the composed button components, which should make maintenance easier.

### Changes

- Add `onMouseOut`, `onMouseOver`, `onMouseLeave`, and `onMouseEnter` to `BaseButtonProps`
- Ensure that `Button`, `DismissButton`, `SquareButton`, and `ConfirmationButton`'s props interfaces are extending `BaseButtonProps`

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
