### PR TITLE
Single Hue Gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.0.4 (Unreleased)
 
+- [#483](https://github.com/influxdata/clockface/pull/483): Add single-hue gradients for each color spectrum
 - [#481](https://github.com/influxdata/clockface/pull/481): Ensure `testID` and `onClick` are attached to the same element in `ResourceName` and `ResourceNameEditable`
 - [#477](https://github.com/influxdata/clockface/pull/477): Fix replace `defaultChecked` with `checked` attribute in `Toggle` component
 - [#474](https://github.com/influxdata/clockface/pull/474): Refactor `VisibilityInput` to manage its state internally by default with the option to override using props

--- a/src/Constants/colors.ts
+++ b/src/Constants/colors.ts
@@ -369,25 +369,26 @@ export const influxGradients = {
     start: InfluxColors.Banana,
     stop: InfluxColors.Flan,
   },
+  // Brand Gradients
   WarpSpeed: {
     start: InfluxColors.DeepPurple,
-    stop: InfluxColors.Magenta,
+    stop: InfluxColors.Void,
   },
   PowerStone: {
     start: InfluxColors.Void,
     stop: InfluxColors.Magenta,
   },
   OminousFog: {
-    start: InfluxColors.DeepPurple,
-    stop: InfluxColors.Comet,
+    start: InfluxColors.Pulsar,
+    stop: InfluxColors.Galaxy,
   },
   MilkyWay: {
     start: InfluxColors.Magenta,
-    stop: InfluxColors.Comet,
+    stop: InfluxColors.Galaxy,
   },
   LazyAfternoon: {
     start: InfluxColors.Pool,
-    stop: InfluxColors.Comet,
+    stop: InfluxColors.Galaxy,
   },
   NineteenEightyFour: {
     start: InfluxColors.Pool,
@@ -399,7 +400,7 @@ export const influxGradients = {
   },
   LostGalaxy: {
     start: InfluxColors.DeepPurple,
-    stop: InfluxColors.Void,
+    stop: InfluxColors.Pulsar,
   },
   GrapeSoda: {
     start: InfluxColors.DeepPurple,

--- a/src/Constants/colors.ts
+++ b/src/Constants/colors.ts
@@ -410,6 +410,79 @@ export const influxGradients = {
     start: InfluxColors.DeepPurple,
     stop: InfluxColors.Star,
   },
+  // Single Hue Gradients
+  DefaultDark: {
+    start: InfluxColors.Castle,
+    stop: InfluxColors.Smoke,
+  },
+  Default: {
+    start: InfluxColors.Wolf,
+    stop: InfluxColors.Mist,
+  },
+  DefaultLight: {
+    start: InfluxColors.Mist,
+    stop: InfluxColors.Cloud,
+  },
+  PrimaryDark: {
+    start: InfluxColors.Sapphire,
+    stop: InfluxColors.Ocean,
+  },
+  Primary: {
+    start: InfluxColors.Pool,
+    stop: InfluxColors.Laser,
+  },
+  PrimaryLight: {
+    start: InfluxColors.Laser,
+    stop: InfluxColors.Hydrogen,
+  },
+  SecondaryDark: {
+    start: InfluxColors.Void,
+    stop: InfluxColors.Amethyst,
+  },
+  Secondary: {
+    start: InfluxColors.Star,
+    stop: InfluxColors.Comet,
+  },
+  SecondaryLight: {
+    start: InfluxColors.Comet,
+    stop: InfluxColors.Moonstone,
+  },
+  SuccessDark: {
+    start: InfluxColors.Emerald,
+    stop: InfluxColors.Viridian,
+  },
+  Success: {
+    start: InfluxColors.Rainforest,
+    stop: InfluxColors.Honeydew,
+  },
+  SuccessLight: {
+    start: InfluxColors.Honeydew,
+    stop: InfluxColors.Krypton,
+  },
+  WarningDark: {
+    start: InfluxColors.Topaz,
+    stop: InfluxColors.Tiger,
+  },
+  Warning: {
+    start: InfluxColors.Pineapple,
+    stop: InfluxColors.Thunder,
+  },
+  WarningLight: {
+    start: InfluxColors.Thunder,
+    stop: InfluxColors.Sulfur,
+  },
+  DangerDark: {
+    start: InfluxColors.Ruby,
+    stop: InfluxColors.Fire,
+  },
+  Danger: {
+    start: InfluxColors.Curacao,
+    stop: InfluxColors.Dreamsicle,
+  },
+  DangerLight: {
+    start: InfluxColors.Dreamsicle,
+    stop: InfluxColors.Tungsten,
+  },
 }
 
 export const dropdownScrollColors = {

--- a/src/Types/Types.stories.tsx
+++ b/src/Types/Types.stories.tsx
@@ -356,10 +356,16 @@ dataTypeStories.add(
     const greens = colorsArray.slice(37, 45)
     const yellows = colorsArray.slice(45, 53)
     const reds = colorsArray.slice(53, 61)
-    const brandColors = colorsArray.slice(61, 64)
+    const brandColors = colorsArray.slice(61, 66)
 
     const clockfaceGradients = gradientsArray.slice(0, 40)
     const brandGradients = gradientsArray.slice(40, 50)
+    const defaultGradients = gradientsArray.slice(50, 53)
+    const primaryGradients = gradientsArray.slice(53, 56)
+    const secondaryGradients = gradientsArray.slice(56, 59)
+    const successGradients = gradientsArray.slice(59, 62)
+    const warningGradients = gradientsArray.slice(62, 65)
+    const dangerGradients = gradientsArray.slice(65, 68)
 
     const colorCardClassName = (hexcode: string): string => {
       const lightContrast = chroma.contrast(InfluxColors.White, hexcode)
@@ -508,6 +514,79 @@ dataTypeStories.add(
         <h5>InfluxData Brand Gradients</h5>
         <div className="gradients-grid">
           {brandGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <h5>Single Hue Gradients</h5>
+        <p>Default (Grey)</p>
+        <div className="gradients-grid">
+          {defaultGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <p>Primary (Blue)</p>
+        <div className="gradients-grid">
+          {primaryGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <p>Secondary (Purple)</p>
+        <div className="gradients-grid">
+          {secondaryGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <p>Success (Green)</p>
+        <div className="gradients-grid">
+          {successGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <p>Warning (Yellow)</p>
+        <div className="gradients-grid">
+          {warningGradients.map(g => (
+            <div
+              className={gradientCardClassName(g)}
+              key={g}
+              style={generateGradientStyle(g)}
+            >
+              <p>{g}</p>
+            </div>
+          ))}
+        </div>
+        <p>Danger (Red)</p>
+        <div className="gradients-grid">
+          {dangerGradients.map(g => (
             <div
               className={gradientCardClassName(g)}
               key={g}

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -212,6 +212,8 @@ export enum InfluxColors {
   Chartreuse = '#D6F622',
   DeepPurple = '#13002D',
   Magenta = '#BF2FE5',
+  Galaxy = '#9394FF',
+  Pulsar = '#513CC6',
 }
 
 export enum IconFont {

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -99,6 +99,7 @@ export enum Gradients {
   RobotLogic = 'RobotLogic',
   MintyFresh = 'MintyFresh',
   SimpleCream = 'SimpleCream',
+  // Brand Gradients
   WarpSpeed = 'WarpSpeed',
   PowerStone = 'PowerStone',
   MilkyWay = 'MilkyWay',
@@ -109,6 +110,25 @@ export enum Gradients {
   GrapeSoda = 'GrapeSoda',
   LavenderLatte = 'LavenderLatte',
   OminousFog = 'OminousFog',
+  // Single Hue Gradients
+  DefaultLight = 'DefaultLight',
+  Default = 'Default',
+  DefaultDark = 'DefaultDark',
+  PrimaryLight = 'PrimaryLight',
+  Primary = 'Primary',
+  PrimaryDark = 'PrimaryDark',
+  SecondaryLight = 'SecondaryLight',
+  Secondary = 'Secondary',
+  SecondaryDark = 'SecondaryDark',
+  SuccessLight = 'SuccessLight',
+  Success = 'Success',
+  SuccessDark = 'SuccessDark',
+  WarningLight = 'WarningLight',
+  Warning = 'Warning',
+  WarningDark = 'WarningDark',
+  DangerLight = 'DangerLight',
+  Danger = 'Danger',
+  DangerDark = 'DangerDark',
 }
 
 export enum DropdownMenuTheme {


### PR DESCRIPTION
### Changes

- Add `Comet` and `Planet` from old color palette in as `Galaxy` and `Pulsar` for use in brand gradients
- Add 3 single-hue gradients (light, normal, dark) for each color spectrum

### Screenshots

![Screen Shot 2020-04-13 at 11 36 23 AM](https://user-images.githubusercontent.com/2433762/79149798-880a1400-7d7c-11ea-8c99-48be96b35a0b.png)
![Screen Shot 2020-04-13 at 11 36 17 AM](https://user-images.githubusercontent.com/2433762/79149805-89d3d780-7d7c-11ea-850c-12b02e8c096c.png)
![Screen Shot 2020-04-13 at 11 36 12 AM](https://user-images.githubusercontent.com/2433762/79149808-8c363180-7d7c-11ea-8e58-881833f52099.png)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
