### PR TITLE
Allow popovers to be closed via the Escape key

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -222,6 +222,15 @@ body.sb-show-main {
   &.top {
     align-items: flex-start;
   }
+
+  code {
+    background-color: $g0-obsidian;
+    color: $c-galaxy;
+    font-weight: 700;
+    line-height: 1em;
+    padding: 3px 7px;
+    border-radius: 3px;
+  }
 }
 
 .overlay--example {
@@ -259,6 +268,12 @@ body.sb-show-main {
   p {
     font-weight: $cf-font-weight--medium;
     margin: 0;
+  }
+}
+
+.story--invisible-table {
+  td {
+    padding: 22px;
   }
 }
 

--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -794,8 +794,8 @@ $color-grid-card-width: 154px;
 
   &.relative {
     position: relative;
+    top: initial;
     right: initial;
-    margin: 12px;
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 #### 2.1.2 (Unreleased)
 
-- [#499](https://github.com/influxdata/clockface/pull/499): Fix export for `CATLinkButton`
+- [#499](https://github.com/influxdata/clockface/pull/499): Fix export for `CTALinkButton`
+- [#492](https://github.com/influxdata/clockface/pull/492): Introduce `RBAC` component that conditionally renders content based on permissions
 
 #### 2.1.1 [2020-04-30]
 
-- [#497](https://github.com/influxdata/clockface/pull/497): Add `CATLinkButton` component as composed variant of `LinkButton`
+- [#497](https://github.com/influxdata/clockface/pull/497): Introduce `CTALinkButton` component as composed variant of `LinkButton`
 - [#496](https://github.com/influxdata/clockface/pull/496): Add optional `htmlFor` prop to `FormElement` and `FormValidationElement` that, if true, will render the components with `<label />` instead of `<div />`
 - [#495](https://github.com/influxdata/clockface/pull/495): Add optional `disabled` prop to `DropdownItem` and `DropdownLinkItem`
 - [#493](https://github.com/influxdata/clockface/pull/493): Add testIDs to `Notification` dismiss button and child wrapper for easy testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 2.2.1 (Unreleased)
 
-
+- [#502](https://github.com/influxdata/clockface/pull/502): Enable `Popover` to be closed by the escape key
 
 #### 2.2.0 [2020-05-12]
 

--- a/src/Components/Popover/Base/Popover.scss
+++ b/src/Components/Popover/Base/Popover.scss
@@ -12,6 +12,10 @@
 .cf-popover {
   position: fixed;
   z-index: 9999;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .cf-popover--contents {

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -13,10 +13,7 @@ import classnames from 'classnames'
 import {ClickOutside} from '../../ClickOutside/ClickOutside'
 
 // Utilities
-import {
-  convertCSSPropertiesToString,
-  checkForElementsAlreadyInFocus,
-} from '../../../Utils/index'
+import {convertCSSPropertiesToString} from '../../../Utils/index'
 import {calculatePopoverStyles} from '../../../Utils/popovers'
 
 // Types
@@ -159,7 +156,7 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
     // Ensure dialog element is in focus on mount
     // in order to enable escape key behavior
     useEffect(() => {
-      const okayToPullFocus = !checkForElementsAlreadyInFocus()
+      const okayToPullFocus = !document.activeElement
       if (dialogRef.current && okayToPullFocus) {
         dialogRef.current.focus()
       }

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -147,6 +147,14 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
       handleUpdateStyles()
     })
 
+    // Ensure styles are updated when the
+    // enableDefaultStyles prop changes
+    useEffect(() => {
+      handleUpdateStyles()
+    }, [enableDefaultStyles])
+
+    // Ensure dialog element is in focus on mount
+    // in order to enable escape key behavior
     useEffect(() => {
       if (dialogRef.current) {
         dialogRef.current.focus()

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -3,6 +3,7 @@ import React, {
   useRef,
   RefObject,
   MouseEvent,
+  useEffect,
   useLayoutEffect,
   forwardRef,
 } from 'react'
@@ -146,6 +147,12 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
       handleUpdateStyles()
     })
 
+    useEffect(() => {
+      if (dialogRef.current) {
+        dialogRef.current.focus()
+      }
+    }, [])
+
     return (
       <ClickOutside onClickOutside={onClickOutside}>
         <div
@@ -154,6 +161,7 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
           className={popoverDialogClassName}
           data-testid={`${testID}--dialog`}
           onMouseLeave={onMouseLeave}
+          tabIndex={-1}
         >
           <div
             ref={ref}

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -13,7 +13,10 @@ import classnames from 'classnames'
 import {ClickOutside} from '../../ClickOutside/ClickOutside'
 
 // Utilities
-import {convertCSSPropertiesToString} from '../../../Utils/index'
+import {
+  convertCSSPropertiesToString,
+  checkForElementsAlreadyInFocus,
+} from '../../../Utils/index'
 import {calculatePopoverStyles} from '../../../Utils/popovers'
 
 // Types
@@ -156,7 +159,8 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
     // Ensure dialog element is in focus on mount
     // in order to enable escape key behavior
     useEffect(() => {
-      if (dialogRef.current) {
+      const okayToPullFocus = !checkForElementsAlreadyInFocus()
+      if (dialogRef.current && okayToPullFocus) {
         dialogRef.current.focus()
       }
     }, [])

--- a/src/Components/Popover/Documentation/Popover.md
+++ b/src/Components/Popover/Documentation/Popover.md
@@ -52,9 +52,7 @@ By default `Popover` will apply reasonable default styles to the dialog to save 
 
 ### Gotchas
 
-There is a hierarchy of importance for handling combinations of props in `Popover`. If a `Popover` has its `visible` prop set to `true` then it will be visible so long as that value is unchanged. The dialog will ignore `enableEscapeKey` and defer to the value of `visible`. This decision assumes the intent of `visible` does not want to be disrupted by the escape key interaction.
-
-In addition, if  the Escape key is pressed any and all `Popovers` that can be closed via the Escape key will be closed.
+By default all `Popover` instances will be in focus when they appear so that pressing the `Escape` key dismisses them. If a `Popover` has its state controlled externally via the `visible` prop then the `Escape` key listener is disabled in deference.
 
 <!-- STORY HIDE START -->
 

--- a/src/Components/Popover/Documentation/Popover.md
+++ b/src/Components/Popover/Documentation/Popover.md
@@ -43,12 +43,18 @@ Make sure to use the available `onHide` argument and pass it into your dismiss b
 ### Example
 <!-- STORY -->
 
-### Trying to Make a Custom Popover?
+### Want more control over style within a Popover?
 
 By default `Popover` will apply reasonable default styles to the dialog to save you time. However you may be building a more specialized design and want more control. Rather than fight the default styles you can simply turn them off:
 ```tsx
 <Popover enableDefaultStyles={false} />
 ```
+
+### Gotchas
+
+There is a hierarchy of importance for handling combinations of props in `Popover`. If a `Popover` has its `visible` prop set to `true` then it will be visible so long as that value is unchanged. The dialog will ignore `enableEscapeKey` and defer to the value of `visible`. This decision assumes the intent of `visible` does not want to be disrupted by the escape key interaction.
+
+In addition, if  the Escape key is pressed any and all `Popovers` that can be closed via the Escape key will be closed.
 
 <!-- STORY HIDE START -->
 

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -68,12 +68,10 @@ popoverStories.add(
     const triggerRefB = useRef<HTMLDivElement>(null)
     const triggerRefC = useRef<HTMLButtonElement>(null)
     const triggerRefD = useRef<HTMLDivElement>(null)
-    const triggerRefE = useRef<HTMLDivElement>(null)
     const popover1Ref = useRef<PopoverRef>(null)
     const popover2Ref = useRef<PopoverRef>(null)
     const popover3Ref = useRef<PopoverRef>(null)
     const popover4Ref = useRef<PopoverRef>(null)
-    const popover5Ref = useRef<PopoverRef>(null)
 
     const log1Ref = (): void => {
       /* eslint-disable */
@@ -96,12 +94,6 @@ popoverStories.add(
     const log4Ref = (): void => {
       /* eslint-disable */
       console.log(popover4Ref.current)
-      /* eslint-enable */
-    }
-
-    const log5Ref = (): void => {
-      /* eslint-disable */
-      console.log(popover5Ref.current)
       /* eslint-enable */
     }
 
@@ -149,27 +141,23 @@ popoverStories.add(
                 </div>
               </td>
             </tr>
-            <tr>
-              <td>
-                <code>enableEscapeKey</code> is <code>false</code>
-              </td>
-              <td>
-                <div className="mockComponent mockButton" ref={triggerRefE}>
-                  Click Me
-                </div>
-              </td>
-            </tr>
           </tbody>
         </table>
         <Popover.Popover
           ref={popover1Ref}
           triggerRef={triggerRefA}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
-          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={(onHide: any) => (
             <>
-              PopoverContents
-              <Popover.DismissButton onClick={onHide} />
+              This Popover uses the style prop
+              <Popover.DismissButton
+                onClick={onHide}
+                color={
+                  ComponentColor[
+                    select('color', mapEnumKeys(ComponentColor), 'Primary')
+                  ]
+                }
+              />
               <div className="story--test-buttons">
                 <button onClick={log1Ref}>Log Ref</button>
               </div>
@@ -199,7 +187,6 @@ popoverStories.add(
           ref={popover2Ref}
           triggerRef={triggerRefB}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
-          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={() => (
             <>
               <div style={{marginTop: '30px'}}>
@@ -224,7 +211,6 @@ popoverStories.add(
           ref={popover3Ref}
           triggerRef={triggerRefC}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
-          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={() => (
             <>
               <div style={{marginTop: '30px'}}>
@@ -250,13 +236,15 @@ popoverStories.add(
           triggerRef={triggerRefD}
           visible={boolean('visible', true)}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
-          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={() => (
             <>
               <div style={{marginTop: '30px'}}>
                 My state can be controlled externally
                 <br />
                 via the <strong>visible</strong> prop
+                <br />
+                <br />
+                Look in the <strong>Knobs</strong> panel
               </div>
               <div className="story--test-buttons">
                 <button onClick={log4Ref}>Log Ref</button>
@@ -267,29 +255,6 @@ popoverStories.add(
           hideEvent={PopoverInteraction.None}
           position={PopoverPosition.Below}
           color={ComponentColor.Success}
-          appearance={Appearance.Solid}
-        />
-        <Popover.Popover
-          ref={popover5Ref}
-          triggerRef={triggerRefE}
-          enableDefaultStyles={boolean('enableDefaultStyles', true)}
-          enableEscapeKey={false}
-          contents={() => (
-            <>
-              <div style={{marginTop: '30px'}}>
-                I can never be hidden by the
-                <br />
-                <strong>Escape</strong> key
-              </div>
-              <div className="story--test-buttons">
-                <button onClick={log5Ref}>Log Ref</button>
-              </div>
-            </>
-          )}
-          showEvent={PopoverInteraction.Click}
-          hideEvent={PopoverInteraction.Click}
-          position={PopoverPosition.Below}
-          color={ComponentColor.Primary}
           appearance={Appearance.Solid}
         />
       </div>

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -237,19 +237,17 @@ popoverStories.add(
           visible={boolean('visible', true)}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
           contents={() => (
-            <>
-              <div style={{marginTop: '30px'}}>
-                My state can be controlled externally
-                <br />
-                via the <strong>visible</strong> prop
-                <br />
-                <br />
-                Look in the <strong>Knobs</strong> panel
-              </div>
-              <div className="story--test-buttons">
+            <div>
+              My state can be controlled externally
+              <br />
+              via the <strong>visible</strong> prop
+              <br />
+              <br />
+              Look in the <strong>Knobs</strong> panel
+              <div className="story--test-buttons relative">
                 <button onClick={log4Ref}>Log Ref</button>
               </div>
-            </>
+            </div>
           )}
           showEvent={PopoverInteraction.None}
           hideEvent={PopoverInteraction.None}

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {useRef} from 'react'
+import React, {useRef, ChangeEvent} from 'react'
 import marked from 'marked'
 
 // Storybook
@@ -13,6 +13,7 @@ import {
   object,
 } from '@storybook/addon-knobs'
 import {mapEnumKeys} from '../../../Utils/storybook'
+import {useState} from '@storybook/addons'
 
 // Components
 import {Popover, PopoverRef} from '../'
@@ -23,6 +24,7 @@ import {
 } from '../Composed/QuestionMarkTooltip'
 import {SquareButton} from '../../Button/Composed/SquareButton'
 import {DapperScrollbars} from '../../DapperScrollbars/DapperScrollbars'
+import {Input} from '../../Inputs'
 
 // Types
 import {
@@ -428,6 +430,46 @@ testPopoverStories.add('Popover Trigger within a DapperScrollbars', () => {
           </p>
         </div>
       </DapperScrollbars>
+    </div>
+  )
+})
+
+testPopoverStories.add('Popover + Autofocus Child', () => {
+  const triggerRef = useRef<HTMLDivElement>(null)
+  const [inputValue, updateInputValue] = useState<string>('')
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    updateInputValue(e.target.value)
+  }
+
+  return (
+    <div className="story--example">
+      <Popover.Popover
+        triggerRef={triggerRef}
+        contents={() => (
+          <>
+            <span>
+              This story tests how focus is handled
+              <br />
+              when an autofocus Input exists as a child of Popover
+            </span>
+            <Input
+              autoFocus={true}
+              placeholder="I'm autofocus true"
+              value={inputValue}
+              onChange={handleInputChange}
+            />
+          </>
+        )}
+        showEvent={PopoverInteraction.Click}
+        hideEvent={PopoverInteraction.Click}
+        position={PopoverPosition.Above}
+        color={ComponentColor.Primary}
+        appearance={Appearance.Outline}
+      />
+      <div className="mockComponent mockButton" ref={triggerRef}>
+        Click Me
+      </div>
     </div>
   )
 })

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -67,9 +67,13 @@ popoverStories.add(
     const triggerRefA = useRef<HTMLDivElement>(null)
     const triggerRefB = useRef<HTMLDivElement>(null)
     const triggerRefC = useRef<HTMLButtonElement>(null)
+    const triggerRefD = useRef<HTMLDivElement>(null)
+    const triggerRefE = useRef<HTMLDivElement>(null)
     const popover1Ref = useRef<PopoverRef>(null)
     const popover2Ref = useRef<PopoverRef>(null)
     const popover3Ref = useRef<PopoverRef>(null)
+    const popover4Ref = useRef<PopoverRef>(null)
+    const popover5Ref = useRef<PopoverRef>(null)
 
     const log1Ref = (): void => {
       /* eslint-disable */
@@ -89,31 +93,79 @@ popoverStories.add(
       /* eslint-enable */
     }
 
+    const log4Ref = (): void => {
+      /* eslint-disable */
+      console.log(popover4Ref.current)
+      /* eslint-enable */
+    }
+
+    const log5Ref = (): void => {
+      /* eslint-disable */
+      console.log(popover5Ref.current)
+      /* eslint-enable */
+    }
+
     return (
       <div className="story--example">
-        <div
-          className="mockComponent mockButton"
-          ref={triggerRefA}
-          style={{marginRight: '60px'}}
-        >
-          Click Me
-        </div>
-        <div
-          className="mockComponent mockButton"
-          ref={triggerRefB}
-          style={{marginRight: '60px'}}
-        >
-          Hover Me
-        </div>
-        <SquareButton
-          icon={IconFont.Zap}
-          ref={triggerRefC}
-          status={ComponentStatus.Disabled}
-        />
+        <table className="story--invisible-table">
+          <tbody>
+            <tr>
+              <td>
+                <code>PopoverInteraction.Click</code>
+              </td>
+              <td>
+                <div className="mockComponent mockButton" ref={triggerRefA}>
+                  Click Me
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>PopoverInteraction.Hover</code>
+              </td>
+              <td>
+                <div className="mockComponent mockButton" ref={triggerRefB}>
+                  Hover Me
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>Trigger element is disabled</td>
+              <td>
+                <SquareButton
+                  icon={IconFont.Zap}
+                  ref={triggerRefC}
+                  status={ComponentStatus.Disabled}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Controlled by <code>visible</code> prop
+              </td>
+              <td>
+                <div className="mockComponent mockButton" ref={triggerRefD}>
+                  Use Knobs
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>enableEscapeKey</code> is <code>false</code>
+              </td>
+              <td>
+                <div className="mockComponent mockButton" ref={triggerRefE}>
+                  Click Me
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <Popover.Popover
           ref={popover1Ref}
           triggerRef={triggerRefA}
-          enableDefaultStyles={false}
+          enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={(onHide: any) => (
             <>
               PopoverContents
@@ -147,6 +199,7 @@ popoverStories.add(
           ref={popover2Ref}
           triggerRef={triggerRefB}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={() => (
             <>
               <div style={{marginTop: '30px'}}>
@@ -170,8 +223,8 @@ popoverStories.add(
         <Popover.Popover
           ref={popover3Ref}
           triggerRef={triggerRefC}
-          visible={true}
           enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          enableEscapeKey={boolean('enableEscapeKey', true)}
           contents={() => (
             <>
               <div style={{marginTop: '30px'}}>
@@ -191,6 +244,53 @@ popoverStories.add(
           position={PopoverPosition.Below}
           color={ComponentColor.Success}
           appearance={Appearance.Outline}
+        />
+        <Popover.Popover
+          ref={popover4Ref}
+          triggerRef={triggerRefD}
+          visible={boolean('visible', true)}
+          enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          enableEscapeKey={boolean('enableEscapeKey', true)}
+          contents={() => (
+            <>
+              <div style={{marginTop: '30px'}}>
+                My state can be controlled externally
+                <br />
+                via the <strong>visible</strong> prop
+              </div>
+              <div className="story--test-buttons">
+                <button onClick={log4Ref}>Log Ref</button>
+              </div>
+            </>
+          )}
+          showEvent={PopoverInteraction.None}
+          hideEvent={PopoverInteraction.None}
+          position={PopoverPosition.Below}
+          color={ComponentColor.Success}
+          appearance={Appearance.Solid}
+        />
+        <Popover.Popover
+          ref={popover5Ref}
+          triggerRef={triggerRefE}
+          enableDefaultStyles={boolean('enableDefaultStyles', true)}
+          enableEscapeKey={false}
+          contents={() => (
+            <>
+              <div style={{marginTop: '30px'}}>
+                I can never be hidden by the
+                <br />
+                <strong>Escape</strong> key
+              </div>
+              <div className="story--test-buttons">
+                <button onClick={log5Ref}>Log Ref</button>
+              </div>
+            </>
+          )}
+          showEvent={PopoverInteraction.Click}
+          hideEvent={PopoverInteraction.Click}
+          position={PopoverPosition.Below}
+          color={ComponentColor.Primary}
+          appearance={Appearance.Solid}
         />
       </div>
     )

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -80,6 +80,8 @@ $c-banana: #FFFDDE;
 $c-chartreuse: #D6F622;
 $c-magenta: #BF2FE5;
 $c-deeppurple: #13002D;
+$c-galaxy: #9394FF;
+$c-pulsar: #513CC6;
 
 /*
    Z Variables

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -27,24 +27,24 @@ $g19-ghost: #fafafc;
 $g20-white: #ffffff;
 
 // Reds
-$c-basalt: #2F1F29;
-$c-ruby: #BF3D5E;
-$c-fire: #DC4E58;
-$c-curacao: #F95F53;
-$c-dreamsicle: #FF8564;
-$c-tungsten: #FFB6A0;
-$c-marmelade: #FFDCCF;
-$c-flan: #FFF7F4;
+$c-basalt: #2f1f29;
+$c-ruby: #bf3d5e;
+$c-fire: #dc4e58;
+$c-curacao: #f95f53;
+$c-dreamsicle: #ff8564;
+$c-tungsten: #ffb6a0;
+$c-marmelade: #ffdccf;
+$c-flan: #fff7f4;
 
 // Blues
 $c-abyss: #120653;
 $c-sapphire: #0b3a8d;
 $c-ocean: #066fc5;
 $c-pool: #00a3ff;
-$c-laser: #00C9FF;
-$c-hydrogen: #6BDFFF;
-$c-neutrino: #BEF0FF;
-$c-yeti: #F0FCFF;
+$c-laser: #00c9ff;
+$c-hydrogen: #6bdfff;
+$c-neutrino: #bef0ff;
+$c-yeti: #f0fcff;
 
 // Purples
 $c-shadow: #2b007e;
@@ -67,21 +67,21 @@ $c-wasabi: #c6f98e;
 $c-mint: #f3ffd6;
 
 // Yellows
-$c-oak: #3F241F;
-$c-topaz: #E85B1C;
-$c-tiger: #F48D38;
-$c-pineapple: #FFB94A;
-$c-thunder: #FFD255;
-$c-sulfur: #FFE480;
-$c-daisy: #FFF6B8;
-$c-banana: #FFFDDE;
+$c-oak: #3f241f;
+$c-topaz: #e85b1c;
+$c-tiger: #f48d38;
+$c-pineapple: #ffb94a;
+$c-thunder: #ffd255;
+$c-sulfur: #ffe480;
+$c-daisy: #fff6b8;
+$c-banana: #fffdde;
 
 // Marketing Brand Colors
-$c-chartreuse: #D6F622;
-$c-magenta: #BF2FE5;
-$c-deeppurple: #13002D;
-$c-galaxy: #9394FF;
-$c-pulsar: #513CC6;
+$c-chartreuse: #d6f622;
+$c-magenta: #bf2fe5;
+$c-deeppurple: #13002d;
+$c-galaxy: #9394ff;
+$c-pulsar: #513cc6;
 
 /*
    Z Variables
@@ -140,9 +140,17 @@ $cf-text-base: 1em;
 $cf-text-scale: 1.19;
 $cf-text-base-1: ($cf-text-base * $cf-text-scale);
 $cf-text-base-2: ($cf-text-base * $cf-text-scale * $cf-text-scale);
-$cf-text-base-3: ($cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale);
-$cf-text-base-4: ($cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale * $cf-text-scale);
-$cf-text-base-5: ($cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale * $cf-text-scale * $cf-text-scale);
+$cf-text-base-3: (
+  $cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale
+);
+$cf-text-base-4: (
+  $cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale *
+    $cf-text-scale
+);
+$cf-text-base-5: (
+  $cf-text-base * $cf-text-scale * $cf-text-scale * $cf-text-scale *
+    $cf-text-scale * $cf-text-scale
+);
 
 $cf-text-default: $g13-mist;
 $cf-text-header: $g17-whisper;
@@ -157,11 +165,10 @@ $cf-link-warning-hover: $c-thunder;
 $cf-link-secondary: $c-comet;
 $cf-link-secondary-hover: $c-potassium;
 $cf-link-danger: $c-curacao;
-$cf-link-danger-hover:  $c-dreamsicle;
+$cf-link-danger-hover: $c-dreamsicle;
 
 $cf-text-selection-bg: $c-pool;
 $cf-text-selection-color: $g20-white;
-
 
 /*
    Page Layout Variables
@@ -243,8 +250,7 @@ $cf-empty-state-highlight: $g13-mist;
 */
 
 $cf-input--transition: background-color 0.25s ease, border-color 0.25s ease,
-    color 0.25s ease,
-    box-shadow 0.25s ease, color 0.25s ease;
+  color 0.25s ease, box-shadow 0.25s ease, color 0.25s ease;
 
 $cf-input-background--default: $g2-kevlar;
 $cf-input-background--focused: $g2-kevlar;
@@ -258,7 +264,11 @@ $cf-input-text--disabled: $cf-empty-state-text;
 
 $cf-input-border--default: $g5-pepper;
 $cf-input-border--focused: $c-pool;
-$cf-input-border--hover: mix($cf-input-border--default, $cf-input-border--focused, 50%);
+$cf-input-border--hover: mix(
+  $cf-input-border--default,
+  $cf-input-border--focused,
+  50%
+);
 $cf-input-border--disabled: $g4-onyx;
 
 $cf-input-border--error: mix($cf-input-border--default, $c-dreamsicle, 70%);
@@ -371,37 +381,63 @@ $cf-tree-nav__toggle-icon-hover: $g13-mist;
 
 @mixin gradient-v($startColor, $endColor) {
   background: $startColor;
-  background: -moz-linear-gradient(top,  $startColor 0%, $endColor 100%);
-  background: -webkit-linear-gradient(top,  $startColor 0%,$endColor 100%);
-  background: linear-gradient(to bottom,  $startColor 0%,$endColor 100%);
+  background: -moz-linear-gradient(top, $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(top, $startColor 0%, $endColor 100%);
+  background: linear-gradient(to bottom, $startColor 0%, $endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=0 );
 }
 @mixin gradient-h($startColor, $endColor) {
   background: $startColor;
-  background: -moz-linear-gradient(left,  $startColor 0%, $endColor 100%);
-  background: -webkit-linear-gradient(left,  $startColor 0%,$endColor 100%);
-  background: linear-gradient(to right,  $startColor 0%,$endColor 100%);
+  background: -moz-linear-gradient(left, $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(left, $startColor 0%, $endColor 100%);
+  background: linear-gradient(to right, $startColor 0%, $endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 @mixin gradient-diag-up($startColor, $endColor) {
   background: $startColor;
-  background: -moz-linear-gradient(45deg,  $startColor 0%, $endColor 100%);
-  background: -webkit-linear-gradient(45deg,  $startColor 0%,$endColor 100%);
-  background: linear-gradient(45deg,  $startColor 0%,$endColor 100%);
+  background: -moz-linear-gradient(45deg, $startColor 0%, $endColor 100%);
+  background: -webkit-linear-gradient(45deg, $startColor 0%, $endColor 100%);
+  background: linear-gradient(45deg, $startColor 0%, $endColor 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 @mixin gradient-diag-down($startColor, $endColor) {
   background: $startColor;
-  background: -moz-linear-gradient(135deg,  $startColor 0%, $endColor 100%) !important;
-  background: -webkit-linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
-  background: linear-gradient(135deg,  $startColor 0%,$endColor 100%) !important;
+  background: -moz-linear-gradient(
+    135deg,
+    $startColor 0%,
+    $endColor 100%
+  ) !important;
+  background: -webkit-linear-gradient(
+    135deg,
+    $startColor 0%,
+    $endColor 100%
+  ) !important;
+  background: linear-gradient(
+    135deg,
+    $startColor 0%,
+    $endColor 100%
+  ) !important;
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 ) !important;
 }
 @mixin gradient-r($startColor, $endColor) {
   background: $startColor;
-  background: -moz-radial-gradient(center, ellipse cover,  $startColor 0%, $endColor 100%);
-  background: -webkit-radial-gradient(center, ellipse cover,  $startColor 0%,$endColor 100%);
-  background: radial-gradient(ellipse at center,  $startColor 0%,$endColor 100%);
+  background: -moz-radial-gradient(
+    center,
+    ellipse cover,
+    $startColor 0%,
+    $endColor 100%
+  );
+  background: -webkit-radial-gradient(
+    center,
+    ellipse cover,
+    $startColor 0%,
+    $endColor 100%
+  );
+  background: radial-gradient(
+    ellipse at center,
+    $startColor 0%,
+    $endColor 100%
+  );
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$startColor', endColorstr='$endColor',GradientType=1 );
 }
 
@@ -474,7 +510,6 @@ $cf-scrollbar-offset: 3px;
   }
 }
 
-
 // Block user select
 @mixin no-user-select() {
   user-select: none !important;
@@ -482,7 +517,8 @@ $cf-scrollbar-offset: 3px;
   -webkit-user-select: none !important;
   -ms-user-select: none !important;
   -o-user-select: none !important;
-  &, &:hover {
+  &,
+  &:hover {
     cursor: default;
   }
 }
@@ -492,7 +528,8 @@ $cf-scrollbar-offset: 3px;
   -webkit-user-select: none !important;
   -ms-user-select: none !important;
   -o-user-select: none !important;
-  &, &:hover {
+  &,
+  &:hover {
     cursor: default;
   }
 }

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -298,3 +298,25 @@ export const getRandomGradient = (): Gradients => {
 
   return Gradients[randomGradientKey]
 }
+
+export const checkForElementsAlreadyInFocus = (): boolean => {
+  const activeElement = document.activeElement
+
+  if (!activeElement) {
+    return false
+  }
+
+  const activeElementTag = activeElement.tagName.toLowerCase()
+
+  // Compiling this list based on https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
+  const focusableElements = [
+    'input',
+    'textarea',
+    'button',
+    'select',
+    'anchor',
+    'area',
+  ]
+
+  return focusableElements.includes(activeElementTag)
+}

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -212,7 +212,8 @@ export const getScrollbarColorsFromTheme = (
 export const createPortalElement = (
   id: string,
   portalName: string,
-  classNames?: string
+  classNames?: string,
+  addEventListener?: (element: HTMLElement) => void
 ): void => {
   const portalExists = document.getElementById(id)
   if (portalExists) {
@@ -229,6 +230,10 @@ export const createPortalElement = (
   portalElement.setAttribute('id', id)
 
   document.body.appendChild(portalElement)
+
+  if (addEventListener) {
+    updatePortalEventListener(id, addEventListener)
+  }
 }
 
 export const destroyPortalElement = (id: string): void => {
@@ -238,6 +243,17 @@ export const destroyPortalElement = (id: string): void => {
     portalElement.remove()
   } else {
     console.error('cannot portal find element')
+  }
+}
+
+export const updatePortalEventListener = (
+  id: string,
+  changeEventListener: (element: HTMLElement) => void
+): void => {
+  const portalElement = document.getElementById(id)
+
+  if (portalElement) {
+    changeEventListener(portalElement)
   }
 }
 

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -298,25 +298,3 @@ export const getRandomGradient = (): Gradients => {
 
   return Gradients[randomGradientKey]
 }
-
-export const checkForElementsAlreadyInFocus = (): boolean => {
-  const activeElement = document.activeElement
-
-  if (!activeElement) {
-    return false
-  }
-
-  const activeElementTag = activeElement.tagName.toLowerCase()
-
-  // Compiling this list based on https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
-  const focusableElements = [
-    'input',
-    'textarea',
-    'button',
-    'select',
-    'anchor',
-    'area',
-  ]
-
-  return focusableElements.includes(activeElementTag)
-}

--- a/src/Utils/popovers.ts
+++ b/src/Utils/popovers.ts
@@ -143,8 +143,8 @@ export const calculatePopoverStyles = (
         // Center the dialog horizontally above the trigger by default
         dialogStyles = {
           ...dialogStyles,
-          bottom: `${window.innerHeight - triggerRect.top}px`,
-          left: `${triggerRect.left + triggerRect.width / 2}px`,
+          bottom: `${Math.floor(window.innerHeight - triggerRect.top)}px`,
+          left: `${Math.floor(triggerRect.left + triggerRect.width / 2)}px`,
           transform: 'translateX(-50%)',
           paddingBottom: `${distanceFromTrigger}px`,
         }
@@ -162,7 +162,7 @@ export const calculatePopoverStyles = (
           // Align left edge of dialog to left edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            left: `${triggerRect.left}px`,
+            left: `${Math.floor(triggerRect.left)}px`,
             transform: 'translateX(0)',
           }
           caretStyles = {
@@ -173,7 +173,7 @@ export const calculatePopoverStyles = (
           // Align right edge of dialog to right edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            left: `${triggerRect.left + triggerRect.width}px`,
+            left: `${Math.floor(triggerRect.left + triggerRect.width)}px`,
             transform: 'translateX(-100%)',
           }
           caretStyles = {
@@ -194,8 +194,8 @@ export const calculatePopoverStyles = (
         // Center the dialog horizontally below the trigger by default
         dialogStyles = {
           ...dialogStyles,
-          top: `${triggerRect.top + triggerRect.height}px`,
-          left: `${triggerRect.left + triggerRect.width / 2}px`,
+          top: `${Math.floor(triggerRect.top + triggerRect.height)}px`,
+          left: `${Math.floor(triggerRect.left + triggerRect.width / 2)}px`,
           transform: 'translateX(-50%)',
           paddingTop: `${distanceFromTrigger}px`,
         }
@@ -213,7 +213,7 @@ export const calculatePopoverStyles = (
           // Align left edge of dialog to left edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            left: `${triggerRect.left}px`,
+            left: `${Math.floor(triggerRect.left)}px`,
             transform: 'translateX(0)',
           }
           caretStyles = {
@@ -224,7 +224,7 @@ export const calculatePopoverStyles = (
           // Align right edge of dialog to right edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            left: `${triggerRect.left + triggerRect.width}px`,
+            left: `${Math.floor(triggerRect.left + triggerRect.width)}px`,
             transform: 'translateX(-100%)',
           }
           caretStyles = {
@@ -245,8 +245,8 @@ export const calculatePopoverStyles = (
         // Center the dialog vertically to the left of the trigger by default
         dialogStyles = {
           ...dialogStyles,
-          left: `${triggerRect.left}px`,
-          top: `${triggerRect.top + triggerRect.height / 2}px`,
+          left: `${Math.floor(triggerRect.left)}px`,
+          top: `${Math.floor(triggerRect.top + triggerRect.height / 2)}px`,
           transform: 'translate(-100%, -50%)',
           paddingRight: `${distanceFromTrigger}px`,
         }
@@ -264,7 +264,7 @@ export const calculatePopoverStyles = (
           // Align left edge of dialog to top edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            top: `${triggerRect.top}px`,
+            top: `${Math.floor(triggerRect.top)}px`,
             transform: 'translate(-100%, 0)',
           }
           caretStyles = {
@@ -275,7 +275,7 @@ export const calculatePopoverStyles = (
           // Align right edge of dialog to bottom edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            top: `${triggerRect.top + triggerRect.height}px`,
+            top: `${Math.floor(triggerRect.top + triggerRect.height)}px`,
             transform: 'translate(-100%, -100%)',
           }
           caretStyles = {
@@ -296,8 +296,8 @@ export const calculatePopoverStyles = (
         // Center the dialog vertically to the right of the trigger by default
         dialogStyles = {
           ...dialogStyles,
-          left: `${triggerRect.left + triggerRect.width}px`,
-          top: `${triggerRect.top + triggerRect.height / 2}px`,
+          left: `${Math.floor(triggerRect.left + triggerRect.width)}px`,
+          top: `${Math.floor(triggerRect.top + triggerRect.height / 2)}px`,
           transform: 'translateY(-50%)',
           paddingLeft: `${distanceFromTrigger}px`,
         }
@@ -315,7 +315,7 @@ export const calculatePopoverStyles = (
           // Align left edge of dialog to top edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            top: `${triggerRect.top}px`,
+            top: `${Math.floor(triggerRect.top)}px`,
             transform: 'translateY(0)',
           }
           caretStyles = {
@@ -326,7 +326,7 @@ export const calculatePopoverStyles = (
           // Align right edge of dialog to bottom edge of trigger
           dialogStyles = {
             ...dialogStyles,
-            top: `${triggerRect.top + triggerRect.height}px`,
+            top: `${Math.floor(triggerRect.top + triggerRect.height)}px`,
             transform: 'translateY(-100%)',
           }
           caretStyles = {


### PR DESCRIPTION
Closes #501 

### Changes

- Popovers can be dismissed by hitting the escape key
  - The dialog component can be focusable and receive keyboard events
  - Keyboard events bubble up to the portal containing the popover and then it closes
  - `PopoverDialog` will make itself the browser's active element if nothing else is in focus
- Update documentation
  - Explain nuances of prop combinations
  - Add more permutations of props for manual testing
- Round numbers down to whole numbers when calculating popover position
  - This prevents fuzzy sub-pixel rendering of popovers
- If `visible` is true it will supersede the escape key behavior in the interest of complete external control

### Screenshots

<img width="1078" alt="Screen Shot 2020-05-21 at 12 07 48 PM" src="https://user-images.githubusercontent.com/2433762/82596169-bb01ad80-9b5b-11ea-9cf9-6f4300247e77.png">

Example of `PopoverDialog` deferring focus to an input with `autofocus={true}`:
![popover-doesnt-pull-focus](https://user-images.githubusercontent.com/2433762/84180992-4379bc80-aa3d-11ea-845c-c028203a4bd2.gif)



### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
