### PR TITLE
Allow Tab component to accept links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.0.3 (Unreleased)
 
+- [#469](https://github.com/influxdata/clockface/pull/469): Add optional `linkElement` prop to `Tab`
 - [#466](https://github.com/influxdata/clockface/pull/466): Fix `OverlayHeading` overflow issue
 - [#466](https://github.com/influxdata/clockface/pull/466): Enable optional text wrapping in `OverlayHeading`
 - [#466](https://github.com/influxdata/clockface/pull/466): Fix appearance of dismiss buttons in `NotificationDialog`

--- a/src/Components/NavMenu/NavMenuItem.tsx
+++ b/src/Components/NavMenu/NavMenuItem.tsx
@@ -3,13 +3,13 @@ import React, {forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps} from '../../Types'
+import {StandardFunctionProps, RenderLinkElement} from '../../Types'
 
 export interface NavMenuItemProps extends StandardFunctionProps {
   /** Render prop for linked title text */
-  titleLink: (className: string) => JSX.Element
+  titleLink: RenderLinkElement
   /** Render prop for linked icon component */
-  iconLink: (className: string) => JSX.Element
+  iconLink: RenderLinkElement
   /** Controls highlighting of the menu item */
   active: boolean
 }

--- a/src/Components/Tabs/Documentation/Tabs.stories.tsx
+++ b/src/Components/Tabs/Documentation/Tabs.stories.tsx
@@ -83,6 +83,12 @@ tabsStories.add(
             text="Pentagons"
             onClick={handleTabClick}
           />
+          <Tabs.Tab
+            active={activeTab === 'hexagons'}
+            id="hexagons"
+            text="Hexagons (Link)"
+            linkElement={className => <a href="#" className={className} />}
+          />
         </Tabs.Tabs>
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Tabs/Tab.tsx
+++ b/src/Components/Tabs/Tab.tsx
@@ -3,7 +3,7 @@ import React, {forwardRef, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps} from '../../Types'
+import {StandardFunctionProps, RenderLinkElement} from '../../Types'
 
 export interface TabProps extends StandardFunctionProps {
   /** Renders the tab highlighted */
@@ -15,9 +15,11 @@ export interface TabProps extends StandardFunctionProps {
   /** Icon to appear left of the text label */
   icon?: JSX.Element
   /** Function to call when tab is clicked, id of tab is passed in */
-  onClick: (id?: string) => void
+  onClick?: (id?: string) => void
   /** If a function is passed in a dismiss button is rendered in the right of the tab */
   onDismiss?: (id?: string) => void
+  /** Optional link element. Will override onClick prop */
+  linkElement?: RenderLinkElement
 }
 
 export type TabRef = HTMLDivElement
@@ -29,18 +31,21 @@ export const Tab = forwardRef<TabRef, TabProps>(
       icon,
       text,
       style,
+      testID = 'tabs--tab',
       active,
       onClick,
       className,
       onDismiss,
-      testID = 'tabs--tab',
+      linkElement,
     },
     ref
   ) => {
     const handleClick = (e: MouseEvent<HTMLDivElement>): void => {
       e.stopPropagation()
 
-      onClick(id)
+      if (onClick) {
+        onClick(id)
+      }
     }
 
     const handleDismissClick = (e: MouseEvent<HTMLButtonElement>): void => {
@@ -57,15 +62,8 @@ export const Tab = forwardRef<TabRef, TabProps>(
       [`${className}`]: className,
     })
 
-    return (
-      <div
-        ref={ref}
-        className={tabClass}
-        data-testid={testID}
-        id={id}
-        style={style}
-        onClick={handleClick}
-      >
+    const tabContents = (
+      <>
         {icon}
         <span className="cf-tabs--tab-label">{text}</span>
         {onDismiss && (
@@ -77,6 +75,28 @@ export const Tab = forwardRef<TabRef, TabProps>(
             <div className="cf-tabs--tab-dismiss-circle" />
           </button>
         )}
+        <div className="cf-tabs--state-indicator" />
+      </>
+    )
+
+    if (linkElement) {
+      return React.cloneElement(
+        linkElement(tabClass),
+        {'data-testid': testID},
+        tabContents
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={tabClass}
+        data-testid={testID}
+        id={id}
+        style={style}
+        onClick={handleClick}
+      >
+        {tabContents}
       </div>
     )
   }

--- a/src/Components/Tabs/Tabs.scss
+++ b/src/Components/Tabs/Tabs.scss
@@ -78,6 +78,7 @@ a.cf-tabs--tab:visited {
     width: 0;
     top: 0;
     right: 0;
+    border-radius: $cf-radius-sm 0 0 $cf-radius-sm;
   }
 }
 
@@ -152,7 +153,7 @@ a.cf-tabs--tab.cf-tabs--tab__active:hover,
       margin-right: -$tabPadding;
     }
   }
-  .cf-tabs--tab__active .cf-tabs--state-indicator {
+  &.cf-tabs__horizontal .cf-tabs--tab__active .cf-tabs--state-indicator {
     height: floor($tabHeight * 0.18);
   }
 

--- a/src/Components/Tabs/Tabs.scss
+++ b/src/Components/Tabs/Tabs.scss
@@ -5,7 +5,7 @@
   ------------------------------------------------------------------------------
 */
 
-$cf-tab--text: $g11-sidewalk;
+$cf-tab--text: $g9-mountain;
 $cf-tab--text-hover: $g14-chromium;
 $cf-tab--text-active: $g18-cloud;
 $cf-tab--border-color: $g5-pepper;
@@ -37,7 +37,10 @@ $cf-tab--border-color: $g5-pepper;
   }
 }
 
-.cf-tabs--tab {
+.cf-tabs--tab,
+a.cf-tabs--tab:link,
+a.cf-tabs--tab:active,
+a.cf-tabs--tab:visited {
   flex-direction: row;
   display: flex;
   flex-wrap: nowrap;
@@ -46,29 +49,23 @@ $cf-tab--border-color: $g5-pepper;
   color: $cf-tab--text;
   position: relative;
 
-  &:after {
-    content: '';
-    position: absolute;
-    background-color: $cf-tab--border-color;
-    opacity: 0;
-    transition: opacity 0.25s ease, height 0.25s ease, width 0.25s ease;
-  }
-
   &:hover {
     cursor: pointer;
     color: $cf-tab--text-hover;
   }
 
-  &__active,
-  &__active:hover {
-    color: $cf-tab--text-active;
-  }
-
   > .cf-icon {
     display: inline-block;
   }
+}
 
-  .cf-tabs__horizontal &:after {
+.cf-tabs--state-indicator {
+  position: absolute;
+  background-color: $cf-tab--border-color;
+  opacity: 0;
+  transition: opacity 0.25s ease, height 0.25s ease, width 0.25s ease;
+
+  .cf-tabs__horizontal & {
     width: 100%;
     height: 0;
     left: 0;
@@ -76,20 +73,11 @@ $cf-tab--border-color: $g5-pepper;
     border-radius: $cf-radius-sm $cf-radius-sm 0 0;
   }
 
-  .cf-tabs__horizontal &__active:after {
-    opacity: 1;
-  }
-
-  .cf-tabs__vertical &:after {
+  .cf-tabs__vertical & {
     height: 100%;
     width: 0;
     top: 0;
     right: 0;
-  }
-
-  .cf-tabs__vertical &__active:after {
-    width: $cf-marg-b;
-    opacity: 1;
   }
 }
 
@@ -100,6 +88,26 @@ $cf-tab--border-color: $g5-pepper;
   font-weight: $cf-font-weight--medium;
   white-space: nowrap;
   user-select: none;
+}
+
+// Active State
+
+.cf-tabs--tab__active,
+a.cf-tabs--tab__active:link,
+a.cf-tabs--tab__active:visited,
+a.cf-tabs--tab__active:active,
+a.cf-tabs--tab.cf-tabs--tab__active:hover,
+.cf-tabs--tab__active:hover {
+  color: $cf-tab--text-active;
+
+  .cf-tabs__vertical & .cf-tabs--state-indicator {
+    width: $cf-marg-b;
+    opacity: 1;
+  }
+
+  .cf-tabs__horizontal & .cf-tabs--state-indicator {
+    opacity: 1;
+  }
 }
 
 /*
@@ -144,7 +152,7 @@ $cf-tab--border-color: $g5-pepper;
       margin-right: -$tabPadding;
     }
   }
-  .cf-tabs--tab__active:after {
+  .cf-tabs--tab__active .cf-tabs--state-indicator {
     height: floor($tabHeight * 0.18);
   }
 

--- a/src/Components/TreeNav/TreeNavHeader.tsx
+++ b/src/Components/TreeNav/TreeNavHeader.tsx
@@ -3,7 +3,12 @@ import React, {forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps, Omit, ComponentColor} from '../../Types'
+import {
+  StandardFunctionProps,
+  Omit,
+  ComponentColor,
+  RenderLinkElement,
+} from '../../Types'
 
 export interface TreeNavHeaderProps extends Omit<StandardFunctionProps, 'id'> {
   /** Unique identifier for nav item */
@@ -19,7 +24,7 @@ export interface TreeNavHeaderProps extends Omit<StandardFunctionProps, 'id'> {
   /** Click behavior */
   onClick?: (id: string) => void
   /** Optional link element. Will override onClick prop */
-  linkElement?: (className: string) => JSX.Element
+  linkElement?: RenderLinkElement
 }
 
 export type TreeNavHeaderRef = HTMLDivElement

--- a/src/Components/TreeNav/TreeNavItem.tsx
+++ b/src/Components/TreeNav/TreeNavItem.tsx
@@ -3,7 +3,7 @@ import React, {forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps, Omit} from '../../Types'
+import {StandardFunctionProps, Omit, RenderLinkElement} from '../../Types'
 
 export interface TreeNavItemProps extends Omit<StandardFunctionProps, 'id'> {
   /** Unique identifier for nav item */
@@ -19,7 +19,7 @@ export interface TreeNavItemProps extends Omit<StandardFunctionProps, 'id'> {
   /** Controls state of item */
   active?: boolean
   /** Optional link element. Will override onClick prop */
-  linkElement?: (className: string) => JSX.Element
+  linkElement?: RenderLinkElement
 }
 
 export type TreeNavItemRef = HTMLDivElement

--- a/src/Components/TreeNav/TreeNavSubItem.tsx
+++ b/src/Components/TreeNav/TreeNavSubItem.tsx
@@ -3,7 +3,7 @@ import React, {FunctionComponent} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps, Omit} from '../../Types'
+import {StandardFunctionProps, Omit, RenderLinkElement} from '../../Types'
 
 export interface TreeNavSubItemProps extends Omit<StandardFunctionProps, 'id'> {
   /** Unique identifier for nav sub item */
@@ -15,7 +15,7 @@ export interface TreeNavSubItemProps extends Omit<StandardFunctionProps, 'id'> {
   /** Click behavior */
   onClick?: (id: string) => void
   /** Optional link element. Will override onClick prop */
-  linkElement?: (className: string) => JSX.Element
+  linkElement?: RenderLinkElement
 }
 
 export const TreeNavSubItem: FunctionComponent<TreeNavSubItemProps> = ({

--- a/src/Components/TreeNav/TreeNavUserItem.tsx
+++ b/src/Components/TreeNav/TreeNavUserItem.tsx
@@ -3,7 +3,7 @@ import React, {FunctionComponent} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {StandardFunctionProps, Omit} from '../../Types'
+import {StandardFunctionProps, Omit, RenderLinkElement} from '../../Types'
 
 export interface TreeNavUserItemProps
   extends Omit<StandardFunctionProps, 'id'> {
@@ -16,7 +16,7 @@ export interface TreeNavUserItemProps
   /** Click behavior */
   onClick?: (id: string) => void
   /** Optional link element. Will override onClick prop */
-  linkElement?: (className: string) => JSX.Element
+  linkElement?: RenderLinkElement
 }
 
 export const TreeNavUserItem: FunctionComponent<TreeNavUserItemProps> = ({

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -20,6 +20,9 @@ export interface StandardFunctionProps {
 // Standard Validation Function
 export type ValidationFunction = (input: string) => string | null
 
+// Passing in link elements
+export type RenderLinkElement = (className: string) => JSX.Element
+
 // Shared Data Types
 export enum ComponentColor {
   Default = 'default',


### PR DESCRIPTION
Closes #468 

### Changes

- Create a shared type for this type of prop called `RenderLinkElement`
- Refactor `Tab` to offer a `linkElement` prop akin to `TreeNav` components

### Screenshots

![Screen Shot 2020-03-20 at 12 29 51 PM](https://user-images.githubusercontent.com/2433762/77199888-cd516380-6aa6-11ea-9980-8e3d81e1d119.png)
![Screen Shot 2020-03-20 at 12 29 46 PM](https://user-images.githubusercontent.com/2433762/77199890-ce829080-6aa6-11ea-8800-4af57109b2f3.png)


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
