### PR TITLE
Fix ResourceName TestID issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.0.4 (Unreleased)
 
+- [#481](https://github.com/influxdata/clockface/pull/481): Ensure `testID` and `onClick` are attached to the same element in `ResourceName` and `ResourceNameEditable`
 - [#477](https://github.com/influxdata/clockface/pull/477): Fix replace `defaultChecked` with `checked` attribute in `Toggle` component
 - [#474](https://github.com/influxdata/clockface/pull/474): Refactor `VisibilityInput` to manage its state internally by default with the option to override using props
 - [#472](https://github.com/influxdata/clockface/pull/472): Add `Upgrade` and `Cubo` icons to icon font

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -148,7 +148,6 @@ export const ResourceCardEditableName = forwardRef<
         ref={ref}
         style={style}
         className={resourceCardEditableNameClass}
-        data-testid={testID}
       >
         <SpinnerContainer
           loading={loading}
@@ -157,6 +156,7 @@ export const ResourceCardEditableName = forwardRef<
           <span
             className={resourceCardEditableNameLinkClass}
             onClick={handleClick}
+            data-testid={testID}
           >
             <span>{name || noNameString}</span>
           </span>

--- a/src/Components/ResourceList/Card/ResourceCardName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardName.tsx
@@ -36,14 +36,12 @@ export const ResourceCardName = forwardRef<
   }
 
   return (
-    <div
-      id={id}
-      ref={ref}
-      style={style}
-      className={resourceNameClass}
-      data-testid={testID}
-    >
-      <span className={resourceNameLinkClass} onClick={handleClick}>
+    <div id={id} ref={ref} style={style} className={resourceNameClass}>
+      <span
+        className={resourceNameLinkClass}
+        onClick={handleClick}
+        data-testid={testID}
+      >
         <span>{name}</span>
       </span>
     </div>


### PR DESCRIPTION
Closes #478 

### Changes

- Ensure `testID` and `onClick` are attached to the same DOM element

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
