### PR TITLE
Require newer version of Yarn to ensure passing builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "github:influxdata/clockface"
   },
+  "engines": {
+    "yarn": "^1.22.4"
+  },
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@storybook/addon-info": "^5.2.5",


### PR DESCRIPTION
- Require Yarn `1.22.4` or higher

Running a build with this version of yarn works. It's possible that it could also build fine with a slightly older version as well but that has not been tested

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
