### PR TITLE
fix: use empty state in ResourceList.Body when children is boolean false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 1.1.1 (Unreleased)
 
+- [#422](https://github.com/influxdata/clockface/pull/422): Render the empty state when ResourceList.Body receives boolean false as children
+
 #### 1.1.0
 
 - [#415](https://github.com/influxdata/clockface/pull/415): Fix `DapperScrollbars` to persist scroll position and prevent jumping

--- a/src/Components/ResourceList/Documentation/ResourceList.stories.tsx
+++ b/src/Components/ResourceList/Documentation/ResourceList.stories.tsx
@@ -167,6 +167,16 @@ resourceListStories.add(
       /* eslint-enable */
     }
 
+    const options: any = {
+      null: null,
+      false: false,
+      'React elements': 'Resource List appears here YAY!',
+    }
+    const children = select(
+      'Children',
+      options,
+      'Resource List appears here YAY!'
+    )
     return (
       <div className="story--example">
         <div className="story--test-buttons">
@@ -177,7 +187,9 @@ resourceListStories.add(
           emptyState={
             <div className="mockComponent stretch">EmptyState goes here</div>
           }
-        />
+        >
+          {children}
+        </ResourceListBody>
       </div>
     )
   },

--- a/src/Components/ResourceList/List/ResourceListBody.tsx
+++ b/src/Components/ResourceList/List/ResourceListBody.tsx
@@ -36,7 +36,8 @@ export const ResourceListBody = forwardRef<
     if (
       React.Children.count(children) === 0 ||
       children === undefined ||
-      children === null
+      children === null ||
+      children === false
     ) {
       childElement = emptyState
     }


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/421

### Changes

When ResourceList.Body receives boolean false for its children, then it should render the empty state rather than a blank.

### Screenshots

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/10736577/71223410-c6893980-2288-11ea-96d8-a3e975e7d9ee.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
