### PR TITLE
feat: export variables.scss as a plain scss file for import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-#### 1.1.6 (Unreleased)
+#### 1.2.0
+
+- [#436](https://github.com/influxdata/clockface/pull/436): variables.scss is now exported as part of the clockface bundle `@influxdata/clockface/dist/variables.scss`
 
 #### 1.1.5
 
-- [ #433](https://github.com/influxdata/clockface/pull/433): Fix `Notification` component exports
+- [#433](https://github.com/influxdata/clockface/pull/433): Fix `Notification` component exports
 
 #### 1.1.4
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,10 @@ let plugins = [
     },
   }),
   copy({
-    targets: [{src: 'src/Styles/Fonts', dest: 'dist'}],
+    targets: [
+      {src: 'src/Styles/Fonts', dest: 'dist'},
+      {src: 'src/Styles/variables.scss', dest: 'dist'},
+    ],
   }),
   sourceMaps(),
 ]


### PR DESCRIPTION
Closes #

### Changes

Exports ours variables.scss file as a plain scss file so anything that depends on clockface can access its variables.

this would allow us to do something like the following in Influxdb or giraffe
```scss
@import "reset";
@import "@influxdata/clockface/dist/variables.scss";
@import "mixins";
```

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass