### PR TITLE
fix testID override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.1.1 (Unreleased)
 
+- [#426](https://github.com/influxdata/clockface/pull/426): Replace `data-testid` with `testID` props in components overriding testID.
 - [#422](https://github.com/influxdata/clockface/pull/422): Render the empty state when ResourceList.Body receives boolean false as children
 
 #### 1.1.0

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -158,7 +158,7 @@ const ConfirmationContents: FunctionComponent<{
         </span>
       )}
       <Button
-        data-testid={`${testID}--confirm-button`}
+        testID={`${testID}--confirm-button`}
         onClick={handleClick}
         text={confirmationButtonText}
         color={confirmationButtonColor}

--- a/src/Components/DatePicker/Composed/DateRangePicker.tsx
+++ b/src/Components/DatePicker/Composed/DateRangePicker.tsx
@@ -47,7 +47,7 @@ export const DateRangePicker = forwardRef<
 
   return (
     <FlexBox.FlexBox ref={ref} direction={FlexDirection.Column} style={style}>
-      <FlexBox direction={FlexDirection.Row} data-testid={testID}>
+      <FlexBox direction={FlexDirection.Row} testID={testID}>
         <DatePicker
           dateTime={lower}
           onSelectDate={handleSelectLower}

--- a/src/Components/Panel/Composed/PanelSymbolHeader.tsx
+++ b/src/Components/Panel/Composed/PanelSymbolHeader.tsx
@@ -63,7 +63,7 @@ export const PanelSymbolHeader = forwardRef<
         className={panelSymbolHeaderClassName}
         direction={direction}
         alignItems={alignItems}
-        data-testid={testID}
+        testID={testID}
         justifyContent={justifyContent}
       >
         <div className="cf-panel--symbol-header--title">

--- a/src/Components/Panel/Family/PanelBody.tsx
+++ b/src/Components/Panel/Family/PanelBody.tsx
@@ -51,7 +51,7 @@ export const PanelBody = forwardRef<PanelBodyRef, PanelBodyProps>(
         className={panelBodyClass}
         direction={direction}
         alignItems={alignItems}
-        data-testid={testID}
+        testID={testID}
         justifyContent={justifyContent}
         stretchToFitWidth={true}
       >

--- a/src/Components/Panel/Family/PanelFooter.tsx
+++ b/src/Components/Panel/Family/PanelFooter.tsx
@@ -46,7 +46,7 @@ export const PanelFooter = forwardRef<PanelFooterRef, PanelFooterProps>(
         direction={direction}
         className={panelFooterClass}
         alignItems={alignItems}
-        data-testid={testID}
+        testID={testID}
         justifyContent={justifyContent}
         stretchToFitWidth={true}
       >

--- a/src/Components/Panel/Family/PanelHeader.tsx
+++ b/src/Components/Panel/Family/PanelHeader.tsx
@@ -52,7 +52,7 @@ export const PanelHeader = forwardRef<PanelHeaderRef, PanelHeaderProps>(
         className={panelHeaderClass}
         direction={direction}
         alignItems={alignItems}
-        data-testid={testID}
+        testID={testID}
         justifyContent={justifyContent}
         stretchToFitWidth={true}
       >

--- a/src/Components/Tabs/TabsContainer.tsx
+++ b/src/Components/Tabs/TabsContainer.tsx
@@ -45,7 +45,7 @@ export const TabsContainer = forwardRef<TabsContainerRef, TabsContainerProps>(
     return (
       <FlexBox.FlexBox
         className={className}
-        data-testid={testID}
+        testID={testID}
         id={id}
         ref={ref}
         style={style}


### PR DESCRIPTION
Closes #425

### Changes
Replace `data-testid` with `testID` props in components overriding testID.

### Screenshots
PanelHeader now displays correct testID.
![image](https://user-images.githubusercontent.com/11937365/71940166-2e38f300-316a-11ea-99f6-b99f04e22fe3.png)


### Checklist
Check all that apply

- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
