### PR TITLE
Improve FormElement Accessibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.1.1 (Unreleased)
 
+- [#496](https://github.com/influxdata/clockface/pull/496): Add optional `htmlFor` prop to `FormElement` and `FormValidationElement` that, if true, will render the components with `<label />` instead  of `<div />`
 - [#493](https://github.com/influxdata/clockface/pull/493): Add testIDs to `Notification` dismiss button and child wrapper for easy testing
 
 #### 2.1.0 [2020-04-16]

--- a/src/Components/Form/Documentation/Form.stories.tsx
+++ b/src/Components/Form/Documentation/Form.stories.tsx
@@ -172,6 +172,20 @@ formStories.add(
       /* eslint-enable */
     }
 
+    const addOnElement = () => (
+      <div
+        className="mockComponent mockInput"
+        style={{
+          width: '20px',
+          height: '20px',
+          minHeight: '20px',
+          borderRadius: '10px',
+        }}
+      >
+        $
+      </div>
+    )
+
     return (
       <div className="story--example">
         <div className="story--form-example">
@@ -181,6 +195,7 @@ formStories.add(
             helpText={text('helpText', 'Help Text')}
             errorMessage={text('errorMessage', 'Error Message')}
             required={boolean('required', true)}
+            labelAddOn={boolean('labelAddOn', false) ? addOnElement : undefined}
           >
             <div className="mockComponent mockInput">Input Goes Here</div>
           </Form.Element>

--- a/src/Components/Form/Documentation/Form.stories.tsx
+++ b/src/Components/Form/Documentation/Form.stories.tsx
@@ -53,6 +53,7 @@ import {
 
 // Notes
 import FormReadme from './Form.md'
+import FormElementReadme from './FormElement.md'
 import FormValidationElementReadme from './FormValidationElement.md'
 import NaturalLanguageFormReadme from './NaturalLanguageForm.md'
 import {FormRef} from '../Form'
@@ -208,7 +209,7 @@ formStories.add(
   },
   {
     readme: {
-      content: marked(FormReadme),
+      content: marked(FormElementReadme),
     },
   }
 )

--- a/src/Components/Form/Documentation/FormElement.md
+++ b/src/Components/Form/Documentation/FormElement.md
@@ -1,0 +1,34 @@
+# FormElement
+
+This is the basic building block for laying out forms. It is designed to be generic and work with any component as a child, though it is most commonly used with `Input`.
+
+### Usage
+
+```tsx
+import {Form} from '@influxdata/clockface'
+```
+```tsx
+<Form.Element label="Enter # of Puppies">
+  <Input status={status} value={inputValue} onChange={handleChange} />
+</Form.Element>
+```
+
+### Accessibility
+
+If you are using `FormElement` with `Input` as a child and want the input to render as a child of `<label />` simply pass in a value to the option `htmlFor` prop. If a value is passed in the HTML Element of `FormElement` will be a `label` instead of a `div`.
+
+```tsx
+<Form.Element label="Puppy Name" htmlFor="puppy-name">
+  <Input id="puppy-name" status={status} value={inputValue} onChange={handleChange} />
+</Form.Element>
+```
+
+### Example
+
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Form/Form.scss
+++ b/src/Components/Form/Form.scss
@@ -40,6 +40,16 @@
   width: 100%;
   color: $cf-label--default;
   margin: 0 0 $cf-marg-a 0;
+  display: flex;
+  align-items: center;
+}
+
+.cf-form--label-text {
+  margin-right: $cf-marg-b;
+
+  &:only-child {
+    margin-right: 0;
+  }
 }
 
 .cf-form--help-text {

--- a/src/Components/Form/Form.scss
+++ b/src/Components/Form/Form.scss
@@ -30,7 +30,7 @@
 .cf-form--element-error {
   text-align: left;
   display: inline-block;
-  font-size: 12px;
+  font-size: $cf-form-sm-font;
   font-weight: $cf-font-weight--medium;
   padding: 0 ($cf-form-sm-padding + $cf-border);
   @extend %no-user-select;

--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -25,7 +25,7 @@ export interface FormElementProps extends StandardFunctionProps {
   htmlFor?: string
 }
 
-export type FormElementRef = HTMLDivElement
+export type FormElementRef = HTMLLabelElement
 
 export const FormElement = forwardRef<FormElementRef, FormElementProps>(
   (
@@ -49,22 +49,23 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
     })
 
     return (
-      <div
+      <label
         id={id}
         ref={ref}
         style={style}
+        htmlFor={htmlFor}
         data-testid={testID}
         className={formElementClass}
       >
         {!!label && (
-          <FormLabel label={label} required={required} htmlFor={htmlFor}>
+          <FormLabel label={label} required={required}>
             {!!labelAddOn && labelAddOn()}
           </FormLabel>
         )}
         {children}
         {!!errorMessage && <FormElementError message={errorMessage} />}
         {!!helpText && <FormHelpText text={helpText} />}
-      </div>
+      </label>
     )
   }
 )

--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -25,7 +25,7 @@ export interface FormElementProps extends StandardFunctionProps {
   htmlFor?: string
 }
 
-export type FormElementRef = HTMLLabelElement
+export type FormElementRef = HTMLLabelElement & HTMLDivElement
 
 export const FormElement = forwardRef<FormElementRef, FormElementProps>(
   (
@@ -48,15 +48,8 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
       [`${className}`]: className,
     })
 
-    return (
-      <label
-        id={id}
-        ref={ref}
-        style={style}
-        htmlFor={htmlFor}
-        data-testid={testID}
-        className={formElementClass}
-      >
+    const formElementElements = (
+      <>
         {!!label && (
           <FormLabel label={label} required={required}>
             {!!labelAddOn && labelAddOn()}
@@ -65,7 +58,34 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
         {children}
         {!!errorMessage && <FormElementError message={errorMessage} />}
         {!!helpText && <FormHelpText text={helpText} />}
-      </label>
+      </>
+    )
+
+    if (htmlFor) {
+      return (
+        <label
+          id={id}
+          ref={ref}
+          style={style}
+          htmlFor={htmlFor}
+          data-testid={testID}
+          className={formElementClass}
+        >
+          {formElementElements}
+        </label>
+      )
+    }
+
+    return (
+      <div
+        id={id}
+        ref={ref}
+        style={style}
+        data-testid={testID}
+        className={formElementClass}
+      >
+        {formElementElements}
+      </div>
     )
   }
 )

--- a/src/Components/Form/FormLabel.tsx
+++ b/src/Components/Form/FormLabel.tsx
@@ -10,24 +10,13 @@ export interface FormLabelProps extends StandardFunctionProps {
   label: string
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
-  /** Useful for associating a label with an input */
-  htmlFor?: string
 }
 
-export type FormLabelRef = HTMLLabelElement
+export type FormLabelRef = HTMLDivElement
 
 export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
   (
-    {
-      id,
-      label,
-      style,
-      testID = 'form--label',
-      htmlFor,
-      children,
-      required,
-      className,
-    },
+    {id, label, style, testID = 'form--label', children, required, className},
     ref
   ) => {
     const formLabelClass = classnames('cf-form--label', {
@@ -35,20 +24,19 @@ export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
     })
 
     return (
-      <label
+      <div
         id={id}
         ref={ref}
         style={style}
         data-testid={testID}
         className={formLabelClass}
-        htmlFor={htmlFor}
       >
-        <span>
+        <div className="cf-form--label-text">
           {label}
           {!!required && <span className="cf-form--label-required">*</span>}
-        </span>
+        </div>
         {children}
-      </label>
+      </div>
     )
   }
 )

--- a/src/Components/Form/FormLabel.tsx
+++ b/src/Components/Form/FormLabel.tsx
@@ -10,18 +10,54 @@ export interface FormLabelProps extends StandardFunctionProps {
   label: string
   /** Whether this field is required to submit form, adds red required asterisk */
   required?: boolean
+  /** Useful for associating a label with an input */
+  htmlFor?: string
 }
 
-export type FormLabelRef = HTMLDivElement
+export type FormLabelRef = HTMLDivElement & HTMLLabelElement
 
 export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
   (
-    {id, label, style, testID = 'form--label', children, required, className},
+    {
+      id,
+      label,
+      style,
+      testID = 'form--label',
+      htmlFor,
+      children,
+      required,
+      className,
+    },
     ref
   ) => {
     const formLabelClass = classnames('cf-form--label', {
       [`${className}`]: className,
     })
+
+    const labelChildren = (
+      <>
+        <div className="cf-form--label-text">
+          {label}
+          {!!required && <span className="cf-form--label-required">*</span>}
+        </div>
+        {children}
+      </>
+    )
+
+    if (htmlFor) {
+      return (
+        <label
+          id={id}
+          ref={ref}
+          style={style}
+          htmlFor={htmlFor}
+          data-testid={testID}
+          className={formLabelClass}
+        >
+          {labelChildren}
+        </label>
+      )
+    }
 
     return (
       <div
@@ -31,11 +67,7 @@ export const FormLabel = forwardRef<FormLabelRef, FormLabelProps>(
         data-testid={testID}
         className={formLabelClass}
       >
-        <div className="cf-form--label-text">
-          {label}
-          {!!required && <span className="cf-form--label-required">*</span>}
-        </div>
-        {children}
+        {labelChildren}
       </div>
     )
   }

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -35,7 +35,7 @@ export interface FormValidationElementProps extends StandardFunctionProps {
   htmlFor?: string
 }
 
-export type FormValidationElementRef = HTMLDivElement
+export type FormValidationElementRef = HTMLLabelElement
 
 export const FormValidationElement = forwardRef<
   FormValidationElementRef,
@@ -82,22 +82,23 @@ export const FormValidationElement = forwardRef<
     })
 
     return (
-      <div
+      <label
         id={id}
         ref={ref}
         style={style}
+        htmlFor={htmlFor}
         data-testid={testID}
         className={formValidationElementClass}
       >
         {!!label && (
-          <FormLabel label={label} required={required} htmlFor={htmlFor}>
+          <FormLabel label={label} required={required}>
             {labelAddOn && labelAddOn()}
           </FormLabel>
         )}
         {children(status)}
         {!!errorMessage && <FormElementError message={errorMessage} />}
         {!!helpText && <FormHelpText text={helpText} />}
-      </div>
+      </label>
     )
   }
 )


### PR DESCRIPTION
Closes #494 

This change should allow inputs to be rendered inside labels (which has better accessibility) without breaking the API

### Changes

- Render `FormLabel` as a `<div />` instead of `<label />` unless `htmlFor` is passed in
- Add optional `htmlFor` prop to `FormElement` & `FormValidationElement`
  - If a value is passed in `FormElement` renders as a `<label />` instead of `<div />`
- Bump label font size from `12px` to `13px`

### Screenshots

![Screen Shot 2020-04-30 at 12 03 57 PM](https://user-images.githubusercontent.com/2433762/80749009-b1e06c00-8ada-11ea-8969-d4ef041ebda2.png)

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
