### PR TITLE
Add optional "disabled" prop to DropdownItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.1 (Unreleased)
 
+- [#495](https://github.com/influxdata/clockface/pull/495): Add optional `disabled` prop to `DropdownItem` and `DropdownLinkItem`
 - [#493](https://github.com/influxdata/clockface/pull/493): Add testIDs to `Notification` dismiss button and child wrapper for easy testing
 
 #### 2.1.0 [2020-04-16]

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -223,6 +223,7 @@ dropdownFamilyStories.add(
               select('type', mapEnumKeys(DropdownItemType), 'None')
             ]
           }
+          disabled={boolean('disabled', false)}
         >
           {text('children (text)', 'I am a dropdown item!')}
         </Dropdown.Item>
@@ -293,6 +294,7 @@ dropdownFamilyStories.add(
               select('type', mapEnumKeys(DropdownItemType), 'None')
             ]
           }
+          disabled={boolean('disabled', false)}
         >
           <a
             href={text('link target', 'http://www.influxdata.com')}
@@ -314,6 +316,11 @@ dropdownFamilyStories.add(
   }
 )
 
+interface ExampleDropdownItem {
+  type: 'item' | 'divider'
+  text: string
+}
+
 dropdownFamilyStories.add(
   'DropdownMenu',
   () => {
@@ -329,194 +336,121 @@ dropdownFamilyStories.add(
       /* eslint-enable */
     }
 
+    const exampleItems: ExampleDropdownItem[] = [
+      {
+        type: 'divider',
+        text: 'Domestic Fruits',
+      },
+      {
+        type: 'item',
+        text: 'Banana',
+      },
+      {
+        type: 'item',
+        text: 'Kiwi',
+      },
+      {
+        type: 'item',
+        text: 'Lemon',
+      },
+      {
+        type: 'item',
+        text: 'Apple',
+      },
+      {
+        type: 'item',
+        text: 'Orange',
+      },
+      {
+        type: 'item',
+        text: 'Grapefruit',
+      },
+      {
+        type: 'item',
+        text: 'Pear',
+      },
+      {
+        type: 'divider',
+        text: 'Imported Fruits',
+      },
+      {
+        type: 'item',
+        text: 'Dragonfruit',
+      },
+      {
+        type: 'item',
+        text: 'Yuzu',
+      },
+      {
+        type: 'item',
+        text: 'Mango',
+      },
+      {
+        type: 'item',
+        text: 'Lychee',
+      },
+      {
+        type: 'item',
+        text: 'Passionfruit',
+      },
+      {
+        type: 'item',
+        text: 'Guava',
+      },
+      {
+        type: 'divider',
+        text: 'Testing Only',
+      },
+      {
+        type: 'item',
+        text: 'This dropdown item text is much longer to test text wrapping',
+      },
+    ]
+
+    const selectedItems = array('Selected Items', ['Yuzu', 'Banana'])
+    const disabledItems = array('Disabled Items', ['Passionfruit'])
+
+    const menuStyle = {width: '250px'}
+
     return (
       <div className="story--example">
-        <div style={{width: '200px'}}>
-          <Dropdown.Menu
-            ref={dropdownMenuRef}
-            contentsRef={dropdownMenuContentsRef}
-            theme={
-              DropdownMenuTheme[
-                select('theme', mapEnumKeys(DropdownMenuTheme), 'Onyx')
-              ]
+        <Dropdown.Menu
+          ref={dropdownMenuRef}
+          style={object('style', menuStyle)}
+          contentsRef={dropdownMenuContentsRef}
+          theme={
+            DropdownMenuTheme[
+              select('theme', mapEnumKeys(DropdownMenuTheme), 'Onyx')
+            ]
+          }
+          maxHeight={number('maxHeight', 250)}
+          noScrollX={boolean('noScrollX', true)}
+          noScrollY={boolean('noScrollY', false)}
+          scrollToSelected={boolean('scrollToSelected', true)}
+        >
+          {exampleItems.map(item => {
+            if (item.type === 'divider') {
+              return <Dropdown.Divider key={item.text} text={item.text} />
             }
-            maxHeight={number('maxHeight', 250)}
-            noScrollX={boolean('noScrollX', true)}
-            noScrollY={boolean('noScrollY', false)}
-            scrollToSelected={boolean('scrollToSelected', true)}
-          >
-            <Dropdown.Divider text="Domestic Fruits" />
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Banana"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Banana
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Kiwi"
-              selected={true}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Kiwi
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Lemon"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Lemon
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="custom"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              This dropdown item text is much longer to test text wrapping
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Apple"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Apple
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Orange"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Orange
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Grapefruit"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Grapefruit
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Pear"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Pear
-            </Dropdown.Item>
-            <Dropdown.Divider text="Imported Fruits" />
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Dragonfruit"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Dragonfruit
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Yuzu"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Yuzu
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Mango"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Mango
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Lychee"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Lychee
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Passionfruit"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Passionfruit
-            </Dropdown.Item>
-            <Dropdown.Item
-              wrapText={boolean('item wrapText', false)}
-              value="Guava"
-              selected={false}
-              type={
-                DropdownItemType[
-                  select('item type', mapEnumKeys(DropdownItemType), 'None')
-                ]
-              }
-            >
-              Guava
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </div>
+
+            return (
+              <Dropdown.Item
+                key={item.text}
+                wrapText={boolean('item wrapText', false)}
+                value={item.text}
+                selected={selectedItems.includes(item.text)}
+                disabled={disabledItems.includes(item.text)}
+                type={
+                  DropdownItemType[
+                    select('item type', mapEnumKeys(DropdownItemType), 'None')
+                  ]
+                }
+              >
+                {item.text}
+              </Dropdown.Item>
+            )
+          })}
+        </Dropdown.Menu>
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>
         </div>

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -212,6 +212,23 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
 }
 
 /*
+  Dropdown Item (Disabled State)
+  ------------------------------------------------------------------------------
+*/
+
+.cf-dropdown-item__disabled,
+.cf-dropdown-item__disabled:hover,
+.cf-dropdown-link-item.cf-dropdown-item__disabled a,
+.cf-dropdown-link-item.cf-dropdown-item__disabled a:link,
+.cf-dropdown-link-item.cf-dropdown-item__disabled a:visited,
+.cf-dropdown-link-item.cf-dropdown-item__disabled a:active,
+.cf-dropdown-link-item.cf-dropdown-item__disabled a:hover {
+  color: rgba($g20-white, 0.45);
+  font-style: italic;
+  cursor: default;
+}
+
+/*
   Dropdown Empty Item
   ------------------------------------------------------------------------------
 */
@@ -242,8 +259,8 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
 ) {
   @include gradient-h($backgroundA, $backgroundB);
 
-  .cf-dropdown-item:hover,
-  .cf-dropdown-item.active {
+  .cf-dropdown-item:not(.cf-dropdown-item__disabled):hover,
+  .cf-dropdown-item.active:not(.cf-dropdown-item__disabled) {
     @include gradient-h($hoverA, $hoverB);
   }
   .cf-dropdown-divider {
@@ -252,6 +269,9 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   }
   .cf-dropdown-item--checkbox {
     background-color: $dividerA;
+  }
+  .cf-dropdown-item__disabled .cf-dropdown-item--checkbox {
+    background-color: mix($backgroundA, $dividerA);
   }
   .cf-dropdown-item--checkbox:after {
     background-color: $checkbox;

--- a/src/Components/Dropdowns/DropdownItem.tsx
+++ b/src/Components/Dropdowns/DropdownItem.tsx
@@ -21,6 +21,8 @@ export interface DropdownItemProps extends StandardFunctionProps {
   wrapText?: boolean
   /** Title attribute */
   title?: string
+  /** Prevents any interaction with this element, including the onClick function */
+  disabled?: boolean
 }
 
 export type DropdownItemRef = HTMLDivElement
@@ -38,6 +40,7 @@ export const DropdownItem = forwardRef<DropdownItemRef, DropdownItemProps>(
       wrapText = false,
       selected = false,
       children,
+      disabled,
       className,
     },
     ref
@@ -49,12 +52,13 @@ export const DropdownItem = forwardRef<DropdownItemRef, DropdownItemProps>(
       [`${className}`]: className,
       'cf-dropdown-item__wrap': wrapText,
       'cf-dropdown-item__no-wrap': !wrapText,
+      'cf-dropdown-item__disabled': disabled,
     })
 
     const handleClick = (e: MouseEvent<HTMLElement>): void => {
       e.preventDefault()
 
-      if (onClick) {
+      if (onClick && !disabled) {
         onClick(value)
       }
     }

--- a/src/Components/Dropdowns/DropdownLinkItem.tsx
+++ b/src/Components/Dropdowns/DropdownLinkItem.tsx
@@ -15,6 +15,8 @@ export interface DropdownLinkItemProps extends StandardFunctionProps {
   type?: DropdownItemType
   /** Controls whether the text contents of this item wrap or not */
   wrapText?: boolean
+  /** Renders the element in a disabled state, does not affect functionality */
+  disabled?: boolean
 }
 
 export type DropdownLinkItemRef = HTMLDivElement
@@ -32,6 +34,7 @@ export const DropdownLinkItem = forwardRef<
       wrapText = false,
       selected = false,
       children,
+      disabled,
       className,
     },
     ref
@@ -45,6 +48,7 @@ export const DropdownLinkItem = forwardRef<
         [`${className}`]: className,
         'cf-dropdown-item__wrap': wrapText,
         'cf-dropdown-item__no-wrap': !wrapText,
+        'cf-dropdown-item__disabled': disabled,
       }
     )
 


### PR DESCRIPTION
Closes #490 

### Changes

- Allow both `DropdownItem` and `DropdownLinkItem` to be disabled
- Update documentation for `DropdownMenu` to make it easier to test the above changes

### Screenshots

![dropdown-item-disabled](https://user-images.githubusercontent.com/2433762/80744276-4646d080-8ad3-11ea-9aa5-b960357b2250.gif)


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
