### PR TITLE
fix: add local state to DapperScrollbars to persist scroll position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.1.0 (Unreleased)
 
+- [#415](https://github.com/influxdata/clockface/pull/415): Fix `DapperScrollbars` to persist scroll position and prevent jumping
 - [#414](https://github.com/influxdata/clockface/pull/414): Introduce `Notification` components for briefly conveying information
 - [#413](https://github.com/influxdata/clockface/pull/413): Introduce `SquareGrid` components for fluid, responsive, proportial grids
 - [#410](https://github.com/influxdata/clockface/pull/410): Create CSS classes for styling `FunnelPage` typography

--- a/src/Components/DapperScrollbars/DapperScrollbars.tsx
+++ b/src/Components/DapperScrollbars/DapperScrollbars.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, useRef, useState, useEffect} from 'react'
 import _ from 'lodash'
 import classnames from 'classnames'
 import Scrollbar from 'react-scrollbars-custom'
@@ -62,6 +62,15 @@ export const DapperScrollbars: FunctionComponent<DapperScrollbarsProps> = ({
   removeTrackYWhenNotUsed = true,
   removeTrackXWhenNotUsed = true,
 }) => {
+  const scrollEl = useRef<any>(null)
+  const [scrollTopPos, setScrollTopPos] = useState<number>(Number(scrollTop))
+  const [scrollLeftPos, setScrollLeftPos] = useState<number>(Number(scrollLeft))
+
+  useEffect(() => {
+    setScrollTopPos(Number(scrollTop))
+    setScrollLeftPos(Number(scrollLeft))
+  }, [scrollTop, scrollLeft])
+
   const dapperScrollbarsClass = classnames('cf-dapper-scrollbars', {
     'cf-dapper-scrollbars--autohide': autoHide,
     [`${className}`]: className,
@@ -75,8 +84,15 @@ export const DapperScrollbars: FunctionComponent<DapperScrollbarsProps> = ({
     background: `linear-gradient(to bottom,  ${thumbStartColor} 0%,${thumbStopColor} 100%)`,
   }
 
+  const handleOnScroll = () => {
+    setScrollTopPos(scrollEl.current.scrollTop)
+    setScrollLeftPos(scrollEl.current.scrollLeft)
+  }
+
   return (
     <Scrollbar
+      ref={scrollEl}
+      onScroll={handleOnScroll}
       data-testid={testID}
       translateContentSizesToHolder={autoSize}
       translateContentSizeYToHolder={autoSizeHeight}
@@ -102,8 +118,8 @@ export const DapperScrollbars: FunctionComponent<DapperScrollbarsProps> = ({
         style: thumbYStyle,
         className: 'cf-dapper-scrollbars--thumb-y',
       }}
-      scrollTop={scrollTop}
-      scrollLeft={scrollLeft}
+      scrollTop={scrollTopPos}
+      scrollLeft={scrollLeftPos}
       id={id}
       download={null}
       inlist={null}

--- a/src/Components/DapperScrollbars/Documentation/DapperScrollbars.stories.tsx
+++ b/src/Components/DapperScrollbars/Documentation/DapperScrollbars.stories.tsx
@@ -1,43 +1,40 @@
 // Libraries
 import * as React from 'react'
-import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {
-  withKnobs,
-  boolean,
-  color,
-  object,
-  text,
-  number,
-} from '@storybook/addon-knobs'
+import {useState} from '@storybook/addons'
+import {withKnobs, boolean, color, object, number} from '@storybook/addon-knobs'
 
 // Components
 import {DapperScrollbars} from '../DapperScrollbars'
-
-// Notes
-import DapperScrollbarsExample1Readme from './DapperScrollbarsExample1.md'
-import DapperScrollbarsExample2Readme from './DapperScrollbarsExample2.md'
+import {Form} from '../../Form'
+import {Dropdown} from '../../Dropdowns'
 
 const scrollbarStories = storiesOf('Utilities|Scrollbars', module).addDecorator(
   withKnobs
 )
 
-const fixedDefaultStyle = {width: '300px', height: '180px'}
+const fixedDefaultStyle = {width: '300px', height: '600px'}
 const autoSizeDefaultStyle = {
   width: '300px',
   maxWidth: '300px',
   maxHeight: '300px',
 }
+const selectionStyle = {color: 'red'}
+const instructionStyle = {color: 'green'}
 const contentStyle = {width: '600px'}
 const exampleTextDefault = `Try modifying this text to see how scrolling is affected! Distillery raclette swag, actually selfies cred neutra put a bird on it mlkshk hexagon fam. Iceland man braid echo park succulents flexitarian occupy. Organic health goth activated charcoal helvetica poke beard swag tacos drinking vinegar pop-up kickstarter wolf normcore lyft chillwave. Microdosing migas blog intelligentsia air plant typewriter, echo park mumblecore kombucha yuccie wayfarers poutine actually locavore distillery.
 Blue bottle four loko kogi woke activated charcoal forage tote bag sartorial. Hammock normcore lo-fi tbh trust fund man bun post-ironic locavore DIY plaid wolf tumeric. Poutine cred microdosing, typewriter jianbing marfa vegan. Kombucha four dollar toast organic bespoke af cred freegan meditation biodiesel tilde chia. Tofu microdosing retro lo-fi, DIY raclette kitsch. 
 Art party ramps vice master cleanse ethical scenester. Knausgaard kombucha williamsburg chambray asymmetrical, wolf seitan vaporware swag selfies. Single-origin coffee cloud bread vaporware, authentic sartorial food truck echo park ugh letterpress. IPhone pickled banh mi, lomo fingerstache crucifix letterpress offal lo-fi whatever pok pok chartreuse kitsch banjo.
 Keytar celiac copper mug chia typewriter. Umami crucifix tumblr mixtape taxidermy succulents hammock cardigan narwhal. Vegan four loko disrupt gastropub, pop-up drinking vinegar pinterest semiotics photo booth unicorn ugh pork belly before they sold out scenester. Waistcoat disrupt hashtag vice, raclette flannel farm-to-table butcher iPhone biodiesel. Locavore godard brunch hammock bicycle rights flannel letterpress pabst distillery mixtape jean shorts af chartreuse shoreditch small batch. Banh mi slow-carb brooklyn thundercats, helvetica shoreditch locavore.`
-scrollbarStories.add(
-  'Fixed Example',
-  () => (
+scrollbarStories.add('Scrollbar Example', () => {
+  const [selection, setSelection] = useState<string>('Foo')
+  const handleSelectionChange = (value: string) => {
+    setSelection(value)
+  }
+
+  return (
     <div className="story--example">
       <div className="scroll--container">
         <DapperScrollbars
@@ -55,46 +52,81 @@ scrollbarStories.add(
           scrollTop={number('scrollTop', 0)}
           scrollLeft={number('scrollLeft', 0)}
         >
+          <p style={object('selection style', selectionStyle)}>"{selection}"</p>
+          <p style={object('instruction style', instructionStyle)}>
+            1. Scroll until you hide the above word
+          </p>
+          <p style={object('instruction style', instructionStyle)}>
+            2. Make a selection
+          </p>
+          <p style={object('instruction style', instructionStyle)}>
+            3. Scrollbars should stay in place and you should not see the
+            selection change until you manually scroll back
+          </p>
           <p style={object('content style', contentStyle)}>
-            {text('Text Content', exampleTextDefault)}
+            {exampleTextDefault}
           </p>
         </DapperScrollbars>
+        <Form.Element label="Select a word">
+          <Dropdown
+            button={(active, onClick) => (
+              <Dropdown.Button active={active} onClick={onClick}>
+                {selection}
+              </Dropdown.Button>
+            )}
+            menu={onCollapse => (
+              <Dropdown.Menu onCollapse={onCollapse}>
+                <Dropdown.Item
+                  id="foo"
+                  value="Foo"
+                  onClick={handleSelectionChange}
+                  selected={selection === 'Foo'}
+                >
+                  Foo
+                </Dropdown.Item>
+                <Dropdown.Item
+                  id="bar"
+                  value="Bar"
+                  onClick={handleSelectionChange}
+                  selected={selection === 'Bar'}
+                >
+                  Bar
+                </Dropdown.Item>
+                <Dropdown.Item
+                  id="baz"
+                  value="Baz"
+                  onClick={handleSelectionChange}
+                  selected={selection === 'Baz'}
+                >
+                  Baz
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            )}
+          />
+        </Form.Element>
       </div>
     </div>
-  ),
-  {
-    readme: {
-      content: marked(DapperScrollbarsExample1Readme),
-    },
-  }
-)
+  )
+})
 
-scrollbarStories.add(
-  'AutoSize Example',
-  () => (
-    <div className="story--example">
-      <div className="scroll--container">
-        <DapperScrollbars
-          style={object('style', autoSizeDefaultStyle)}
-          removeTracksWhenNotUsed={boolean('removeTracksWhenNotUsed', false)}
-          removeTrackYWhenNotUsed={boolean('removeTrackYWhenNotUsed', false)}
-          removeTrackXWhenNotUsed={boolean('removeTrackXWhenNotUsed', false)}
-          noScrollX={boolean('noScrollX', false)}
-          noScrollY={boolean('noScrollY', false)}
-          noScroll={boolean('noScroll', false)}
-          autoHide={boolean('autoHide', true)}
-          autoSize={true}
-          thumbStartColor={color('thumbStartColor', '#00C9FF')}
-          thumbStopColor={color('thumbStopColor', '#9394FF')}
-        >
-          <p>{text('Text Content', exampleTextDefault)}</p>
-        </DapperScrollbars>
-      </div>
+scrollbarStories.add('AutoSize Example', () => (
+  <div className="story--example">
+    <div className="scroll--container">
+      <DapperScrollbars
+        style={object('style', autoSizeDefaultStyle)}
+        removeTracksWhenNotUsed={boolean('removeTracksWhenNotUsed', false)}
+        removeTrackYWhenNotUsed={boolean('removeTrackYWhenNotUsed', false)}
+        removeTrackXWhenNotUsed={boolean('removeTrackXWhenNotUsed', false)}
+        noScrollX={boolean('noScrollX', false)}
+        noScrollY={boolean('noScrollY', false)}
+        noScroll={boolean('noScroll', false)}
+        autoHide={boolean('autoHide', true)}
+        autoSize={true}
+        thumbStartColor={color('thumbStartColor', '#00C9FF')}
+        thumbStopColor={color('thumbStopColor', '#9394FF')}
+      >
+        <p>{exampleTextDefault}</p>
+      </DapperScrollbars>
     </div>
-  ),
-  {
-    readme: {
-      content: marked(DapperScrollbarsExample2Readme),
-    },
-  }
-)
+  </div>
+))


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15633

### Changes

Adds local state to DapperScrollbars to persist scroll position. This prevents the scrollbar from jumping back to the default position when parent elements are re-rendered.

### Screenshots

<img width="1680" alt="Screen Shot 2019-12-03 at 6 22 32 PM" src="https://user-images.githubusercontent.com/10736577/70106940-eb7b7c80-15f9-11ea-99c2-81036c5cd6d5.png">


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
