### PR TITLE
Polish Funnel Page Styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 1.1.0 (Unreleased)
 
+- [#410](https://github.com/influxdata/clockface/pull/410): Create CSS classes for styling `FunnelPage` typography
+- [#410](https://github.com/influxdata/clockface/pull/410): Adjust `CTAButton` and `PanelSymbolHeader` to match design specifications
 - [#409](https://github.com/influxdata/clockface/pull/409): Introduce `PanelSymbolHeader` component
 - [#409](https://github.com/influxdata/clockface/pull/409): Introduce `Bullet` component
 - [#409](https://github.com/influxdata/clockface/pull/409): [Breaking] Remove `NumberedPanel`

--- a/src/Components/Button/Composed/CTAButton.scss
+++ b/src/Components/Button/Composed/CTAButton.scss
@@ -5,17 +5,19 @@
   ------------------------------------------------------------------------------
 */
 
-$cf-cta-button--height: $cf-marg-e + $cf-marg-b;
+$cf-cta-button--height: $cf-marg-e + $cf-marg-a;
+$cf-cta-button--font: 1.375em;
+$cf-cta-button--icon: 1.7em;
 
 .cf-button-lg.cf-cta-button {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   height: $cf-cta-button--height;
   padding: 0 $cf-marg-d;
   
   > .cf-button-icon {
-    font-size: floor($cf-text-base-4 * 1.25);
+    font-size: $cf-cta-button--icon;
 
     &:first-child {
       margin-right: 0.4em;
@@ -26,7 +28,7 @@ $cf-cta-button--height: $cf-marg-e + $cf-marg-b;
   }
   
   > .cf-button--label {
-    font-size: $cf-text-base-4;
+    font-size: $cf-cta-button--font;
     margin: 0;
     font-weight: 900;
     letter-spacing: -0.02em;

--- a/src/Components/FunnelPage/Documentation/ExampleFunnelPage.md
+++ b/src/Components/FunnelPage/Documentation/ExampleFunnelPage.md
@@ -1,20 +1,11 @@
-# Example Funnel Page
+# Sign Up Page
 
-This example utilizes all the components designed to collectively implement Funnel Page type designs.
+This example utilizes all the components necessary to build a Cloud 2 sign up page. See the `FunnelPage` documentation for how to ensure the typography is correct
 
 ### Usage
 
 ```tsx
-import {FunnelPage} from '@influxdata/clockface'
-```
-```tsx
-// Recommended usage:
-<AppWrapper type="funnel">
-  <FunnelPage />
-  <FunnelPage.Footer>
-    <FunnelPage.FooterSection>I am a footer!</FunnelPage.FooterSection>
-  </FunnelPage.Footer>
-</AppWrapper>
+import {FunnelPage, Panel, Bullet, CTAButton} from '@influxdata/clockface'
 ```
 
 ### Example

--- a/src/Components/FunnelPage/Documentation/FunnelPage.md
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.md
@@ -7,12 +7,23 @@ Funnel pages are designed to guide a user through a funnel (aka focused workflow
 ```tsx
 import {FunnelPage} from '@influxdata/clockface'
 ```
+
+### Typography
+
+For semantic purposes the page title should always be `h1`. The subtitles can be `<p>` or whatever tag you see fit. We have created some CSS Classes that will ensure visual consistency regardless of what heading or paragraph elements you use.
+
+| Design | Element | Class |
+|:------------|:--------|:------|
+| Page Title | `<h1 />` | `.cf-funnel-page--title` |
+| Subtitle | `any` | `.cf-funnel-page--subtitle` |
+| Panel Title | `any` | `.cf-funnel-page--panel-title` |
+
 ```tsx
 // Recommended usage:
 <AppWrapper type="funnel">
   <FunnelPage>
-    <h2>I am a title!</h2>
-    <h5>I am a sub-title</h5>
+    <h1 className="cf-funnel-page--title">I am a page title</h1>
+    <p className="cf-funnel-page--subtitle">I am a subtitle</p>
   </FunnelPage>
 </AppWrapper>
 ```

--- a/src/Components/FunnelPage/Documentation/FunnelPage.md
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.md
@@ -16,7 +16,9 @@ For semantic purposes the page title should always be `h1`. The subtitles can be
 |:------------|:--------|:------|
 | Page Title | `<h1 />` | `.cf-funnel-page--title` |
 | Subtitle | `any` | `.cf-funnel-page--subtitle` |
-| Panel Title | `any` | `.cf-funnel-page--panel-title` |
+| Panel Title | `<h3 />`* | `.cf-funnel-page--panel-title` |
+
+* While we recommend `<h3 />` as the element for Panel Titles, feel free to adjust as necessary.
 
 ```tsx
 // Recommended usage:

--- a/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
@@ -10,8 +10,11 @@ import {mapEnumKeys} from '../../../Utils/storybook'
 // Components
 import {FunnelPage, FunnelPageRef, FunnelPageFooterRef} from '../'
 import {AppWrapper} from '../../AppWrapper/AppWrapper'
-import {Icon} from '../../Icon/Base/Icon'
+import {Icon, Bullet} from '../../Icon'
 import {Button} from '../../Button/Composed/Button'
+import {CTAButton} from '../../Button/Composed/CTAButton'
+import {Grid} from '../../Grid'
+import {Panel} from '../../Panel'
 import {FlexBox} from '../../FlexBox'
 
 // Types
@@ -23,11 +26,13 @@ import {
   FlexDirection,
   ComponentColor,
   ComponentSize,
+  Columns,
 } from '../../../Types'
 
 // Notes
 import FunnelPageReadme from './FunnelPage.md'
 import FunnelPageFooterReadme from './FunnelPageFooter.md'
+import ExampleFunnelPageReadme from './ExampleFunnelPage.md'
 
 const funnelPageStories = storiesOf(
   'Layout|FunnelPage/Family',
@@ -87,22 +92,8 @@ funnelPageStories.add(
                 ]
               }
             >
-              <h2>Use H2 for Funnel Page titles</h2>
-              <h5>
-                Use H5 for <strong>Funnel Page</strong> sub-titles,
-                <br />
-                but don't feel too constrained
-              </h5>
-              <p>
-                Lorem ipsum dolor amet cold-pressed selvage literally humblebrag
-                YOLO, kale chips adaptogen whatever synth deep v letterpress
-                iceland post-ironic. 3 wolf moon fixie sriracha synth. Cronut
-                thundercats aesthetic gentrify flexitarian gastropub tumeric
-                direct trade migas umami hot chicken wolf poke skateboard etsy.
-                Post-ironic raw denim air plant kogi cray shabby chic normcore
-                yuccie. Skateboard raw denim bitters lumbersexual. Drinking
-                vinegar flannel bushwick literally crucifix marfa.
-              </p>
+              <h1 className="cf-funnel-page--title">I am a page title</h1>
+              <p className="cf-funnel-page--subtitle">I am a <strong>subtitle</strong></p>
               <p>
                 Hell of wayfarers bespoke, butcher unicorn adaptogen kitsch
                 enamel pin sustainable. Hoodie adaptogen pok pok, tofu small
@@ -200,56 +191,74 @@ funnelPageExampleStories.add(
         <div className="mockPage">
           <AppWrapper type="funnel">
             <FunnelPage logo={logo}>
-              <h2>Create your Free InfluxCloud Account</h2>
-              <h5>No credit card required</h5>
-              <p>
-                Lorem ipsum dolor amet cold-pressed selvage literally humblebrag
-                YOLO, kale chips adaptogen whatever synth deep v letterpress
-                iceland post-ironic. 3 wolf moon fixie sriracha synth. Cronut
-                thundercats aesthetic gentrify flexitarian gastropub tumeric
-                direct trade migas umami hot chicken wolf poke skateboard etsy.
-                Post-ironic raw denim air plant kogi cray shabby chic normcore
-                yuccie. Skateboard raw denim bitters lumbersexual. Drinking
-                vinegar flannel bushwick literally crucifix marfa.
-              </p>
-              <p>
-                Hell of wayfarers bespoke, butcher unicorn adaptogen kitsch
-                enamel pin sustainable. Hoodie adaptogen pok pok, tofu small
-                batch synth trust fund jianbing marfa activated charcoal
-                pour-over mlkshk knausgaard truffaut. Waistcoat salvia neutra
-                DIY, bespoke glossier disrupt you probably haven't heard of
-                them. Aesthetic pork belly flexitarian kale chips you probably
-                haven't heard of them.
-              </p>
-              <p>
-                Tattooed hella enamel pin lo-fi shaman vexillologist. Hoodie
-                cornhole lyft taxidermy. Hammock tote bag taxidermy shaman.
-                Migas everyday carry quinoa gastropub try-hard kitsch literally
-                locavore freegan austin swag. Jianbing swag deep v helvetica
-                vexillologist dreamcatcher distillery typewriter, microdosing
-                pinterest slow-carb. Taxidermy hashtag whatever, taiyaki
-                wayfarers air plant la croix brooklyn. Austin hell of mlkshk,
-                normcore hashtag live-edge you probably haven't heard of them
-                listicle meggings.
-              </p>
-              <p>
-                Trust fund celiac 3 wolf moon neutra, brunch put a bird on it
-                bespoke. Pinterest four loko gluten-free copper mug sriracha.
-                Whatever street art cornhole, irony hexagon live-edge actually
-                church-key pug vape. Locavore pork belly quinoa unicorn whatever
-                fanny pack af vape. Hashtag bushwick narwhal, polaroid unicorn
-                viral shabby chic blog vexillologist.
-              </p>
-              <p>
-                Organic keytar roof party put a bird on it, tacos lyft art party
-                crucifix man bun single-origin coffee seitan 8-bit disrupt etsy
-                farm-to-table. Palo santo mustache pitchfork cold-pressed 8-bit.
-                Master cleanse crucifix yuccie cliche cornhole. Chillwave
-                butcher enamel pin roof party celiac. Chia street art ethical
-                flannel kale chips. Offal gluten-free roof party knausgaard,
-                hella trust fund readymade 3 wolf moon meditation swag. Selvage
-                irony paleo franzen pork belly shoreditch.
-              </p>
+              <Grid>
+                <Grid.Row>
+                  <Grid.Column widthSM={Columns.Eight} offsetSM={Columns.Two}>
+                    <h1 className="cf-funnel-page--title">
+                      Create your Free InfluxCloud Account
+                    </h1>
+                    <p className="cf-funnel-page--subtitle">
+                      No credit card required
+                    </p>
+                    <Panel>
+                      <Panel.SymbolHeader
+                        symbol={<Bullet text="1" />}
+                        title={
+                          <h5 className="cf-funnel-page--panel-title">
+                            Get a coconut
+                          </h5>
+                        }
+                      />
+                      <Panel.Body>
+                        <p style={{textAlign: 'left'}}>
+                          Use a <code>H4</code> for panel titles. Lorem ipsum
+                          dolor amet cold-pressed selvage literally humblebrag
+                          YOLO, kale chips adaptogen whatever synth deep v
+                          letterpress iceland post-ironic.
+                        </p>
+                      </Panel.Body>
+                    </Panel>
+                    <Panel>
+                      <Panel.SymbolHeader
+                        symbol={<Bullet text="2" />}
+                        title={
+                          <h5 className="cf-funnel-page--panel-title">
+                            Put a lime in the coconut
+                          </h5>
+                        }
+                      />
+                      <Panel.Body>
+                        <p style={{textAlign: 'left'}}>
+                          Lorem ipsum dolor amet cold-pressed selvage literally
+                          humblebrag YOLO, kale chips adaptogen whatever synth
+                          deep v letterpress iceland post-ironic.
+                        </p>
+                      </Panel.Body>
+                    </Panel>
+                    <Panel>
+                      <Panel.SymbolHeader
+                        symbol={<Bullet text="3" />}
+                        title={
+                          <h5 className="cf-funnel-page--panel-title">
+                            Mix it all up
+                          </h5>
+                        }
+                      />
+                      <Panel.Body>
+                        <p style={{textAlign: 'left'}}>
+                          Lorem ipsum dolor amet cold-pressed selvage literally
+                          humblebrag YOLO, kale chips adaptogen whatever synth
+                          deep v letterpress iceland post-ironic.
+                        </p>
+                      </Panel.Body>
+                    </Panel>
+                    <p className="cf-funnel-page--subtitle">
+                      Next: <strong>Make Some Spaghetti</strong>
+                    </p>
+                    <CTAButton text="Continue" color={ComponentColor.Primary} />
+                  </Grid.Column>
+                </Grid.Row>
+              </Grid>
             </FunnelPage>
             <FunnelPage.Footer>
               <FunnelPage.FooterSection
@@ -264,25 +273,36 @@ funnelPageExampleStories.add(
                 </p>
               </FunnelPage.FooterSection>
               <FunnelPage.FooterSection>
-                <FlexBox
-                  justifyContent={JustifyContent.SpaceBetween}
-                  alignItems={AlignItems.Center}
-                  direction={FlexDirection.Row}
-                  stretchToFitWidth={true}
-                  style={{margin: '18px 0'}}
-                >
-                  <div>
-                    <h2 style={{color: InfluxColors.Rainforest, margin: '0'}}>
-                      $450/mo
-                    </h2>
-                    <h5 style={{margin: '0'}}>Estimated Costs</h5>
-                  </div>
-                  <Button
-                    color={ComponentColor.Secondary}
-                    text="Upgrade to Usage-Based Plan"
-                    size={ComponentSize.Large}
-                  />
-                </FlexBox>
+                <Grid>
+                  <Grid.Row>
+                    <Grid.Column widthSM={Columns.Eight} offsetSM={Columns.Two}>
+                      <FlexBox
+                        justifyContent={JustifyContent.SpaceBetween}
+                        alignItems={AlignItems.Center}
+                        direction={FlexDirection.Row}
+                        stretchToFitWidth={true}
+                        style={{margin: '18px 0'}}
+                      >
+                        <div>
+                          <h2
+                            style={{
+                              color: InfluxColors.Rainforest,
+                              margin: '0',
+                            }}
+                          >
+                            $450/mo
+                          </h2>
+                          <h5 style={{margin: '0'}}>Estimated Costs</h5>
+                        </div>
+                        <Button
+                          color={ComponentColor.Secondary}
+                          text="Upgrade to Usage-Based Plan"
+                          size={ComponentSize.Large}
+                        />
+                      </FlexBox>
+                    </Grid.Column>
+                  </Grid.Row>
+                </Grid>
               </FunnelPage.FooterSection>
             </FunnelPage.Footer>
           </AppWrapper>
@@ -292,7 +312,7 @@ funnelPageExampleStories.add(
   },
   {
     readme: {
-      content: marked(FunnelPageFooterReadme),
+      content: marked(ExampleFunnelPageReadme),
     },
   }
 )

--- a/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
@@ -206,9 +206,9 @@ funnelPageExampleStories.add(
                       <Panel.SymbolHeader
                         symbol={<Bullet text="1" />}
                         title={
-                          <h5 className="cf-funnel-page--panel-title">
+                          <h3 className="cf-funnel-page--panel-title">
                             Get a coconut
-                          </h5>
+                          </h3>
                         }
                       />
                       <Panel.Body>
@@ -223,9 +223,9 @@ funnelPageExampleStories.add(
                       <Panel.SymbolHeader
                         symbol={<Bullet text="2" />}
                         title={
-                          <h5 className="cf-funnel-page--panel-title">
+                          <h3 className="cf-funnel-page--panel-title">
                             Put a lime in the coconut
-                          </h5>
+                          </h3>
                         }
                       />
                       <Panel.Body>
@@ -240,9 +240,9 @@ funnelPageExampleStories.add(
                       <Panel.SymbolHeader
                         symbol={<Bullet text="3" />}
                         title={
-                          <h5 className="cf-funnel-page--panel-title">
+                          <h3 className="cf-funnel-page--panel-title">
                             Mix it all up
-                          </h5>
+                          </h3>
                         }
                       />
                       <Panel.Body>

--- a/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
@@ -93,7 +93,9 @@ funnelPageStories.add(
               }
             >
               <h1 className="cf-funnel-page--title">I am a page title</h1>
-              <p className="cf-funnel-page--subtitle">I am a <strong>subtitle</strong></p>
+              <p className="cf-funnel-page--subtitle">
+                I am a <strong>subtitle</strong>
+              </p>
               <p>
                 Hell of wayfarers bespoke, butcher unicorn adaptogen kitsch
                 enamel pin sustainable. Hoodie adaptogen pok pok, tofu small
@@ -211,10 +213,9 @@ funnelPageExampleStories.add(
                       />
                       <Panel.Body>
                         <p style={{textAlign: 'left'}}>
-                          Use a <code>H4</code> for panel titles. Lorem ipsum
-                          dolor amet cold-pressed selvage literally humblebrag
-                          YOLO, kale chips adaptogen whatever synth deep v
-                          letterpress iceland post-ironic.
+                          Lorem ipsum dolor amet cold-pressed selvage literally
+                          humblebrag YOLO, kale chips adaptogen whatever synth
+                          deep v letterpress iceland post-ironic.
                         </p>
                       </Panel.Body>
                     </Panel>

--- a/src/Components/FunnelPage/Family/FunnelPage.scss
+++ b/src/Components/FunnelPage/Family/FunnelPage.scss
@@ -5,7 +5,8 @@
   ------------------------------------------------------------------------------
 */
 
-$funnel-page--base-font: 16px;
+$funnel-page--base-font: 14px;
+$funnel-page--base-font--large: 16px;
 $funnel-page--tiny-gutter: $cf-marg-b;
 $funnel-page--gutter: $cf-marg-d;
 
@@ -48,32 +49,41 @@ $funnel-page--gutter: $cf-marg-d;
   font-size: $funnel-page--base-font;
   color: $c-moonstone;
 
-  h1,
-  h2,
-  h3,
+  .cf-funnel-page--title {
+    font-weight: 400;
+    color: $g20-white;
+    font-size: 1.75em;
+    margin-bottom: 0em;
+  }
+
+  .cf-funnel-page--subtitle {
+    font-weight: 500;
+    font-size: 1.125em;
+    margin: 1.25em 0;
+  }
+
+  .cf-funnel-page--panel-title {
+    font-size: 1.125em;
+    font-weight: 500;
+  }
+
+  .cf-panel {
+    margin-bottom: $cf-marg-a;
+  }
+
+  .cf-cta-button {
+    margin-bottom: $cf-marg-d;
+  }
+
   strong {
     color: $g20-white;
-  }
-
-  h1,
-  h2,
-  h3 {
-    font-weight: 300;
-  }
-
-  h4,
-  h5,
-  h6 {
-    font-weight: 600;
-  }
-
-  strong {
     font-weight: 900;
   }
 }
 
 @media screen and (min-width: $grid--breakpoint-md) {
   .cf-funnel-page--content {
+    font-size: $funnel-page--base-font--large;
     padding: $funnel-page--gutter;
   }
 }

--- a/src/Components/Panel/Composed/PanelSymbolHeader.scss
+++ b/src/Components/Panel/Composed/PanelSymbolHeader.scss
@@ -5,8 +5,8 @@
    -----------------------------------------------------------------------------
 */
 
-$panel-symbol-header-gutter-small: $cf-marg-d;
-$panel-symbol-header-gutter: $cf-marg-e;
+$panel-symbol-header-gutter-small: $cf-marg-c;
+$panel-symbol-header-gutter: $cf-marg-d + $cf-marg-b;
 
 .cf-panel--symbol-header {
   padding-left: $panel-symbol-header-gutter-small;


### PR DESCRIPTION
Goal 1: Make funnel pages look more like the mockups

Goal 2: Decouple semantics from aesthetics

### Changes

- Create CSS classes specifically for typography elements featured in the mockups
  - These ensure visual consistency independently of what HTML element is used
- Make `CTAButton` match font size and height as specified in the mockups
- Adjust horizontal padding of `PanelSymbolHeader` to match mockups
- Add `PanelSymbolHeader` based panels to `FunnelPage` example
- Document funnel page specific CSS classes

### Screenshots

![Screen Shot 2019-11-21 at 3 35 51 PM](https://user-images.githubusercontent.com/2433762/69385590-baec2800-0c74-11ea-90ac-eb56f6885183.png)
![Screen Shot 2019-11-21 at 3 36 31 PM](https://user-images.githubusercontent.com/2433762/69385598-bfb0dc00-0c74-11ea-94e8-a01eaf3bdc6b.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
