### PR TITLE
Fix circular panel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prettier": "prettier --config .prettierrc.json --check 'src/**/*.{ts,tsx}'",
     "prettier:fix": "prettier --config .prettierrc.json --write 'src/**/*.{ts,tsx}'",
     "typecheck": "tsc --noEmit --pretty",
+    "fix": "eslint --fix 'src/**/*.{ts,tsx}'; prettier --config .prettierrc.json --check 'src/**/*.{ts,tsx}'",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "publishStorybook": "storybook-to-ghpages --out=.out"
   },

--- a/src/Components/Panel/Composed/PanelSymbolHeader.tsx
+++ b/src/Components/Panel/Composed/PanelSymbolHeader.tsx
@@ -43,6 +43,9 @@ export const PanelSymbolHeader = forwardRef<
       symbol,
       children,
       className,
+      direction = FlexDirection.Row,
+      alignItems = AlignItems.Center,
+      justifyContent = JustifyContent.SpaceBetween,
     },
     ref
   ) => {
@@ -58,7 +61,10 @@ export const PanelSymbolHeader = forwardRef<
         size={size}
         style={style}
         className={panelSymbolHeaderClassName}
+        direction={direction}
+        alignItems={alignItems}
         data-testid={testID}
+        justifyContent={justifyContent}
       >
         <div className="cf-panel--symbol-header--title">
           <div className="cf-panel--symbol-header--symbol">{symbol}</div>

--- a/src/Components/Panel/Composed/PanelSymbolHeader.tsx
+++ b/src/Components/Panel/Composed/PanelSymbolHeader.tsx
@@ -6,18 +6,25 @@ import classnames from 'classnames'
 import './PanelSymbolHeader.scss'
 
 // Components
-import {Panel, PanelHeaderRef} from '..'
+import {
+  PanelHeader,
+  PanelHeaderProps,
+  PanelHeaderRef,
+} from '../Family/PanelHeader'
 
 // Types
-import {ComponentSize, StandardFunctionProps} from '../../../Types'
+import {
+  ComponentSize,
+  FlexDirection,
+  AlignItems,
+  JustifyContent,
+} from '../../../Types'
 
-export interface PanelSymbolHeaderProps extends StandardFunctionProps {
+export interface PanelSymbolHeaderProps extends PanelHeaderProps {
   /** Element to display before header text (Bullet or Icon) */
   symbol?: JSX.Element
   /** Panel title */
   title?: JSX.Element
-  /** Controls padding on nested header component */
-  size?: ComponentSize
 }
 
 export type PanelSymbolHeaderRef = PanelHeaderRef
@@ -29,13 +36,13 @@ export const PanelSymbolHeader = forwardRef<
   (
     {
       id,
+      size = ComponentSize.Small,
       style,
       title,
       testID = 'panel--symbol-header',
       symbol,
       children,
       className,
-      size = ComponentSize.Small,
     },
     ref
   ) => {
@@ -45,20 +52,20 @@ export const PanelSymbolHeader = forwardRef<
     })
 
     return (
-      <Panel.Header
-        className={panelSymbolHeaderClassName}
-        data-testid={testID}
+      <PanelHeader
+        id={id}
+        ref={ref}
         size={size}
         style={style}
-        ref={ref}
-        id={id}
+        className={panelSymbolHeaderClassName}
+        data-testid={testID}
       >
         <div className="cf-panel--symbol-header--title">
           <div className="cf-panel--symbol-header--symbol">{symbol}</div>
           {title}
         </div>
         {children}
-      </Panel.Header>
+      </PanelHeader>
     )
   }
 )


### PR DESCRIPTION
Noticed a circular dependency error when building Clockface

- Import `PanelHeader` directly into `PanelSymbolHeader` rather than from the index
- Make `PanelSymbolHeaderProps` extend `PanelHeaderProps`
- Ensure flexbox layout props are passed through to `PanelHeader`
- Create yarn script that runs `prettier:fix` and `eslint:fix` simultaneously