### PR TITLE
feat(clockface): expose onShow & onHide props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 2.1.0 (Unreleased)
 
-- [#484](https://github.com/influxdata/clockface/pull/486): Expose `onShow` and `onHide` props in `ConfirmationButton` component
+- [#486](https://github.com/influxdata/clockface/pull/486): Expose `onShow` and `onHide` props in `ConfirmationButton` component
 - [#484](https://github.com/influxdata/clockface/pull/484): Fix `z-index` issue causing notifications to appear underneath `FunnelPage`
 - [#482](https://github.com/influxdata/clockface/pull/482): [Breaking] Remove render props from `ResourceCard` in favor of `children`
 - [#482](https://github.com/influxdata/clockface/pull/482): Refactor `ResourceCard` to extend `FlexBox` to offer more layout control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.0 (Unreleased)
 
+- [#484](https://github.com/influxdata/clockface/pull/486): Expose `onShow` and `onHide` props in `ConfirmationButton` component
 - [#484](https://github.com/influxdata/clockface/pull/484): Fix `z-index` issue causing notifications to appear underneath `FunnelPage`
 - [#482](https://github.com/influxdata/clockface/pull/482): [Breaking] Remove render props from `ResourceCard` in favor of `children`
 - [#482](https://github.com/influxdata/clockface/pull/482): Refactor `ResourceCard` to extend `FlexBox` to offer more layout control

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -43,6 +43,10 @@ export interface ConfirmationButtonProps
   popoverClassName?: string
   /** Allows customization of Popover */
   popoverStyle?: CSSProperties
+  /** Callback function fired when state changes to "show" */
+  onShow?: () => void
+  /** Callback function fired when state changes to "hide" */
+  onHide?: () => void
   /** Function to call when confirmation is clicked, passes 'value' prop in */
   onConfirm: (returnValue?: any) => void
   /** Optional value to have passed back via onConfirm */
@@ -54,6 +58,8 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
   icon,
   text,
   style,
+  onHide,
+  onShow,
   tabIndex,
   className,
   titleText,
@@ -86,6 +92,8 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
         color={popoverColor}
         appearance={popoverAppearance}
         enableDefaultStyles={false}
+        onShow={onShow}
+        onHide={onHide}
         contents={onHide => (
           <ConfirmationContents
             testID={testID}

--- a/src/Components/Button/Documentation/Button.stories.tsx
+++ b/src/Components/Button/Documentation/Button.stories.tsx
@@ -132,6 +132,7 @@ buttonComposedStories.add(
       console.log(buttonRef.current)
       /* eslint-enable */
     }
+
     return (
       <div className="story--example">
         <SquareButton
@@ -170,52 +171,70 @@ buttonComposedStories.add(
 
 buttonComposedStories.add(
   'ConfirmationButton',
-  () => (
-    <div className="story--example">
-      <ConfirmationButton
-        confirmationButtonText={text(
-          'confirmationButtonText',
-          'Yes, Delete it'
-        )}
-        confirmationButtonColor={
-          ComponentColor[
-            select('confirmationColor', mapEnumKeys(ComponentColor), 'Danger')
-          ]
-        }
-        confirmationLabel={text(
-          'confirmationLabel',
-          'Really delete your soul?'
-        )}
-        popoverColor={
-          ComponentColor[
-            select('popoverColor', mapEnumKeys(ComponentColor), 'Default')
-          ]
-        }
-        popoverAppearance={
-          Appearance[select('appearance', mapEnumKeys(Appearance), 'Solid')]
-        }
-        onConfirm={value => alert(`returnValue: ${value}`)}
-        returnValue={text('returnValue', '')}
-        icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Trash')]}
-        titleText={text('titleText', 'Title Text')}
-        color={
-          ComponentColor[select('color', mapEnumKeys(ComponentColor), 'Danger')]
-        }
-        size={
-          ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
-        }
-        shape={
-          ButtonShape[select('shape', mapEnumKeys(ButtonShape), 'Default')]
-        }
-        text={text('text', 'Delete Soul')}
-        status={
-          ComponentStatus[
-            select('status', mapEnumKeys(ComponentStatus), 'Default')
-          ]
-        }
-      />
-    </div>
-  ),
+  () => {
+    const onShow = (): void => {
+      /* eslint-disable */
+      console.log('calling onShow')
+      /* eslint-enable */
+    }
+
+    const onHide = (): void => {
+      /* eslint-disable */
+      console.log('calling onHide')
+      /* eslint-enable */
+    }
+
+    return (
+      <div className="story--example">
+        <ConfirmationButton
+          confirmationButtonText={text(
+            'confirmationButtonText',
+            'Yes, Delete it'
+          )}
+          onShow={onShow}
+          onHide={onHide}
+          confirmationButtonColor={
+            ComponentColor[
+              select('confirmationColor', mapEnumKeys(ComponentColor), 'Danger')
+            ]
+          }
+          confirmationLabel={text(
+            'confirmationLabel',
+            'Really delete your soul?'
+          )}
+          popoverColor={
+            ComponentColor[
+              select('popoverColor', mapEnumKeys(ComponentColor), 'Default')
+            ]
+          }
+          popoverAppearance={
+            Appearance[select('appearance', mapEnumKeys(Appearance), 'Solid')]
+          }
+          onConfirm={value => alert(`returnValue: ${value}`)}
+          returnValue={text('returnValue', '')}
+          icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Trash')]}
+          titleText={text('titleText', 'Title Text')}
+          color={
+            ComponentColor[
+              select('color', mapEnumKeys(ComponentColor), 'Danger')
+            ]
+          }
+          size={
+            ComponentSize[select('size', mapEnumKeys(ComponentSize), 'Small')]
+          }
+          shape={
+            ButtonShape[select('shape', mapEnumKeys(ButtonShape), 'Default')]
+          }
+          text={text('text', 'Delete Soul')}
+          status={
+            ComponentStatus[
+              select('status', mapEnumKeys(ComponentStatus), 'Default')
+            ]
+          }
+        />
+      </div>
+    )
+  },
   {
     readme: {
       content: marked(ConfirmationButtonReadme),


### PR DESCRIPTION
### Changes
Expose `onShow` and `onHide` props in `ConfirmationButton` component.

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
