### PR TITLE
Improve TreeNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#464](https://github.com/influxdata/clockface/pull/464): Allow optional `shortLabel` on `TreeNavItem` strictly for display when `TreeNav` is collapsed
 - [#464](https://github.com/influxdata/clockface/pull/464): Make `TreeNavSubMenu` visible so long as the entire `TreeNav` is visible
 - [#464](https://github.com/influxdata/clockface/pull/464): Allow `TreeNav` to be opened and closed on small screens independently of the `expanded` prop
+- [#464](https://github.com/influxdata/clockface/pull/464): Allow banner element to optionally remain visible when `TreeNav` is collapsed
 
 #### 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#464](https://github.com/influxdata/clockface/pull/464): Ensure `testID` prop is assigned to `TreeNav` children using `linkElement` prop
 - [#464](https://github.com/influxdata/clockface/pull/464): Allow optional `shortLabel` on `TreeNavItem` strictly for display when `TreeNav` is collapsed
 - [#464](https://github.com/influxdata/clockface/pull/464): Make `TreeNavSubMenu` visible so long as the entire `TreeNav` is visible
-
+- [#464](https://github.com/influxdata/clockface/pull/464): Allow `TreeNav` to be opened and closed on small screens independently of the `expanded` prop
 
 #### 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-#### 2.0.2 (Unreleased)
+#### 2.0.3 (Unreleased)
+
+- [#464](https://github.com/influxdata/clockface/pull/464): Ensure `testID` prop is assigned to `TreeNav` children using `linkElement` prop
+- [#464](https://github.com/influxdata/clockface/pull/464): Allow optional `shortLabel` on `TreeNavItem` strictly for display when `TreeNav` is collapsed
+- [#464](https://github.com/influxdata/clockface/pull/464): Make `TreeNavSubMenu` visible so long as the entire `TreeNav` is visible
+
+
+#### 2.0.2
 
 - [#453](https://github.com/influxdata/clockface/pull/453): Add Sun & Moon icons to icon font
 - [#451](https://github.com/influxdata/clockface/pull/451): Add optional `title` prop to `DropdownItem`

--- a/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
+++ b/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
@@ -510,10 +510,10 @@ layoutStories.add(
       {id: 'user', label: 'JohnDoe (OrgName)'},
       {id: 'data', label: 'Data'},
       {id: 'data-buckets', label: 'Buckets'},
-      {id: 'data-sources', label: 'Sources'},
-      {id: 'queries', label: 'Queries'},
-      {id: 'boards', label: 'Boards'},
-      {id: 'team', label: 'Team'},
+      {id: 'data-sources', label: 'Data Sources'},
+      {id: 'explore', label: 'Data Explorer'},
+      {id: 'boards', label: 'Dashboards'},
+      {id: 'org', label: 'Organization'},
       {id: 'tasks', label: 'Tasks'},
       {id: 'alerts', label: 'Alerts'},
       {id: 'settings', label: 'Settings'},
@@ -619,24 +619,27 @@ layoutStories.add(
                 </TreeNav.SubMenu>
               </TreeNav.Item>
               <TreeNav.Item
-                id="queries"
-                label="Queries"
+                id="explore"
+                label="Data Explorer"
+                shortLabel="Explore"
                 icon={<Icon glyph={IconFont.GraphLine} />}
-                active={isItemActive('queries')}
+                active={isItemActive('explore')}
                 onClick={handleNavClick}
               />
               <TreeNav.Item
                 id="boards"
-                label="Boards"
+                label="Dashboards"
+                shortLabel="Boards"
                 icon={<Icon glyph={IconFont.Dashboards} />}
                 active={isItemActive('boards')}
                 onClick={handleNavClick}
               />
               <TreeNav.Item
-                id="team"
-                label="Team"
+                id="org"
+                label="Organization"
+                shortLabel="Org"
                 icon={<Icon glyph={IconFont.UsersDuo} />}
-                active={isItemActive('team')}
+                active={isItemActive('org')}
                 onClick={handleNavClick}
               />
               <TreeNav.Item

--- a/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
+++ b/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
@@ -572,8 +572,8 @@ layoutStories.add(
                 />
               }
               bannerElement={banner}
-              showBannerWhenCollapsed={boolean(
-                'showBannerWhenCollapsed',
+              hideBannerWhenCollapsed={boolean(
+                'hideBannerWhenCollapsed',
                 false
               )}
               expanded={navState}

--- a/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
+++ b/src/Components/AppWrapper/Documentation/AppWrapper.stories.tsx
@@ -572,6 +572,10 @@ layoutStories.add(
                 />
               }
               bannerElement={banner}
+              showBannerWhenCollapsed={boolean(
+                'showBannerWhenCollapsed',
+                false
+              )}
               expanded={navState}
               onToggleClick={handleToggleNavState}
               userElement={

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -275,14 +275,18 @@ a.cf-tree-nav--item-block:active {
   font-size: 1.7em;
 }
 
+.cf-tree-nav--label,
+.cf-tree-nav--short-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .cf-tree-nav--label {
   flex: 1 0 0;
   display: flex;
   font-size: 1.25em;
   font-weight: $cf-font-weight--medium;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   text-align: center;
 }
 

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -286,6 +286,10 @@ a.cf-tree-nav--item-block:active {
   text-align: center;
 }
 
+.cf-tree-nav--short-label {
+  display: none;
+}
+
 .cf-tree-nav--expander {
   width: $cf-tree-nav__small-height;
   height: $cf-tree-nav__small-height;
@@ -476,6 +480,7 @@ $cf-tree-nav--user-padding: (($cf-tree-nav--user-block - $cf-tree-nav--avatar-ra
     margin-right: $cf-marg-d;
   }
 }
+
 .cf-tree-nav--username,
 .cf-tree-nav--team {
   text-align: left;
@@ -659,6 +664,10 @@ a.cf-tree-nav--user-item:hover {
     width: $cf-tree-nav__width;
     
     .cf-tree-nav--label {
+      display: none;
+    }
+
+    .cf-tree-nav--short-label {
       display: block;
       font-size: 0.9em;
       font-weight: $cf-font-weight--medium;
@@ -669,9 +678,6 @@ a.cf-tree-nav--user-item:hover {
       width: $cf-tree-nav__width - $cf-marg-b;
     }
 
-    .cf-tree-nav--header .cf-tree-nav--label {
-      display: none;
-    }
     .cf-tree-nav--sub-menu,
     .cf-tree-nav--expander,
     .cf-tree-nav--banner,

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -6,8 +6,7 @@
 */
 
 
-.cf-tree-nav,
-.cf-tree-nav__collapsed {
+.cf-tree-nav {
   width: 100%;
   user-select: none;
 }
@@ -23,10 +22,10 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  
-  .cf-tree-nav__collapsed & {
-    display: none;
-  }
+}
+
+.cf-tree-nav__mobile-collapsed .cf-tree-nav--menu {
+  display: none;
 }
 
 .cf-tree-nav--scroll-area {
@@ -35,6 +34,10 @@
 }
 
 .cf-tree-nav--toggle {
+  display: none;
+}
+
+.cf-tree-nav--mobile-toggle {
   width: $cf-tree-nav__small-height;
   height: $cf-tree-nav__small-height;
   flex: 0 0 $cf-tree-nav__small-height;
@@ -45,10 +48,6 @@
 
   &:hover {
     cursor: pointer;
-  }
-
-  > .cf-icon {
-    display: none;
   }
 }
 
@@ -83,14 +82,14 @@
     transform: translate(-50%, 0%) rotate(-45deg);
   }
 
-  .cf-tree-nav__collapsed & {
+  .cf-tree-nav__mobile-collapsed & {
     background-color: $g20-white;
   }
 
-  .cf-tree-nav__collapsed &:before {
+  .cf-tree-nav__mobile-collapsed &:before {
     transform: translate(-50%, 300%);
   }
-  .cf-tree-nav__collapsed &:after {
+  .cf-tree-nav__mobile-collapsed &:after {
     transform: translate(-50%, -300%);
   }
 }
@@ -590,7 +589,9 @@ a.cf-tree-nav--user-item:hover {
     z-index: $cf-z--nav-menu;
   }
 
-  .cf-tree-nav--menu {
+  .cf-tree-nav--menu,
+  .cf-tree-nav__mobile-collapsed .cf-tree-nav--menu {
+    display: flex;
     background-color: transparent;
     position: relative !important;
     height: auto !important;
@@ -603,14 +604,13 @@ a.cf-tree-nav--user-item:hover {
       display: flex;
     }
   }
-
-  .cf-tree-nav--hamburger {
+  
+  .cf-tree-nav--mobile-toggle {
     display: none;
   }
 
   .cf-tree-nav--toggle {
-    top: initial;
-    right: initial;
+    display: block;
     width: 100%;
     height: 30px;
     flex: 0 0 30px;
@@ -621,6 +621,7 @@ a.cf-tree-nav--user-item:hover {
     transition: color 0.25s ease, background-color 0.25s ease;
 
     &:hover {
+      cursor: pointer;
       background-color: $cf-tree-nav__bg-hover;
       color: $cf-tree-nav__toggle-icon-hover;
     }

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -343,6 +343,9 @@ a.cf-tree-nav--item-block:active {
   a.cf-tree-nav--item-block:after {
     opacity: 1;
   }
+}
+
+.cf-tree-nav--item__active {
   .cf-tree-nav--expander:before,
   .cf-tree-nav--expander:after {
     background-color: $cf-tree-nav__text-active;
@@ -351,7 +354,7 @@ a.cf-tree-nav--item-block:active {
     transform: translate(-50%, -50%) rotate(0deg);
   }
   .cf-tree-nav--sub-menu {
-    display: flex;
+    background-color: $cf-tree-nav__bg-active;
   }
 }
 
@@ -361,12 +364,11 @@ a.cf-tree-nav--item-block:active {
 */
 
 .cf-tree-nav--sub-menu {
-  display: none;
+  display: flex;
   flex-direction: column;
   align-items: stretch;
-  padding-left: calc(#{$cf-tree-nav__width} - 0.75em);
+  padding-left: calc(#{$cf-tree-nav__width} - 1.5em);
   padding-bottom: $cf-marg-b;
-  background-color: $cf-tree-nav__bg-active;
 }
 
 .cf-tree-nav--sub-item {
@@ -402,10 +404,6 @@ a.cf-tree-nav--sub-item-label:active {
   .cf-tree-nav--sub-item-label:hover {
     background-color: $cf-tree-nav__sub-item-bg-active;
     color: $cf-tree-nav__sub-item-text-active;
-  }
-
-  .cf-tree-nav--sub-menu {
-    display: flex;
   }
 }
 
@@ -658,6 +656,10 @@ a.cf-tree-nav--user-item:hover {
       content: '';
       width: $cf-tree-nav__width * 0.2;
     }
+  }
+
+  .cf-tree-nav--sub-menu {
+    padding-left: calc(#{$cf-tree-nav__width} - 0.75em);
   }
 
   /*

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -546,6 +546,7 @@ a.cf-tree-nav--user-item:active {
   padding-left: $cf-tree-nav--user-block + $cf-border;
   color: $cf-tree-nav__sub-item-text;
   transition: color 0.25s ease, background-color 0.25s ease;
+  white-space: nowrap;
 }
 
 .cf-tree-nav--user-item:hover,

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -31,6 +31,18 @@
 .cf-tree-nav--scroll-area {
   flex: 1 0 0;
   display: block;
+
+  .cf-dapper-scrollbars--content {
+    display: flex !important;
+    flex-direction: column;
+  }
+}
+
+.cf-tree-nav--children {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .cf-tree-nav--toggle {
@@ -562,6 +574,11 @@ a.cf-tree-nav--user-item:hover {
 .cf-tree-nav--banner {
   padding: $cf-marg-c;
   display: block;
+}
+
+.cf-tree-nav--banner-spacer {
+  flex: 1 0 0;
+  width: 100%;
 }
 
 /*

--- a/src/Components/TreeNav/TreeNav.scss
+++ b/src/Components/TreeNav/TreeNav.scss
@@ -305,38 +305,6 @@ a.cf-tree-nav--item-block:active {
   display: none;
 }
 
-.cf-tree-nav--expander {
-  width: $cf-tree-nav__small-height;
-  height: $cf-tree-nav__small-height;
-  flex: 0 0 $cf-tree-nav__small-height;
-  position: relative;
-  
-  &:before,
-  &:after {
-    content: '';
-    width: $cf-tree-nav__small-height * 0.2;
-    height: $cf-border;
-    background-color: $cf-tree-nav__text;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    border-radius: $cf-border / 2;
-    transition: transform 0.25s ease, background-color 0.25s ease;
-  }
-  
-  &:before {
-    transform: translate(-50%, -50%) rotate(0deg);
-  }
-  &:after {
-    transform: translate(-50%, -50%) rotate(90deg);
-  }
-
-  .cf-tree-nav--item-block:hover &:before,
-  .cf-tree-nav--item-block:hover &:after {
-    background-color: $cf-tree-nav__text-hover;
-  }
-}
-
 .cf-tree-nav--item__active {
   &.cf-tree-nav--item:after {
     opacity: 1;
@@ -355,16 +323,7 @@ a.cf-tree-nav--item-block:active {
   a.cf-tree-nav--item-block:after {
     opacity: 1;
   }
-}
 
-.cf-tree-nav--item__active {
-  .cf-tree-nav--expander:before,
-  .cf-tree-nav--expander:after {
-    background-color: $cf-tree-nav__text-active;
-  }
-  .cf-tree-nav--expander:after {
-    transform: translate(-50%, -50%) rotate(0deg);
-  }
   .cf-tree-nav--sub-menu {
     background-color: $cf-tree-nav__bg-active;
   }
@@ -663,18 +622,6 @@ a.cf-tree-nav--user-item:hover {
     flex: 0 0 $cf-tree-nav__width;
   }
 
-  .cf-tree-nav--expander {
-    width: $cf-tree-nav__width;
-    height: $cf-tree-nav__width;
-    flex: 0 0 $cf-tree-nav__width;
-    
-    &:before,
-    &:after {
-      content: '';
-      width: $cf-tree-nav__width * 0.2;
-    }
-  }
-
   .cf-tree-nav--sub-menu {
     padding-left: calc(#{$cf-tree-nav__width} - 0.75em);
   }
@@ -704,10 +651,16 @@ a.cf-tree-nav--user-item:hover {
     }
 
     .cf-tree-nav--sub-menu,
-    .cf-tree-nav--expander,
-    .cf-tree-nav--banner,
     .cf-tree-nav--user-caret,
     .cf-tree-nav--avatar-label {
+      display: none;
+    }
+
+    .cf-tree-nav--banner {
+      padding: $cf-marg-a;
+    }
+
+    .cf-tree-nav--banner:not(.cf-tree-nav--banner__always-visible) {
       display: none;
     }
 

--- a/src/Components/TreeNav/TreeNav.tsx
+++ b/src/Components/TreeNav/TreeNav.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef} from 'react'
+import React, {forwardRef, useState} from 'react'
 import classnames from 'classnames'
 import _ from 'lodash'
 
@@ -27,6 +27,7 @@ export interface TreeNavProps extends StandardFunctionProps {
 }
 
 export type TreeNavRef = HTMLElement
+export type TreeNavMobileState = 'expanded' | 'collapsed'
 
 export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
   (
@@ -44,8 +45,13 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
     },
     ref
   ) => {
+    const [mobileState, setMobileState] = useState<TreeNavMobileState>(
+      'collapsed'
+    )
+
     const navMenuRootClass = classnames('cf-tree-nav', {
       'cf-tree-nav__collapsed': !expanded,
+      'cf-tree-nav__mobile-collapsed': mobileState === 'collapsed',
       [`${className}`]: className,
     })
 
@@ -61,9 +67,16 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
       toggleElement = (
         <div className="cf-tree-nav--toggle" onClick={onToggleClick}>
           <Icon glyph={toggleIcon} />
-          <div className="cf-tree-nav--hamburger" />
         </div>
       )
+    }
+
+    const handleMobileToggleClick = (): void => {
+      if (mobileState === 'expanded') {
+        setMobileState('collapsed')
+      } else {
+        setMobileState('expanded')
+      }
     }
 
     return (
@@ -86,6 +99,12 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
           </DapperScrollbars>
         </div>
         {toggleElement}
+        <div
+          className="cf-tree-nav--mobile-toggle"
+          onClick={handleMobileToggleClick}
+        >
+          <div className="cf-tree-nav--hamburger" />
+        </div>
       </nav>
     )
   }

--- a/src/Components/TreeNav/TreeNav.tsx
+++ b/src/Components/TreeNav/TreeNav.tsx
@@ -59,7 +59,12 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
     let toggleElement = <></>
 
     if (bannerElement && expanded) {
-      banner = <div className="cf-tree-nav--banner">{bannerElement}</div>
+      banner = (
+        <>
+          <div className="cf-tree-nav--banner-spacer" />
+          <div className="cf-tree-nav--banner">{bannerElement}</div>
+        </>
+      )
     }
 
     if (onToggleClick) {

--- a/src/Components/TreeNav/TreeNav.tsx
+++ b/src/Components/TreeNav/TreeNav.tsx
@@ -25,7 +25,7 @@ export interface TreeNavProps extends StandardFunctionProps {
   /** User widget to appear below the header element */
   userElement?: JSX.Element
   /** Controls how the Banner element renders when in collapsed state */
-  showBannerWhenCollapsed?: boolean
+  hideBannerWhenCollapsed?: boolean
 }
 
 export type TreeNavRef = HTMLElement
@@ -44,7 +44,7 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
       bannerElement,
       onToggleClick,
       headerElement,
-      showBannerWhenCollapsed = false,
+      hideBannerWhenCollapsed = false,
     },
     ref
   ) => {
@@ -63,7 +63,7 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
 
     if (bannerElement) {
       const bannerClass = classnames('cf-tree-nav--banner', {
-        'cf-tree-nav--banner__always-visible': showBannerWhenCollapsed,
+        'cf-tree-nav--banner__always-visible': !hideBannerWhenCollapsed,
       })
 
       banner = (

--- a/src/Components/TreeNav/TreeNav.tsx
+++ b/src/Components/TreeNav/TreeNav.tsx
@@ -24,6 +24,8 @@ export interface TreeNavProps extends StandardFunctionProps {
   bannerElement?: JSX.Element
   /** User widget to appear below the header element */
   userElement?: JSX.Element
+  /** Controls how the Banner element renders when in collapsed state */
+  showBannerWhenCollapsed?: boolean
 }
 
 export type TreeNavRef = HTMLElement
@@ -42,6 +44,7 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
       bannerElement,
       onToggleClick,
       headerElement,
+      showBannerWhenCollapsed = false,
     },
     ref
   ) => {
@@ -58,11 +61,15 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
     let banner = <></>
     let toggleElement = <></>
 
-    if (bannerElement && expanded) {
+    if (bannerElement) {
+      const bannerClass = classnames('cf-tree-nav--banner', {
+        'cf-tree-nav--banner__always-visible': showBannerWhenCollapsed,
+      })
+
       banner = (
         <>
           <div className="cf-tree-nav--banner-spacer" />
-          <div className="cf-tree-nav--banner">{bannerElement}</div>
+          <div className={bannerClass}>{bannerElement}</div>
         </>
       )
     }

--- a/src/Components/TreeNav/TreeNavHeader.tsx
+++ b/src/Components/TreeNav/TreeNavHeader.tsx
@@ -62,7 +62,7 @@ export const TreeNavHeader = forwardRef<TreeNavHeaderRef, TreeNavHeaderProps>(
       )
       const link = React.cloneElement(
         linkElement(navMenuHeaderClass),
-        [],
+        {'data-testid': testID},
         linkItems
       )
 

--- a/src/Components/TreeNav/TreeNavItem.tsx
+++ b/src/Components/TreeNav/TreeNavItem.tsx
@@ -12,6 +12,8 @@ export interface TreeNavItemProps extends Omit<StandardFunctionProps, 'id'> {
   icon: JSX.Element
   /** Label to appear to the right of the icon, only visible when expanded */
   label: string
+  /** Optional label displayed when the TreeNav is collapsed */
+  shortLabel?: string
   /** Click behavior */
   onClick?: (id: string) => void
   /** Controls state of item */
@@ -34,6 +36,7 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
       onClick,
       children,
       className,
+      shortLabel,
       linkElement,
     },
     ref
@@ -60,6 +63,7 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
         <>
           <div className="cf-tree-nav--square">{icon}</div>
           <div className="cf-tree-nav--label">{label}</div>
+          <div className="cf-tree-nav--short-label">{shortLabel || label}</div>
           {expandIcon}
         </>
       )
@@ -89,6 +93,7 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
         >
           <div className="cf-tree-nav--square">{icon}</div>
           <div className="cf-tree-nav--label">{label}</div>
+          <div className="cf-tree-nav--short-label">{shortLabel || label}</div>
           {expandIcon}
         </div>
         {children}

--- a/src/Components/TreeNav/TreeNavItem.tsx
+++ b/src/Components/TreeNav/TreeNavItem.tsx
@@ -52,19 +52,12 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
       }
     }
 
-    let expandIcon = <></>
-
-    if (React.Children.count(children) > 0) {
-      expandIcon = <span className="cf-tree-nav--expander" />
-    }
-
     if (linkElement) {
       const linkItems = (
         <>
           <div className="cf-tree-nav--square">{icon}</div>
           <div className="cf-tree-nav--label">{label}</div>
           <div className="cf-tree-nav--short-label">{shortLabel || label}</div>
-          {expandIcon}
         </>
       )
       const link = React.cloneElement(
@@ -94,7 +87,6 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
           <div className="cf-tree-nav--square">{icon}</div>
           <div className="cf-tree-nav--label">{label}</div>
           <div className="cf-tree-nav--short-label">{shortLabel || label}</div>
-          {expandIcon}
         </div>
         {children}
       </div>

--- a/src/Components/TreeNav/TreeNavItem.tsx
+++ b/src/Components/TreeNav/TreeNavItem.tsx
@@ -69,7 +69,7 @@ export const TreeNavItem = forwardRef<TreeNavItemRef, TreeNavItemProps>(
       )
       const link = React.cloneElement(
         linkElement('cf-tree-nav--item-block'),
-        [],
+        {'data-testid': testID},
         linkItems
       )
 

--- a/src/Components/TreeNav/TreeNavSubItem.tsx
+++ b/src/Components/TreeNav/TreeNavSubItem.tsx
@@ -48,7 +48,7 @@ export const TreeNavSubItem: FunctionComponent<TreeNavSubItemProps> = ({
   if (linkElement) {
     labelElement = React.cloneElement(
       linkElement('cf-tree-nav--sub-item-label'),
-      [],
+      {'data-testid': testID},
       label
     )
   }

--- a/src/Components/TreeNav/TreeNavUser.tsx
+++ b/src/Components/TreeNav/TreeNavUser.tsx
@@ -44,8 +44,12 @@ export const TreeNavUser = forwardRef<TreeNavUserRef, TreeNavUserProps>(
     if (hasChildren && expandedState) {
       childWrapper = (
         <div className="cf-tree-nav--user-menu">
-          <div className="cf-tree-nav--username">{username}</div>
-          <div className="cf-tree-nav--team">{team}</div>
+          <div className="cf-tree-nav--username" title={username}>
+            {username}
+          </div>
+          <div className="cf-tree-nav--team" title={team}>
+            {team}
+          </div>
           {children}
         </div>
       )
@@ -78,8 +82,12 @@ export const TreeNavUser = forwardRef<TreeNavUserRef, TreeNavUserProps>(
               <Icon glyph={IconFont.User} />
             </div>
             <div className="cf-tree-nav--avatar-label">
-              <div className="cf-tree-nav--username">{username}</div>
-              <div className="cf-tree-nav--team">{team}</div>
+              <div className="cf-tree-nav--username" title={username}>
+                {username}
+              </div>
+              <div className="cf-tree-nav--team" title={team}>
+                {team}
+              </div>
               {caret}
             </div>
           </div>

--- a/src/Components/TreeNav/TreeNavUserItem.tsx
+++ b/src/Components/TreeNav/TreeNavUserItem.tsx
@@ -41,7 +41,11 @@ export const TreeNavUserItem: FunctionComponent<TreeNavUserItemProps> = ({
   }
 
   if (linkElement) {
-    return React.cloneElement(linkElement(treeNavUserItemClass), [], label)
+    return React.cloneElement(
+      linkElement(treeNavUserItemClass),
+      {'data-testid': testID},
+      label
+    )
   }
 
   return (


### PR DESCRIPTION
Closes #463 
Closes #461 
Closes #460 
Closes #458 

### Changes

- Allow `TreeNav` to be opened & closed in mobile mode independently of the `expanded` prop
- Allow optional `shortLabel` prop on `TreeNavItem` to only be displayed when `TreeNav` is collapsed
- Ensure `testID` is assigned when `linkElement` prop is used in any of the `TreeNav` items
- Make sub menus visible so long as `TreeNav` is expanded
- Add `title` attributes to both the username and team elements in `TreeNavUser`

### Screenshots

![tree-nav-sub-menu](https://user-images.githubusercontent.com/2433762/77122440-d5ec6000-69fa-11ea-971c-6ef18920bbd4.gif)
![tree-nav-short-labels](https://user-images.githubusercontent.com/2433762/77122447-dbe24100-69fa-11ea-9fef-46b4b87fe1cb.gif)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
