### PR TITLE
Fix gradient mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.0.3 (Unreleased)
 
+- [#465](https://github.com/influxdata/clockface/pull/465): Fix gradient mixin transparency issue
 - [#464](https://github.com/influxdata/clockface/pull/464): Ensure `testID` prop is assigned to `TreeNav` children using `linkElement` prop
 - [#464](https://github.com/influxdata/clockface/pull/464): Allow optional `shortLabel` on `TreeNavItem` strictly for display when `TreeNav` is collapsed
 - [#464](https://github.com/influxdata/clockface/pull/464): Make `TreeNavSubMenu` visible so long as the entire `TreeNav` is visible

--- a/src/Components/Button/Base/ButtonBaseContrastTester.tsx
+++ b/src/Components/Button/Base/ButtonBaseContrastTester.tsx
@@ -8,6 +8,9 @@ import {ButtonBase, ButtonBaseRef} from './ButtonBase'
 // Types
 import {ComponentColor, ComponentStatus} from '../../../Types'
 
+// Utils
+import {getAverageColorFromLinearGradient} from '../../../Utils/colors'
+
 // Styles
 import './ButtonBaseContrastTester.scss'
 
@@ -117,17 +120,23 @@ export const ButtonBaseContrastTester: FunctionComponent<{}> = () => {
       // Default State
       const defaultStyle = window.getComputedStyle(button.defaultRef.current)
       const defaultColor = `${defaultStyle.color}`
-      const defaultBackground = `${defaultStyle.backgroundColor}`
+      const defaultBackground = getAverageColorFromLinearGradient(
+        `${defaultStyle.backgroundImage}`
+      )
 
       // Active State
       const activeStyle = window.getComputedStyle(button.activeRef.current)
       const activeColor = `${activeStyle.color}`
-      const activeBackground = `${activeStyle.backgroundColor}`
+      const activeBackground = getAverageColorFromLinearGradient(
+        `${activeStyle.backgroundImage}`
+      )
 
       // Disabled State
       const disabledStyle = window.getComputedStyle(button.disabledRef.current)
       const disabledColor = `${disabledStyle.color}`
-      const disabledBackground = `${disabledStyle.backgroundColor}`
+      const disabledBackground = getAverageColorFromLinearGradient(
+        `${disabledStyle.backgroundImage}`
+      )
 
       return {
         default: chroma.contrast(defaultColor, defaultBackground).toFixed(2),

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -201,7 +201,7 @@
   @include buttonColorModifier($c-emerald, mix($c-honeydew, $c-pool, 80%), $c-rainforest, mix($c-krypton, $c-laser, 80%), $g20-white, $g20-white);
 }
 .cf-button-warning {
-  @include buttonColorModifier($c-topaz, $c-pineapple, $c-thunder, $c-daisy, $g4-onyx, $g6-smoke);
+  @include buttonColorModifier($c-topaz, $c-pineapple, $c-thunder, $c-daisy, $g4-onyx, $g4-onyx);
 }
 .cf-button-danger {
   @include buttonColorModifier($c-ruby, $c-curacao, $c-curacao, $c-tungsten, $g20-white, $g20-white);

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -367,38 +367,38 @@ $cf-tree-nav__toggle-icon-hover: $g13-mist;
 */
 
 @mixin gradient-v($startColor, $endColor) {
-  background-color: $startColor;
-  background-image: -moz-linear-gradient(top,  $startColor 0%, $endColor 100%);
-  background-image: -webkit-linear-gradient(top,  $startColor 0%,$endColor 100%);
-  background-image: linear-gradient(to bottom,  $startColor 0%,$endColor 100%);
+  background: $startColor;
+  background: -moz-linear-gradient(top,  $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(top,  $startColor 0%,$endColor 100%);
+  background: linear-gradient(to bottom,  $startColor 0%,$endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=0 );
 }
 @mixin gradient-h($startColor, $endColor) {
-  background-color: $startColor;
-  background-image: -moz-linear-gradient(left,  $startColor 0%, $endColor 100%);
-  background-image: -webkit-linear-gradient(left,  $startColor 0%,$endColor 100%);
-  background-image: linear-gradient(to right,  $startColor 0%,$endColor 100%);
+  background: $startColor;
+  background: -moz-linear-gradient(left,  $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(left,  $startColor 0%,$endColor 100%);
+  background: linear-gradient(to right,  $startColor 0%,$endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 @mixin gradient-diag-up($startColor, $endColor) {
-  background-color: $startColor;
-  background-image: -moz-linear-gradient(45deg,  $startColor 0%, $endColor 100%);
-  background-image: -webkit-linear-gradient(45deg,  $startColor 0%,$endColor 100%);
-  background-image: linear-gradient(45deg,  $startColor 0%,$endColor 100%);
+  background: $startColor;
+  background: -moz-linear-gradient(45deg,  $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(45deg,  $startColor 0%,$endColor 100%);
+  background: linear-gradient(45deg,  $startColor 0%,$endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 @mixin gradient-diag-down($startColor, $endColor) {
-  background-color: $startColor;
-  background-image: -moz-linear-gradient(135deg,  $startColor 0%, $endColor 100%) !important;
-  background-image: -webkit-linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
-  background-image: linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
+  background: $startColor;
+  background: -moz-linear-gradient(135deg,  $startColor 0%, $endColor 100%) !important;
+  background: -webkit-linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
+  background: linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 ) !important;
 }
 @mixin gradient-r($startColor, $endColor) {
-  background-color: $startColor;
-  background-image: -moz-radial-gradient(center, ellipse cover,  $startColor 0%, $endColor 100%);
-  background-image: -webkit-radial-gradient(center, ellipse cover,  $startColor 0%,$endColor 100%);
-  background-image: radial-gradient(ellipse at center,  $startColor 0%,$endColor 100%);
+  background: $startColor;
+  background: -moz-radial-gradient(center, ellipse cover,  $startColor 0%, $endColor 100%);
+  background: -webkit-radial-gradient(center, ellipse cover,  $startColor 0%,$endColor 100%);
+  background: radial-gradient(ellipse at center,  $startColor 0%,$endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 

--- a/src/Utils/colors.ts
+++ b/src/Utils/colors.ts
@@ -1,5 +1,6 @@
 // Libraries
 import {CSSProperties} from 'react'
+import chroma from 'chroma-js'
 
 // Types
 import {Gradients, Gradient, DropdownMenuTheme} from '../Types'
@@ -31,4 +32,21 @@ export const generateInlineCSSGradient = (
   const joinedProperties = [angleText, ...colorsText].join(', ')
 
   return {background: `linear-gradient(${joinedProperties})`}
+}
+
+export const getAverageColorFromLinearGradient = (
+  linearGradient: string
+): string => {
+  const rgbColors = linearGradient.match(
+    /[rR][gG][bB][(]\d+[,]\s\d+[,]\s\d+[)]/g
+  )
+
+  if (rgbColors && rgbColors.length === 2) {
+    const startColor = chroma(rgbColors[0])
+    const stopColor = chroma(rgbColors[1])
+
+    return `${chroma.mix(startColor, stopColor)}`
+  }
+
+  return 'fail'
 }

--- a/src/Utils/colors.ts
+++ b/src/Utils/colors.ts
@@ -41,6 +41,10 @@ export const getAverageColorFromLinearGradient = (
     /[rR][gG][bB][(]\d+[,]\s\d+[,]\s\d+[)]/g
   )
 
+  // This function could fail if a linear gradient string is passed in using hexcodes
+  // Didn't seem worth the time to make it more resilient since it is only
+  // used within the button contrast tester widget
+
   if (rgbColors && rgbColors.length === 2) {
     const startColor = chroma(rgbColors[0])
     const stopColor = chroma(rgbColors[1])


### PR DESCRIPTION
Closes #459

### Changes

- Revert gradient mixins to set only the `background` property in shorthand
- Update contrast tester widget

### Screenshots

![Screen Shot 2020-03-19 at 4 46 38 PM](https://user-images.githubusercontent.com/2433762/77124841-426a5d80-6a01-11ea-8aee-522090851a9d.png)

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
