### PR TITLE
Remove "width" prop from TableCell and TableHeaderCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.7 (Unreleased)
 
+- [#402](https://github.com/influxdata/clockface/pull/402): [Breaking] Remove `width` prop from `TableCell` and `TableHeaderCell`
 - [#400](https://github.com/influxdata/clockface/pull/400): Refactor `PanelHeader`, `PanelBody`, and `PanelFooter` to extend `FlexBox`
 - [#400](https://github.com/influxdata/clockface/pull/400): [Breaking] Remove `PanelTitle` component
 - [#400](https://github.com/influxdata/clockface/pull/400): [Breaking] Rename `childMargin` prop to `margin` in `PanelHeader`

--- a/src/Components/Table/Documentation/Table.stories.tsx
+++ b/src/Components/Table/Documentation/Table.stories.tsx
@@ -85,7 +85,7 @@ tableStories.add(
             <Table.Row ref={tableRowRef}>
               <Table.HeaderCell
                 ref={tableHeaderCellRef}
-                width={text('Name - width', '30%')}
+                style={{width: `${text('Name - width', '30%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -99,7 +99,7 @@ tableStories.add(
                 Name
               </Table.HeaderCell>
               <Table.HeaderCell
-                width={text('Description - width', '50%')}
+                style={{width: `${text('Description - width', '50%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -113,7 +113,7 @@ tableStories.add(
                 Description
               </Table.HeaderCell>
               <Table.HeaderCell
-                width={text('Price - width', '20%')}
+                style={{width: `${text('Price - width', '20%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -142,7 +142,7 @@ tableStories.add(
             >
               <Table.Cell
                 ref={tableCellRef}
-                width={text('Name - width', '30%')}
+                style={{width: `${text('Name - width', '30%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -156,7 +156,7 @@ tableStories.add(
                 Peach
               </Table.Cell>
               <Table.Cell
-                width={text('Description - width', '50%')}
+                style={{width: `${text('Description - width', '50%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -170,7 +170,7 @@ tableStories.add(
                 A sweet fruit that makes a great pie
               </Table.Cell>
               <Table.Cell
-                width={text('Price - width', '20%')}
+                style={{width: `${text('Price - width', '20%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -196,7 +196,7 @@ tableStories.add(
               }
             >
               <Table.Cell
-                width={text('Name - width', '30%')}
+                style={{width: `${text('Name - width', '30%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -210,7 +210,7 @@ tableStories.add(
                 Pineapple
               </Table.Cell>
               <Table.Cell
-                width={text('Description - width', '50%')}
+                style={{width: `${text('Description - width', '50%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -225,7 +225,7 @@ tableStories.add(
                 Colada
               </Table.Cell>
               <Table.Cell
-                width={text('Price - width', '20%')}
+                style={{width: `${text('Price - width', '20%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -251,7 +251,7 @@ tableStories.add(
               }
             >
               <Table.Cell
-                width={text('Name - width', '30%')}
+                style={{width: `${text('Name - width', '30%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -265,7 +265,7 @@ tableStories.add(
                 Yuzu
               </Table.Cell>
               <Table.Cell
-                width={text('Description - width', '50%')}
+                style={{width: `${text('Description - width', '50%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -279,7 +279,7 @@ tableStories.add(
                 A golden citrus fruit from Japan & China with a powerful aroma
               </Table.Cell>
               <Table.Cell
-                width={text('Price - width', '20%')}
+                style={{width: `${text('Price - width', '20%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -305,7 +305,7 @@ tableStories.add(
               }
             >
               <Table.Cell
-                width={text('Name - width', '30%')}
+                style={{width: `${text('Name - width', '30%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -319,7 +319,7 @@ tableStories.add(
                 Lychee
               </Table.Cell>
               <Table.Cell
-                width={text('Description - width', '50%')}
+                style={{width: `${text('Description - width', '50%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(
@@ -333,7 +333,7 @@ tableStories.add(
                 A light and refreshing fruit encased in a spiky shell
               </Table.Cell>
               <Table.Cell
-                width={text('Price - width', '20%')}
+                style={{width: `${text('Price - width', '20%')}`}}
                 horizontalAlignment={
                   Alignment[
                     select(

--- a/src/Components/Table/TableCell.tsx
+++ b/src/Components/Table/TableCell.tsx
@@ -12,8 +12,6 @@ export interface TableCellProps extends StandardFunctionProps {
   horizontalAlignment?: Alignment
   /** Vertical alignment of contents */
   verticalAlignment?: VerticalAlignment
-  /** Width of column, can be % or px */
-  width?: string
 }
 
 export type TableCellRef = HTMLTableDataCellElement

--- a/src/Components/Table/TableHeaderCell.tsx
+++ b/src/Components/Table/TableHeaderCell.tsx
@@ -12,8 +12,6 @@ export interface TableHeaderCellProps extends StandardFunctionProps {
   horizontalAlignment?: Alignment
   /** Vertical alignment of contents */
   verticalAlignment?: VerticalAlignment
-  /** Width of column, can be % or px */
-  width?: string
 }
 
 export type TableHeaderCellRef = HTMLTableHeaderCellElement
@@ -26,7 +24,6 @@ export const TableHeaderCell = forwardRef<
     {
       id,
       style,
-      width,
       testID = 'table-header-cell',
       colSpan = 1,
       children,
@@ -43,7 +40,6 @@ export const TableHeaderCell = forwardRef<
     const tableHeaderCellStyle = {
       textAlign: horizontalAlignment,
       verticalAlign: verticalAlignment,
-      width,
       ...style,
     }
 


### PR DESCRIPTION
Closes #401

### Changes

- Remove "width" prop from `TableCell` and `TableHeaderCell`
  - html5 no longer supports the "width" attribute on `<td>` and `<th>` elements and suggests using inline styles instead

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
