### PR TITLE
fix(clockface): remove same color used by text from the background in IndexList body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#482](https://github.com/influxdata/clockface/pull/482): [Breaking] Remove render props from `ResourceCard` in favor of `children`
 - [#482](https://github.com/influxdata/clockface/pull/482): Refactor `ResourceCard` to extend `FlexBox` to offer more layout control
 - [#475](https://github.com/influxdata/clockface/pull/475): Refactor `Tabs` to optionally render as a space-efficient dropdown at a customizable breakpoint
+- [#489](https://github.com/influxdata/clockface/pull/489): Remove same color used by text from the background in IndexList body
 
 #### 2.0.4
 

--- a/src/Components/IndexList/IndexList.scss
+++ b/src/Components/IndexList/IndexList.scss
@@ -154,7 +154,6 @@ $cf-index-list--sort-text: $g11-sidewalk;
 
 // Empty state
 .cf-index-list--empty-cell {
-  background-color: $cf-card-text--disabled;
   border-radius: $cf-radius;
   display: flex;
   align-content: center;

--- a/src/Components/IndexList/IndexList.scss
+++ b/src/Components/IndexList/IndexList.scss
@@ -154,6 +154,7 @@ $cf-index-list--sort-text: $g11-sidewalk;
 
 // Empty state
 .cf-index-list--empty-cell {
+  background-color: $cf-card-background--disabled;
   border-radius: $cf-radius;
   display: flex;
   align-content: center;


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17635
Closes #488 

### Changes

Remove the background color which is the same value as the text color. This applies to IndexList body when it is empty.

### Screenshots

BEFORE: With text and background color the same
<img width="1680" alt="Screen Shot 2020-04-15 at 2 49 13 PM" src="https://user-images.githubusercontent.com/10736577/79392521-5cc42800-7f28-11ea-9772-e7ef6df68a7d.png">

AFTER: Correct background color and text color
<img width="1680" alt="Screen Shot 2020-04-15 at 3 08 38 PM" src="https://user-images.githubusercontent.com/10736577/79394193-c5f96a80-7f2b-11ea-8300-3ca96bd3c491.png">


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)


