### PR TITLE
Add htmlFor prop to FormLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.0 (Unreleased)
 
+- [#487](https://github.com/influxdata/clockface/pull/487): Add `htmlFor` prop to `FormLabel`, `FormElement`, `FormValidationElement`
 - [#484](https://github.com/influxdata/clockface/pull/484): Fix `z-index` issue causing notifications to appear underneath `FunnelPage`
 - [#482](https://github.com/influxdata/clockface/pull/482): [Breaking] Remove render props from `ResourceCard` in favor of `children`
 - [#482](https://github.com/influxdata/clockface/pull/482): Refactor `ResourceCard` to extend `FlexBox` to offer more layout control

--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -21,6 +21,8 @@ export interface FormElementProps extends StandardFunctionProps {
   labelAddOn?: () => JSX.Element
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
+  /** Useful for associating a label with an input */
+  htmlFor?: string
 }
 
 export type FormElementRef = HTMLDivElement
@@ -31,6 +33,7 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
       id,
       label,
       style,
+      htmlFor,
       required,
       helpText,
       children,
@@ -54,7 +57,7 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
         className={formElementClass}
       >
         {!!label && (
-          <FormLabel label={label} required={required}>
+          <FormLabel label={label} required={required} htmlFor={htmlFor}>
             {!!labelAddOn && labelAddOn()}
           </FormLabel>
         )}

--- a/src/Components/Form/FormLabel.tsx
+++ b/src/Components/Form/FormLabel.tsx
@@ -10,13 +10,24 @@ export interface FormLabelProps extends StandardFunctionProps {
   label: string
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
+  /** Useful for associating a label with an input */
+  htmlFor?: string
 }
 
 export type FormLabelRef = HTMLLabelElement
 
 export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
   (
-    {label, children, className, required, id, style, testID = 'form--label'},
+    {
+      id,
+      label,
+      style,
+      testID = 'form--label',
+      htmlFor,
+      children,
+      required,
+      className,
+    },
     ref
   ) => {
     const formLabelClass = classnames('cf-form--label', {
@@ -30,6 +41,7 @@ export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
         style={style}
         data-testid={testID}
         className={formLabelClass}
+        htmlFor={htmlFor}
       >
         <span>
           {label}

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -31,6 +31,8 @@ export interface FormValidationElementProps extends StandardFunctionProps {
   helpText?: string
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
+  /** Useful for associating a label with an input */
+  htmlFor?: string
 }
 
 export type FormValidationElementRef = HTMLDivElement
@@ -45,6 +47,7 @@ export const FormValidationElement = forwardRef<
       value,
       style,
       label,
+      htmlFor,
       helpText,
       children,
       required,
@@ -87,7 +90,7 @@ export const FormValidationElement = forwardRef<
         className={formValidationElementClass}
       >
         {!!label && (
-          <FormLabel label={label} required={required}>
+          <FormLabel label={label} required={required} htmlFor={htmlFor}>
             {labelAddOn && labelAddOn()}
           </FormLabel>
         )}


### PR DESCRIPTION
Closes #485

### Changes

- Add `htmlFor` prop to `FormLabel`
- Expose `htmlFor` prop in `FormElement` and `FormValidationElement` and pass through to `FormLabel`

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
