### PR TITLE
Update RangeSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### 1.0.6 (Unreleased)
 
+- [#389](https://github.com/influxdata/clockface/pull/389): Move `RangeSlider` labels inside visible rectangle
+- [#389](https://github.com/influxdata/clockface/pull/389): Add optional `labelPrefix` and `labelSuffix` props to `RangeSlider`
+
 #### 1.0.5
 
 - [#379](https://github.com/influxdata/clockface/pull/379): Add tests and testing CI infrastructure

--- a/src/Components/Inputs/Composed/RangeSlider.scss
+++ b/src/Components/Inputs/Composed/RangeSlider.scss
@@ -108,56 +108,88 @@ $slider-hover: $g17-whisper;
   }
 }
 
-.cf-range-slider--wrapper {
+.cf-range-slider {
+  display: flex;
+  align-items: center;
   width: 100%;
+  border-radius: $cf-radius;
+  background: $slider-bg;
+  position: relative;
 }
 
-.cf-range-slider--container {
-  width: 100%;
-  height: 30px;
-  background: $slider-bg;
-  border: 2px solid $slider-track;
-  border-radius: $cf-radius;
+.cf-range-slider--input {
+  flex: 1 0 0;
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0 $cf-marg-c;
-  transition: border-color 0.25s ease;
+}
 
-  &:hover {
-    border-color: $slider-hover-border;
+.cf-range-slider--label {
+  font-size: 12px;
+  font-weight: 600;
+  @extend %no-user-select;
+
+  &:first-of-type {
+    text-align: left;
+  }
+
+  &:last-of-type {
+    text-align: right;
   }
 }
 
-.cf-range-slider--labels {
-  margin-top: $cf-marg-a;
-  padding: 0 $cf-marg-c;
-  display: inline-flex;
-  width: 100%;
-  justify-content: space-between;
+.cf-range-slider--focus {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border: $cf-border solid $slider-track;
+  border-radius: $cf-radius;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  pointer-events: none;
+}
 
-  .cf-range-slider--bound {
-    text-align: center;
-    font-size: 12px;
-    font-weight: 600;
-    @extend %no-user-select;
-  }
+.cf-input:hover + .cf-range-slider--focus {
+  border-color: $cf-input-border--hover;
+}
+
+.cf-input__focused + .cf-range-slider--focus,
+.cf-input__focused:hover + .cf-range-slider--focus {
+  box-shadow: 0 0 6px 0 $cf-input-border--focused;
+  border-color: $cf-input-border--focused;
 }
 
 /*
   Size Modifiers
   ------------------------------------------------------------------------------
 */
-@mixin sliderSizeModifier($fontSize, $height, $containerHeight) {
+@mixin rangeSliderSizeModifier($fontSize, $height, $containerHeight, $padding) {
   $slider-handle-mod-height: $height + 10px;
+  padding: 0 $padding;
 
-  &.cf-range-slider--container {
+  &.cf-range-slider--input {
     height: $containerHeight;
+  }
+
+  .cf-range-slider--label {
+    font-size: $fontSize;
+
+    &:first-of-type {
+      margin-right: $padding;
+    }
+    &:last-of-type {
+      margin-left: $padding;
+    }
   }
 
   input[type='range'] {
     height: $height;
+    
+    &:focus {
+      box-shadow: none;
+    }
 
     &::-webkit-slider-runnable-track {
       height: $height;
@@ -166,6 +198,7 @@ $slider-hover: $g17-whisper;
     &::-webkit-slider-thumb {
       height: $slider-handle-mod-height;
       width: $slider-handle-mod-height;
+      border-radius: 50%;
       margin-top: -(($slider-handle-mod-height/2) - ($height/2));
     }
 
@@ -188,31 +221,31 @@ $slider-hover: $g17-whisper;
     }
   }
 
-  &.cf-range-slider--fill {
+  &.cf-range-slider__fill {
     ::-moz-range-progress {
       height: $height;
     }
   }
 }
 
-.cf-input-xs {
-  @include sliderSizeModifier($form-xs-font, $cf-marg-a, $form-xs-height);
+.cf-range-slider__xs {
+  @include rangeSliderSizeModifier($form-xs-font, $cf-marg-a, $form-xs-height, $form-xs-padding);
 }
-.cf-input-sm {
-  @include sliderSizeModifier($form-sm-font, ($cf-marg-a + 2), $form-sm-height);
+.cf-range-slider__sm {
+  @include rangeSliderSizeModifier($form-sm-font, ($cf-marg-a + 2), $form-sm-height, $form-sm-padding);
 }
-.cf-input-md {
-  @include sliderSizeModifier($form-md-font, $cf-marg-b, $form-md-height);
+.cf-range-slider__md {
+  @include rangeSliderSizeModifier($form-md-font, $cf-marg-b, $form-md-height, $form-md-padding);
 }
-.cf-input-lg {
-  @include sliderSizeModifier($form-lg-font, ($cf-marg-b + 2), $form-lg-height);
+.cf-range-slider__lg {
+  @include rangeSliderSizeModifier($form-lg-font, ($cf-marg-b + 2), $form-lg-height, $form-lg-padding);
 }
 
 /*
   Color Modifiers
   ------------------------------------------------------------------------------
 */
-@mixin handleColorModifier($bg, $bgHover, $bgActive) {
+@mixin rangeSliderColorModifier($bg, $bgHover, $bgActive) {
   input[type='range'] {
     &::-webkit-slider-thumb {
       background: $bg;
@@ -242,23 +275,23 @@ $slider-hover: $g17-whisper;
   }
 }
 
-.cf-range-slider--default {
-  @include handleColorModifier($g7-graphite, $g8-storm, $g9-mountain);
+.cf-range-slider__default {
+  @include rangeSliderColorModifier($g7-graphite, $g8-storm, $g9-mountain);
 }
-.cf-range-slider--primary {
-  @include handleColorModifier($c-pool, $c-laser, $c-hydrogen);
+.cf-range-slider__primary {
+  @include rangeSliderColorModifier($c-pool, $c-laser, $c-hydrogen);
 }
-.cf-range-slider--secondary {
-  @include handleColorModifier($c-star, $c-comet, $c-potassium);
+.cf-range-slider__secondary {
+  @include rangeSliderColorModifier($c-star, $c-comet, $c-potassium);
 }
-.cf-range-slider--success {
-  @include handleColorModifier($c-rainforest, $c-honeydew, $c-wasabi);
+.cf-range-slider__success {
+  @include rangeSliderColorModifier($c-rainforest, $c-honeydew, $c-wasabi);
 }
-.cf-range-slider--warning {
-  @include handleColorModifier($c-pineapple, $c-thunder, $c-daisy);
+.cf-range-slider__warning {
+  @include rangeSliderColorModifier($c-pineapple, $c-thunder, $c-daisy);
 }
-.cf-range-slider--danger {
-  @include handleColorModifier($c-curacao, $c-dreamsicle, $c-tungsten);
+.cf-range-slider__danger {
+  @include rangeSliderColorModifier($c-curacao, $c-dreamsicle, $c-tungsten);
 }
 
 /*
@@ -266,7 +299,7 @@ $slider-hover: $g17-whisper;
   ------------------------------------------------------------------------------
 */
 
-.cf-range-slider--container.cf-input__disabled {
+.cf-range-slider--input.cf-input__disabled {
   border-color: $slider-track-disabled;
 
   &:hover {
@@ -274,7 +307,7 @@ $slider-hover: $g17-whisper;
   }
 }
 
-.cf-input__disabled + .cf-range-slider--labels {
+.cf-range-slider__disabled .cf-range-slider--label {
   color: $slider-disabled-text;
   font-style: italic;
 }

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, forwardRef, FunctionComponent} from 'react'
+import React, {ChangeEvent, forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -64,19 +64,19 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       onChange,
       className,
       hideLabels = false,
-      orientation = Orientation.Horizontal,
       autocomplete,
     },
     ref
   ) => {
-    const rangeSliderClass = classnames('cf-range-slider--container', {
-      [`cf-range-slider__${orientation}`]: orientation,
-      [`cf-range-slider--${color}`]: color,
-      'cf-range-slider--fill': fill,
+    const rangeSliderClass = classnames('cf-range-slider', {
+      [`cf-range-slider__${color}`]: color,
+      [`cf-range-slider__${size}`]: size,
+      'cf-range-slider__disabled': status === ComponentStatus.Disabled,
+      [`${className}`]: className,
     })
 
-    const rangeSliderContainerClass = classnames('cf-range-slider--wrapper', {
-      [`${className}`]: className,
+    const rangeSliderInputClass = classnames('cf-range-slider--input', {
+      'cf-range-slider__fill': fill,
     })
 
     const inputStyle = generateRangeSliderTrackFillStyle(
@@ -88,10 +88,15 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       status
     )
 
+    const labelStyle = {
+      flex: `0 0 ${String(max).length * 11}px`
+    }
+
     const cleanedValue = valueWithBounds(value, min, max)
 
     return (
-      <div className={rangeSliderContainerClass} style={style}>
+      <div className={rangeSliderClass} style={style}>
+        {!hideLabels && <span className="cf-range-slider--label" style={labelStyle}>{min}</span>}
         <Input
           id={id}
           ref={ref}
@@ -104,11 +109,12 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           testID={testID}
           status={status}
           onChange={onChange}
-          className={rangeSliderClass}
+          className={rangeSliderInputClass}
           inputStyle={inputStyle}
           autocomplete={autocomplete}
-        />
-        {!hideLabels && <RangeSliderLabels min={min} max={max} />}
+          />
+          <div className="cf-range-slider--focus" />
+        {!hideLabels && <span className="cf-range-slider--label" style={labelStyle}>{max}</span>}
       </div>
     )
   }
@@ -129,24 +135,4 @@ const valueWithBounds = (value: number, min: number, max: number): number => {
   }
 
   return value
-}
-
-interface RangeSliderlabelsProps {
-  min: number
-  max: number
-}
-
-const RangeSliderLabels: FunctionComponent<RangeSliderlabelsProps> = ({
-  min,
-  max,
-}) => {
-  const minVal = Math.min(min, max)
-  const maxVal = Math.max(min, max)
-
-  return (
-    <div className="cf-range-slider--labels">
-      <span className="cf-range-slider--bound">{minVal}</span>
-      <span className="cf-range-slider--bound">{maxVal}</span>
-    </div>
-  )
 }

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -15,7 +15,6 @@ import {
   InputType,
   StandardFunctionProps,
   ComponentColor,
-  Orientation,
   ComponentSize,
   AutoComplete,
   ComponentStatus,
@@ -40,8 +39,6 @@ export interface RangeSliderProps extends StandardFunctionProps {
   size?: ComponentSize
   /** Color of slider handle */
   color?: ComponentColor
-  /** Color of slider track */
-  orientation?: Orientation
   /** Fill the track before the handle to indicate percentage */
   fill?: boolean
   /** Displays the min and max values below the slider */

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -1,4 +1,9 @@
-import React, { ChangeEvent, forwardRef, FunctionComponent, CSSProperties} from 'react'
+import React, {
+  ChangeEvent,
+  forwardRef,
+  FunctionComponent,
+  CSSProperties,
+} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -104,14 +109,21 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
     }
 
     const labelStyle = {
-      flex: `0 0 ${labelCharLength * 11}px`
+      flex: `0 0 ${labelCharLength * 11}px`,
     }
 
     const cleanedValue = valueWithBounds(value, min, max)
 
     return (
       <div className={rangeSliderClass} style={style}>
-        <RangeSliderLabel value={min} prefix={labelPrefix} suffix={labelSuffix} style={labelStyle} hidden={hideLabels} testID={`${testID}--min`} />
+        <RangeSliderLabel
+          value={min}
+          prefix={labelPrefix}
+          suffix={labelSuffix}
+          style={labelStyle}
+          hidden={hideLabels}
+          testID={`${testID}--min`}
+        />
         <Input
           id={id}
           ref={ref}
@@ -127,9 +139,16 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           className={rangeSliderInputClass}
           inputStyle={inputStyle}
           autocomplete={autocomplete}
-          />
+        />
         <div className="cf-range-slider--focus" />
-        <RangeSliderLabel value={max} prefix={labelPrefix} suffix={labelSuffix} style={labelStyle} hidden={hideLabels} testID={`${testID}--max`} />
+        <RangeSliderLabel
+          value={max}
+          prefix={labelPrefix}
+          suffix={labelSuffix}
+          style={labelStyle}
+          hidden={hideLabels}
+          testID={`${testID}--max`}
+        />
       </div>
     )
   }
@@ -161,13 +180,24 @@ interface RangeSliderLabelProps {
   testID: string
 }
 
-const RangeSliderLabel: FunctionComponent<RangeSliderLabelProps> = ({value, prefix, suffix, hidden, style, testID}) => {
+const RangeSliderLabel: FunctionComponent<RangeSliderLabelProps> = ({
+  value,
+  prefix,
+  suffix,
+  hidden,
+  style,
+  testID,
+}) => {
   if (hidden) {
     return null
   }
 
   return (
-    <span className="cf-range-slider--label" style={style} data-testid={testID}>{prefix}{value}{suffix}</span>
+    <span className="cf-range-slider--label" style={style} data-testid={testID}>
+      {prefix}
+      {value}
+      {suffix}
+    </span>
   )
 }
 

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, forwardRef} from 'react'
+import React, { ChangeEvent, forwardRef, FunctionComponent, CSSProperties} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -43,6 +43,10 @@ export interface RangeSliderProps extends StandardFunctionProps {
   fill?: boolean
   /** Displays the min and max values below the slider */
   hideLabels?: boolean
+  /** Adds a prefix to labels */
+  labelPrefix?: string
+  /** Adds a suffix to labels */
+  labelSuffix?: string
 }
 
 export type RangeSliderRef = HTMLInputElement
@@ -64,6 +68,8 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       onChange,
       className,
       hideLabels = false,
+      labelPrefix,
+      labelSuffix,
       autocomplete,
     },
     ref
@@ -88,15 +94,24 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       status
     )
 
+    let labelCharLength = String(max).length
+
+    if (labelPrefix) {
+      labelCharLength += labelPrefix.length
+    }
+    if (labelSuffix) {
+      labelCharLength += labelSuffix.length
+    }
+
     const labelStyle = {
-      flex: `0 0 ${String(max).length * 11}px`
+      flex: `0 0 ${labelCharLength * 11}px`
     }
 
     const cleanedValue = valueWithBounds(value, min, max)
 
     return (
       <div className={rangeSliderClass} style={style}>
-        {!hideLabels && <span className="cf-range-slider--label" style={labelStyle}>{min}</span>}
+        <RangeSliderLabel value={min} prefix={labelPrefix} suffix={labelSuffix} style={labelStyle} hidden={hideLabels} testID={`${testID}--min`} />
         <Input
           id={id}
           ref={ref}
@@ -113,8 +128,8 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           inputStyle={inputStyle}
           autocomplete={autocomplete}
           />
-          <div className="cf-range-slider--focus" />
-        {!hideLabels && <span className="cf-range-slider--label" style={labelStyle}>{max}</span>}
+        <div className="cf-range-slider--focus" />
+        <RangeSliderLabel value={max} prefix={labelPrefix} suffix={labelSuffix} style={labelStyle} hidden={hideLabels} testID={`${testID}--max`} />
       </div>
     )
   }
@@ -136,3 +151,24 @@ const valueWithBounds = (value: number, min: number, max: number): number => {
 
   return value
 }
+
+interface RangeSliderLabelProps {
+  value: number
+  prefix?: string
+  suffix?: string
+  hidden?: boolean
+  style?: CSSProperties
+  testID: string
+}
+
+const RangeSliderLabel: FunctionComponent<RangeSliderLabelProps> = ({value, prefix, suffix, hidden, style, testID}) => {
+  if (hidden) {
+    return null
+  }
+
+  return (
+    <span className="cf-range-slider--label" style={style} data-testid={testID}>{prefix}{value}{suffix}</span>
+  )
+}
+
+RangeSliderLabel.displayName = 'RangeSliderLabel'

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -44,7 +44,6 @@ import {
   AlignItems,
   InputType,
   AutoInputMode,
-  Orientation,
 } from '../../../Types'
 
 // Notes
@@ -584,11 +583,6 @@ inputsComposedStories.add(
           value={number('value', 50)}
           step={number('step', 0)}
           onChange={() => {}}
-          orientation={
-            Orientation[
-              select('orientation', mapEnumKeys(Orientation), 'Horizontal')
-            ]
-          }
           size={
             ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
           }

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {RefObject, createRef} from 'react'
+import React, {RefObject, createRef, ChangeEvent} from 'react'
 import marked from 'marked'
 
 // Storybook
@@ -564,7 +564,12 @@ inputsComposedStories.add(
 inputsComposedStories.add(
   'Range Slider',
   () => {
+    const [rangeSliderValue, setRangeSliderValue] = useState<number>(50)
     const rangeSliderRef: RefObject<RangeSliderRef> = createRef()
+
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+      setRangeSliderValue(parseInt(e.target.value))
+    }
 
     const handleLogRef = (): void => {
       /* eslint-disable */
@@ -580,9 +585,9 @@ inputsComposedStories.add(
           ref={rangeSliderRef}
           min={number('min', 0)}
           max={number('max', 100)}
-          value={number('value', 50)}
+          value={rangeSliderValue}
           step={number('step', 0)}
-          onChange={() => {}}
+          onChange={handleInputChange}
           size={
             ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
           }

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -596,6 +596,8 @@ inputsComposedStories.add(
               select('color', mapEnumKeys(ComponentColor), 'Primary')
             ]
           }
+          labelPrefix={text('labelPrefix', '')}
+          labelSuffix={text('labelSuffix', '')}
           fill={boolean('fill', true)}
           hideLabels={boolean('hide labels', false)}
           style={object('style', exampleRangeSliderStyle)}

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -5,6 +5,7 @@ import React, {
   KeyboardEvent,
   forwardRef,
   RefObject,
+  useState,
 } from 'react'
 import classnames from 'classnames'
 
@@ -125,10 +126,12 @@ export const Input = forwardRef<InputRef, InputProps>(
     },
     ref
   ) => {
+    const [isFocused, setFocus] = useState<boolean>(autoFocus)
     const correctStatus = value === value ? status : ComponentStatus.Error
 
     const inputClass = classnames('cf-input', {
       [`cf-input-${size}`]: size,
+      'cf-input__focused': isFocused,
       'cf-input__has-checkbox': type === InputType.Checkbox,
       'cf-input__has-icon': icon,
       'cf-input__valid': correctStatus === ComponentStatus.Valid,
@@ -137,6 +140,22 @@ export const Input = forwardRef<InputRef, InputProps>(
       'cf-input__disabled': correctStatus === ComponentStatus.Disabled,
       [`${className}`]: className,
     })
+
+    const handleInputFocus = (e: ChangeEvent<HTMLInputElement>): void => {
+      setFocus(true)
+
+      if (onFocus) {
+        onFocus(e)
+      }
+    }
+
+    const handleInputBlur = (e: ChangeEvent<HTMLInputElement>): void => {
+      setFocus(false)
+
+      if (onBlur) {
+        onBlur(e)
+      }
+    }
 
     const inputCheckboxClass = classnames('cf-input--checkbox', {checked})
 
@@ -178,8 +197,8 @@ export const Input = forwardRef<InputRef, InputProps>(
           autoFocus={autoFocus}
           spellCheck={spellCheck}
           onChange={onChange}
-          onBlur={onBlur}
-          onFocus={onFocus}
+          onBlur={handleInputBlur}
+          onFocus={handleInputFocus}
           onKeyPress={onKeyPress}
           onKeyUp={onKeyUp}
           onKeyDown={onKeyDown}


### PR DESCRIPTION
Closes #380 

### Changes

- Move labels inside slider rectangle
- Make label font size change with `size` prop
- Remove `orientation` prop (was not doing anything)
- Change appearance of `focus` and `hover` state to be aligned with other inputs
- Rename some classes:
  - `.cf-range-slider--wrapper` --> `.cf-range-slider`
  - `.cf-range-slider--container` --> `.cf-range-slider--input`

### Screenshots

![updated-slider](https://user-images.githubusercontent.com/2433762/68689779-ecf7de80-053e-11ea-8396-1bd1652a1ad3.gif)
![range-slider-prefix-suffix](https://user-images.githubusercontent.com/2433762/68691059-16196e80-0541-11ea-97b6-fb0225bef6d8.gif)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
