### PR TITLE
Prevent dropdowns from dismissing when scrollbar is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-#### 1.0.7 (Unreleased)
+#### 1.0.8 (Unreleased)
+
+- [#407](https://github.com/influxdata/clockface/pull/407): Prevent `DropdownMenu` from dismissing when the scrollbar is clicked or dragged
+
+#### 1.0.7
 
 - [#402](https://github.com/influxdata/clockface/pull/402): [Breaking] Remove `width` prop from `TableCell` and `TableHeaderCell`
 - [#400](https://github.com/influxdata/clockface/pull/400): Refactor `PanelHeader`, `PanelBody`, and `PanelFooter` to extend `FlexBox`

--- a/src/Components/Button/Documentation/SquareButton.md
+++ b/src/Components/Button/Documentation/SquareButton.md
@@ -1,10 +1,10 @@
-# Square Button
+# SquareButton
 
 This is composed variation of a the Base Button intended for a common use case to save time. The Square button only contains a single icon and includes status indicators.
 
 ### Usage
 ```tsx
-import {Button} from '@influxdata/clockface'
+import {SquareButton} from '@influxdata/clockface'
 ```
 
 ### Example

--- a/src/Components/Dropdowns/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/DropdownMenu.tsx
@@ -77,7 +77,6 @@ export const DropdownMenu = forwardRef<DropdownMenuRef, DropdownMenuProps>(
         id={id}
         ref={ref}
         style={style}
-        onClick={onCollapse}
         className={DropdownMenuClass}
         data-testid={testID}
       >
@@ -94,6 +93,7 @@ export const DropdownMenu = forwardRef<DropdownMenuRef, DropdownMenuProps>(
           <div
             ref={contentsRef}
             style={contentsStyle}
+            onClick={onCollapse}
             className="cf-dropdown-menu--contents"
             data-testid={`${testID}--contents`}
           >


### PR DESCRIPTION
Closes #404
Closes #257 

### Changes

- Bind the `onHide` function to the contents of the menu rather than the wrapper
- Fix typo in `SquareButton` documentation

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
