### PR TITLE
Introduce LinkButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 1.1.1 (Unreleased)
 
+- [#424](https://github.com/influxdata/clockface/pull/424): Introduce `LinkButton` component as a composed variation of `Button`
+
 #### 1.1.0
 
 - [#415](https://github.com/influxdata/clockface/pull/415): Fix `DapperScrollbars` to persist scroll position and prevent jumping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-#### 1.1.0 (Unreleased)
+#### 1.1.1 (Unreleased)
+
+#### 1.1.0
 
 - [#415](https://github.com/influxdata/clockface/pull/415): Fix `DapperScrollbars` to persist scroll position and prevent jumping
 - [#414](https://github.com/influxdata/clockface/pull/414): Introduce `Notification` components for briefly conveying information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 1.1.1 (Unreleased)
 
 - [#424](https://github.com/influxdata/clockface/pull/424): Introduce `LinkButton` component as a composed variation of `Button`
+- [#424](https://github.com/influxdata/clockface/pull/424): Pass back optional event object to `RightClickMenuItem` click handler
 - [#422](https://github.com/influxdata/clockface/pull/422): Render the empty state when ResourceList.Body receives boolean false as children
 
 #### 1.1.0

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "uuid": "^3.2.1"
   },
   "scripts": {
+    "clean": "rm -rf node_modules",
     "start": "rollup -cw",
     "build": "rm -rf dist && NODE_ENV=production rollup -c",
     "ci": "yarn test && yarn lint && yarn typecheck",

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -10,6 +10,7 @@
   font-family: $cf-text-font;
   border-style: solid;
   border-width: $cf-border;
+  text-decoration: none;
   transition:
     background-color 0.25s ease,
     border-color 0.25s ease,

--- a/src/Components/Button/Composed/LinkButton.tsx
+++ b/src/Components/Button/Composed/LinkButton.tsx
@@ -1,0 +1,106 @@
+// Libraries
+import React, {forwardRef} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {ButtonProps} from '../Composed/Button'
+import {IconAndText} from './IconAndText'
+
+// Types
+import {
+  Omit,
+  ComponentStatus,
+  ComponentColor,
+  ComponentSize,
+  ButtonShape,
+  LinkTarget,
+  LinkRel,
+} from '../../../Types'
+
+interface LinkButtonProps
+  extends Omit<
+    ButtonProps,
+    | 'onClick'
+    | 'onMouseOver'
+    | 'onMouseOut'
+    | 'onMouseEnter'
+    | 'onMouseLeave'
+    | 'type'
+  > {
+  /** Destination for link button */
+  href: string
+  /** Where to open to the link */
+  target?: LinkTarget
+  /** Describes the relationship between this document and the linked document */
+  rel?: LinkRel
+}
+
+export type LinkButtonRef = HTMLAnchorElement
+
+export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
+  (
+    {
+      id,
+      rel,
+      text,
+      size,
+      icon,
+      href,
+      style,
+      active,
+      target,
+      tabIndex,
+      titleText,
+      className,
+      testID = 'link-button',
+      shape = ButtonShape.Default,
+      color = ComponentColor.Default,
+      status = ComponentStatus.Default,
+      placeIconAfterText,
+    },
+    ref
+  ) => {
+    const linkButtonClass = classnames(
+      `cf-button cf-button-${size} cf-button-${color}`,
+      {
+        'cf-button-square': shape === ButtonShape.Square,
+        'cf-button-stretch': shape === ButtonShape.StretchToFit,
+        'cf-button--loading': status === ComponentStatus.Loading,
+        'cf-button--disabled': status === ComponentStatus.Disabled,
+        active,
+        [`${className}`]: className,
+      }
+    )
+
+    return (
+      <a
+        id={id}
+        ref={ref}
+        rel={rel}
+        href={href}
+        style={style}
+        title={titleText}
+        color={color}
+        target={target}
+        tabIndex={tabIndex}
+        className={linkButtonClass}
+        data-testid={testID}
+      >
+        <IconAndText
+          placeIconAfterText={placeIconAfterText}
+          text={text}
+          icon={icon}
+        />
+        {status === ComponentStatus.Loading && (
+          <div
+            className={`cf-button-spinner cf-button-spinner--${
+              ComponentSize.Large
+            }`}
+          />
+        )}
+      </a>
+    )
+  }
+)
+
+LinkButton.displayName = 'LinkButton'

--- a/src/Components/Button/Composed/LinkButton.tsx
+++ b/src/Components/Button/Composed/LinkButton.tsx
@@ -30,7 +30,7 @@ interface LinkButtonProps
   /** Destination for link button */
   href: string
   /** Where to open to the link */
-  target?: LinkTarget
+  target?: LinkTarget | string
   /** Describes the relationship between this document and the linked document */
   rel?: LinkRel
 }
@@ -48,7 +48,7 @@ export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
       href,
       style,
       active,
-      target,
+      target = LinkTarget.Self,
       tabIndex,
       titleText,
       className,

--- a/src/Components/Button/Documentation/Button.stories.tsx
+++ b/src/Components/Button/Documentation/Button.stories.tsx
@@ -15,6 +15,7 @@ import {SquareButton, SquareButtonRef} from '../Composed/SquareButton'
 import {ConfirmationButton} from '../Composed/ConfirmationButton'
 import {DismissButton, DismissButtonRef} from '../Composed/DismissButton'
 import {CTAButton, CTAButtonRef} from '../Composed/CTAButton'
+import {LinkButton, LinkButtonRef} from '../Composed/LinkButton'
 
 // Types
 import {
@@ -25,6 +26,8 @@ import {
   ButtonShape,
   ComponentStatus,
   ButtonType,
+  LinkRel,
+  LinkTarget,
 } from '../../../Types'
 
 // Notes
@@ -34,6 +37,7 @@ import SquareButtonReadme from './SquareButton.md'
 import ConfirmationButtonReadme from './ConfirmationButton.md'
 import DismissButtonReadme from './DismissButton.md'
 import CTAButtonReadme from './CTAButton.md'
+import LinkButtonReadme from './LinkButton.md'
 import ButtonBaseContrastTesterReadme from './ButtonBaseContrastTester.md'
 
 const buttonBaseStories = storiesOf(
@@ -370,6 +374,64 @@ buttonBaseStories.add(
   {
     readme: {
       content: marked(ButtonBaseReadme),
+    },
+  }
+)
+
+buttonComposedStories.add(
+  'LinkButton',
+  () => {
+    const buttonRef = createRef<LinkButtonRef>()
+
+    const logRef = (): void => {
+      /* eslint-disable */
+      console.log(buttonRef.current)
+      /* eslint-enable */
+    }
+
+    return (
+      <div className="story--example">
+        <LinkButton
+          href={text('href', 'http://www.example.com')}
+          target={
+            LinkTarget[select('target', mapEnumKeys(LinkTarget), 'Blank')]
+          }
+          rel={
+            LinkRel[
+              select('rel', {None: 'none', ...mapEnumKeys(LinkRel)}, 'None')
+            ]
+          }
+          ref={buttonRef}
+          icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Zap')]}
+          text={text('text', 'Yeehaw')}
+          titleText={text('titleText', 'Title Text')}
+          color={
+            ComponentColor[
+              select('color', mapEnumKeys(ComponentColor), 'Default')
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          status={
+            ComponentStatus[
+              select('status', mapEnumKeys(ComponentStatus), 'Default')
+            ]
+          }
+          shape={
+            ButtonShape[select('shape', mapEnumKeys(ButtonShape), 'Default')]
+          }
+          active={boolean('active', false)}
+        />
+        <div className="story--test-buttons">
+          <button onClick={logRef}>Log Ref</button>
+        </div>
+      </div>
+    )
+  },
+  {
+    readme: {
+      content: marked(LinkButtonReadme),
     },
   }
 )

--- a/src/Components/Button/Documentation/LinkButton.md
+++ b/src/Components/Button/Documentation/LinkButton.md
@@ -14,6 +14,10 @@ import {LinkButton} from '@influxdata/clockface'
 
 Specifies where to open the linked document
 
+```tsx
+import {LinkTarget} from '@influxdata/clockface'
+```
+
 | Target | Opens in |
 |:----------|:---------------------------------------------------|
 | `_blank` | A new window or tab |
@@ -25,6 +29,10 @@ Specifies where to open the linked document
 ### Rel
 
 Specifies the relationship between the current document and the linked document
+
+```tsx
+import {LinkRel} from '@influxdata/clockface'
+```
 
 | Rel | Description |
 |:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/Components/Button/Documentation/LinkButton.md
+++ b/src/Components/Button/Documentation/LinkButton.md
@@ -10,6 +10,38 @@ import {LinkButton} from '@influxdata/clockface'
 ### Example
 <!-- STORY -->
 
+### Target
+
+Specifies where to open the linked document
+
+| Target | Opens in |
+|:----------|:---------------------------------------------------|
+| `_blank` | A new window or tab |
+| `_self` | The same frame as it was clicked (this is default) |
+| `_parent` | The parent frame |
+| `_top` | The full body of the window |
+| framename | A named frame |
+
+### Rel
+
+Specifies the relationship between the current document and the linked document
+
+| Rel | Description |
+|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `alternate` | Provides a link to an alternate representation of the document (i.e. print page, translated or mirror) |
+| `author` | Provides a link to the author of the document |
+| `bookmark` | Permanent URL used for bookmarking |
+| `external` | Indicates that the referenced document is not part of the same site as the current document |
+| `help` | Provides a link to a help document |
+| `license` | Provides a link to licensing information for the document |
+| `next` | Provides a link to the next document in the series |
+| `nofollow` | Links to an unendorsed document, like a paid link.("nofollow" is used by Google, to specify that the Google search spider should not follow that link) |
+| `noreferrer` | Requires that the browser should not send an HTTP referrer header if the user follows the hyperlink |
+| `noopener` | Requires that any browsing context created by following the hyperlink must not have an opener browsing context |
+| `prev` | Provides a link to the previous document in the series |
+| `search` | Links to a search tool for the document |
+| `tag` | A tag (keyword) for the current document |
+
 <!-- STORY HIDE START -->
 
 <!-- STORY HIDE END -->

--- a/src/Components/Button/Documentation/LinkButton.md
+++ b/src/Components/Button/Documentation/LinkButton.md
@@ -1,0 +1,17 @@
+# LinkButton
+
+This composed variation of `BaseButton` functions almost identically to `Button` except the underlying HTML element is an anchor tag, and the props interface is slightly different to match the properties of anchor tags.
+
+### Usage
+```tsx
+import {LinkButton} from '@influxdata/clockface'
+```
+
+### Example
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/RightClick/Base/RightClickMenuItem.tsx
+++ b/src/Components/RightClick/Base/RightClickMenuItem.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef} from 'react'
+import React, {forwardRef, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Types
@@ -7,7 +7,7 @@ import {StandardFunctionProps} from '../../../Types'
 
 export interface RightClickMenuItemProps extends StandardFunctionProps {
   /** Click handler */
-  onClick: (value?: any) => void
+  onClick: (value?: any, e?: MouseEvent<HTMLLIElement>) => void
   /** Disabled */
   disabled?: boolean
   /** Optional return value */
@@ -41,12 +41,12 @@ export const RightClickMenuItem = forwardRef<
       }
     )
 
-    const handleClick = (): void => {
+    const handleClick = (e: MouseEvent<HTMLLIElement>): void => {
       if (disabled) {
         return
       }
 
-      onClick(value)
+      onClick(value, e)
     }
 
     return (

--- a/src/Styles/typography.scss
+++ b/src/Styles/typography.scss
@@ -12,8 +12,8 @@ body {
 
 // Base Link Styles
 // -----------------------------------------------------------------------------
-a:link,
-a:visited {
+a:not(.cf-button):link,
+a:not(.cf-button):visited {
   color: $cf-link-default;
   transition: color 0.25s ease;
   text-decoration: none;
@@ -32,8 +32,8 @@ a:visited {
     color: $cf-text-secondary;
   }
 }
-a:hover,
-a:active {
+a:not(.cf-button):hover,
+a:not(.cf-button):active {
   color: $cf-link-default-hover;
   text-decoration: none;
 

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -448,3 +448,26 @@ export interface Coordinates {
   x: number
   y: number
 }
+
+export enum LinkTarget {
+  Blank = '_blank',
+  Parent = '_parent',
+  Self = '_self',
+  Top = '_top',
+}
+
+export enum LinkRel {
+  Alternate = 'alternate',
+  Author = 'author',
+  Bookmark = 'bookmark',
+  External = 'external',
+  Help = 'help',
+  License = 'license',
+  Next = 'next',
+  NoFollow = 'nofollow',
+  NoOpener = 'noopener',
+  NoReferrer = 'noreferrer',
+  Prev = 'prev',
+  Search = 'search',
+  Tag = 'tag',
+}


### PR DESCRIPTION
Closes #420 
Closes #419 

### Changes

- Introduce `LinkButton` component
- Create enums for `target` and `rel` props of anchor elements
- Pass back optional event object to `RightClickMenuItem` click handler

### Screenshots

![Screen Shot 2020-01-02 at 9 29 09 AM](https://user-images.githubusercontent.com/2433762/71681751-6394a980-2d42-11ea-97c1-c7796e98db88.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
