### PR TITLE
Update design of color & gradient documentation

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -614,82 +614,89 @@ table.two-axis-table {
   ------------------------------------------------------------------------------
 */
 
+$color-grid-card-width: 154px;
+
 .colors-grid,
 .gradients-grid {
   width: 100%;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr;
+  margin-bottom: 16px;
+  grid-column-gap: 2px;
+  grid-row-gap: 2px;
 }
 
 .colors-grid--card,
 .gradients-grid--card {
-  margin-right: 4px;
-  margin-bottom: 4px;
-  height: 180px;
-  border-radius: $cf-radius;
-  position: relative;
+  width: 100%;
+  height: 90px;
   padding: 8px;
-
-  p {
-    opacity: 0.6;
-    margin: 0;
-    font-size: 13px;
+  display: flex;
+  border-radius: $cf-radius-sm;
+  flex-direction: column;
+  
+  > p {
+    opacity: 0.8;
+    margin: 0 !important;
+    font-size: 12px !important;
     font-weight: 700;
-
+    
     &.colors-grid--hex {
       text-transform: uppercase;
     }
   }
-
+  
   &.dark-text > p {
     color: $g0-obsidian !important;
   }
-
+  
   &.light-text > p {
     color: $g20-white !important;
   }
 }
 
-.colors-grid--card {
-  flex: 0 0 calc(33.3333% - 4px);
-}
-
-.gradients-grid--card {
-  margin-right: 0;
-  flex: 0 0 calc(100%);
-}
-
-@media screen and (min-width: 700px) {
-  .colors-grid--card {
-    flex: 0 0 calc(25% - 4px);
+@media screen and (min-width: $color-grid-card-width * 2) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr;
   }
 }
 
-@media screen and (min-width: 900px) {
-  .colors-grid--card {
-    flex: 0 0 calc(20% - 4px);
-  }
-  .gradients-grid--card {
-    margin-right: 4px;
-    flex: 0 0 calc(20% - 4px);
+@media screen and (min-width: $color-grid-card-width * 3) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
-@media screen and (min-width: 1100px) {
-  .colors-grid--card {
-    flex: 0 0 calc(16.6666667% - 4px);
+@media screen and (min-width: $color-grid-card-width * 4) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 }
 
-@media screen and (min-width: 1300px) {
-  .colors-grid--card {
-    flex: 0 0 calc(12.5% - 4px);
+@media screen and (min-width: $color-grid-card-width * 5) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
   }
 }
 
-@media screen and (min-width: 1500px) {
-  .colors-grid--card {
-    flex: 0 0 calc(10% - 4px);
+@media screen and (min-width: $color-grid-card-width * 6) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+  }
+  .gradients-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  }
+}
+
+@media screen and (min-width: $color-grid-card-width * 7) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  }
+}
+
+@media screen and (min-width: $color-grid-card-width * 8) {
+  .colors-grid {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   }
 }
 

--- a/src/Constants/colors.ts
+++ b/src/Constants/colors.ts
@@ -373,6 +373,10 @@ export const influxGradients = {
     start: InfluxColors.DeepPurple,
     stop: InfluxColors.Magenta,
   },
+  PowerStone: {
+    start: InfluxColors.Void,
+    stop: InfluxColors.Magenta,
+  },
   OminousFog: {
     start: InfluxColors.DeepPurple,
     stop: InfluxColors.Comet,
@@ -389,7 +393,7 @@ export const influxGradients = {
     start: InfluxColors.Pool,
     stop: InfluxColors.Magenta,
   },
-  Radioactive: {
+  RadioactiveWarning: {
     start: InfluxColors.Pool,
     stop: InfluxColors.Chartreuse,
   },

--- a/src/Types/Types.stories.tsx
+++ b/src/Types/Types.stories.tsx
@@ -348,12 +348,18 @@ dataTypeStories.add(
     }
 
     const colorsArray = convertEnumToObjArray(InfluxColors)
+    const gradientsArray = Object.keys(Gradients)
+
     const nuetrals = colorsArray.slice(0, 21)
     const blues = colorsArray.slice(21, 29)
     const purples = colorsArray.slice(29, 37)
     const greens = colorsArray.slice(37, 45)
     const yellows = colorsArray.slice(45, 53)
     const reds = colorsArray.slice(53, 61)
+    const brandColors = colorsArray.slice(61, 64)
+
+    const clockfaceGradients = gradientsArray.slice(0, 40)
+    const brandGradients = gradientsArray.slice(40, 50)
 
     const colorCardClassName = (hexcode: string): string => {
       const lightContrast = chroma.contrast(InfluxColors.White, hexcode)
@@ -385,7 +391,7 @@ dataTypeStories.add(
 
     return (
       <div className="markdown-body">
-        <h3>Clockface Color Palette</h3>
+        <h3>Clockface Colors</h3>
         <pre className="language-js">
           <code>
             import &#123;InfluxColors&#125; from '@influxdata/clockface'
@@ -469,13 +475,39 @@ dataTypeStories.add(
             </div>
           ))}
         </div>
+        <h5>InfluxData Brand Colors</h5>
+        <div className="colors-grid">
+          {brandColors.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
+            >
+              <p>{color.key}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
         <hr />
         <h3>Clockface Gradients</h3>
         <pre className="language-js">
           <code>import &#123;Gradients&#125; from '@influxdata/clockface'</code>
         </pre>
+        <h5>Multi-Hue Gradients</h5>
         <div className="gradients-grid">
-          {Object.keys(Gradients).map(g => (
+          {clockfaceGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <h5>InfluxData Brand Gradients</h5>
+        <div className="gradients-grid">
+          {brandGradients.map(g => (
             <div
               className={gradientCardClassName(g)}
               key={g}

--- a/src/Types/Types.stories.tsx
+++ b/src/Types/Types.stories.tsx
@@ -416,7 +416,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>
@@ -429,7 +429,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>
@@ -442,7 +442,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>
@@ -455,7 +455,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>
@@ -468,7 +468,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>
@@ -481,7 +481,7 @@ dataTypeStories.add(
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
-              style={{ backgroundColor: color.value }}
+              style={{backgroundColor: color.value}}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>

--- a/src/Types/Types.stories.tsx
+++ b/src/Types/Types.stories.tsx
@@ -348,10 +348,18 @@ dataTypeStories.add(
     }
 
     const colorsArray = convertEnumToObjArray(InfluxColors)
+    const nuetrals = colorsArray.slice(0, 21)
+    const blues = colorsArray.slice(21, 29)
+    const purples = colorsArray.slice(29, 37)
+    const greens = colorsArray.slice(37, 45)
+    const yellows = colorsArray.slice(45, 53)
+    const reds = colorsArray.slice(53, 61)
 
     const colorCardClassName = (hexcode: string): string => {
+      const lightContrast = chroma.contrast(InfluxColors.White, hexcode)
+      const darkContrast = chroma.contrast(InfluxColors.Obsidian, hexcode)
       const cardTextColor =
-        chroma(hexcode).luminance() >= 0.4 ? 'dark-text' : 'light-text'
+        lightContrast >= darkContrast ? 'light-text' : 'dark-text'
 
       return `colors-grid--card ${cardTextColor}`
     }
@@ -359,8 +367,10 @@ dataTypeStories.add(
     const gradientCardClassName = (gradient: string): string => {
       const {start} = getColorsFromGradient(gradient)
 
+      const lightContrast = chroma.contrast(InfluxColors.White, start)
+      const darkContrast = chroma.contrast(InfluxColors.Obsidian, start)
       const cardTextColor =
-        chroma(start).luminance() >= 0.4 ? 'dark-text' : 'light-text'
+        lightContrast >= darkContrast ? 'light-text' : 'dark-text'
 
       return `gradients-grid--card ${cardTextColor}`
     }
@@ -381,12 +391,78 @@ dataTypeStories.add(
             import &#123;InfluxColors&#125; from '@influxdata/clockface'
           </code>
         </pre>
+        <h5>Nuetrals</h5>
         <div className="colors-grid">
-          {colorsArray.map(color => (
+          {nuetrals.map((color, i) => (
             <div
               className={colorCardClassName(color.value)}
               key={color.key}
               style={{backgroundColor: color.value}}
+            >
+              <p>{`G${i} ${color.key}`}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Blues</h5>
+        <div className="colors-grid">
+          {blues.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
+            >
+              <p>{color.key}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Purples</h5>
+        <div className="colors-grid">
+          {purples.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
+            >
+              <p>{color.key}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Greens</h5>
+        <div className="colors-grid">
+          {greens.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
+            >
+              <p>{color.key}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Yellows</h5>
+        <div className="colors-grid">
+          {yellows.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
+            >
+              <p>{color.key}</p>
+              <p className="colors-grid--hex">{color.value}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Reds</h5>
+        <div className="colors-grid">
+          {reds.map(color => (
+            <div
+              className={colorCardClassName(color.value)}
+              key={color.key}
+              style={{ backgroundColor: color.value }}
             >
               <p>{color.key}</p>
               <p className="colors-grid--hex">{color.value}</p>

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -97,14 +97,15 @@ export enum Gradients {
   MintyFresh = 'MintyFresh',
   SimpleCream = 'SimpleCream',
   WarpSpeed = 'WarpSpeed',
-  OminousFog = 'OminousFog',
+  PowerStone = 'PowerStone',
   MilkyWay = 'MilkyWay',
   LazyAfternoon = 'LazyAfternoon',
   NineteenEightyFour = 'NineteenEightyFour',
-  Radioactive = 'Radioactive',
+  RadioactiveWarning = 'RadioactiveWarning',
   LostGalaxy = 'LostGalaxy',
   GrapeSoda = 'GrapeSoda',
   LavenderLatte = 'LavenderLatte',
+  OminousFog = 'OminousFog',
 }
 
 export enum DropdownMenuTheme {


### PR DESCRIPTION
### Changes

- Use CSS grid to layout color and gradient swatches
  - Able to fit 8 columns on a laptop screen
- Use better means of determining contrasting swatch label color
- Separate colors and gradients into individual spectrums

### Screenshots

<img width="1265" alt="Screen Shot 2019-11-13 at 9 13 12 PM" src="https://user-images.githubusercontent.com/2433762/68820785-73eda980-065a-11ea-9839-2343106c6e80.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
