### PR TITLE
Refactor Portal-Based Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 2.3.2 (Unreleased)
 
+- [#526](https://github.com/influxdata/clockface/pull/526): Optimize portal-based components to share a single portal element
+- [#526](https://github.com/influxdata/clockface/pull/526): Introduce `usePortal` hook to interact with the Clockface portal system
 
 #### 2.3.1 (2020-06-23)
 

--- a/src/Components/Notification/Notification.scss
+++ b/src/Components/Notification/Notification.scss
@@ -71,7 +71,7 @@ $cf-notification-screen-margin: $cf-marg-c;
   content: none;
 }
 
-.cf-notification-portal {
+.cf-notification-container {
   position: fixed;
   display: inline-flex;
   flex-direction: column;

--- a/src/Components/Notification/Notification.tsx
+++ b/src/Components/Notification/Notification.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {forwardRef, useEffect} from 'react'
-import {createPortal} from 'react-dom'
 import {Transition} from 'react-spring/renderprops'
 import * as easings from 'd3-ease'
 
@@ -20,7 +19,7 @@ import {
 } from './NotificationDialog'
 
 // Utils
-import {createPortalElement, destroyPortalElement} from '../../Utils'
+import {usePortal} from '../../Utils/portals'
 
 // Styles
 import './Notification.scss'
@@ -39,8 +38,6 @@ export interface NotificationProps extends NotificationDialogProps {
 }
 
 export type NotificationRef = NotificationDialogRef
-
-const notificationsPortalName = `notification`
 
 const defaultNotificationStyle = {maxWidth: '500px'}
 
@@ -65,19 +62,7 @@ export const NotificationRoot = forwardRef<NotificationRef, NotificationProps>(
     },
     ref
   ) => {
-    const notificationsPortalId = `notification-container__${verticalAlignment}-${horizontalAlignment}`
-    const portalClassNames = `cf-notification__${verticalAlignment} cf-notification__${horizontalAlignment}`
-    createPortalElement(
-      notificationsPortalId,
-      notificationsPortalName,
-      portalClassNames
-    )
-
-    useEffect(() => {
-      return (): void => {
-        destroyPortalElement(notificationsPortalId)
-      }
-    }, [])
+    const {addNotificationToPortal} = usePortal()
 
     useEffect(() => {
       if (visible && duration !== Infinity) {
@@ -92,12 +77,6 @@ export const NotificationRoot = forwardRef<NotificationRef, NotificationProps>(
       if (onTimeout) {
         onTimeout(id)
       }
-    }
-
-    const portalElement = document.getElementById(notificationsPortalId)
-
-    if (!portalElement) {
-      return null
     }
 
     const transitionConfig = {
@@ -154,7 +133,11 @@ export const NotificationRoot = forwardRef<NotificationRef, NotificationProps>(
       </Transition>
     )
 
-    return createPortal(notificationElement, portalElement)
+    return addNotificationToPortal(
+      notificationElement,
+      horizontalAlignment,
+      verticalAlignment
+    )
   }
 )
 

--- a/src/Components/Overlay/Overlay.scss
+++ b/src/Components/Overlay/Overlay.scss
@@ -5,10 +5,6 @@
    -----------------------------------------------------------------------------
 */
 
-.cf-overlay-portal {
-  @include portal-style($cf-z--overlays);
-}
-
 // Mixins for shared styles
 %overlay-styles {
   position: absolute !important;
@@ -67,13 +63,12 @@
   @include no-user-select();
 }
 
-
 .cf-overlay--title {
   font-family: $cf-overlay--title-font;
   font-size: $cf-overlay--title-size;
   font-weight: $cf-overlay--title-weight;
   color: $cf-overlay--title-color;
-  
+
   .cf-overlay--header__dismissable & {
     width: calc(100% - #{$cf-overlay--header-height - 50px});
   }

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -50,6 +50,15 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
     <>
       <Transition
         items={visible}
+        from={{opacity: 0}}
+        enter={{opacity: 0.7}}
+        leave={{opacity: 0}}
+        config={transitionConfig}
+      >
+        {visible => visible && (props => renderMaskElement(props))}
+      </Transition>
+      <Transition
+        items={visible}
         from={{opacity: 0, transform: 'translateY(44px)'}}
         enter={{opacity: 1, transform: 'translateY(0)'}}
         leave={{opacity: 0, transform: 'translateY(44px)'}}
@@ -77,15 +86,6 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
             </DapperScrollbars>
           ))
         }
-      </Transition>
-      <Transition
-        items={visible}
-        from={{opacity: 0}}
-        enter={{opacity: 0.7}}
-        leave={{opacity: 0}}
-        config={transitionConfig}
-      >
-        {visible => visible && (props => renderMaskElement(props))}
       </Transition>
     </>
   )

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -1,14 +1,7 @@
 // Libraries
-import React, {
-  FunctionComponent,
-  CSSProperties,
-  useLayoutEffect,
-  useState,
-} from 'react'
-import {createPortal} from 'react-dom'
+import React, {FunctionComponent, CSSProperties} from 'react'
 import {Transition} from 'react-spring/renderprops'
 import classnames from 'classnames'
-import uuid from 'uuid'
 import * as easings from 'd3-ease'
 
 // Components
@@ -16,7 +9,7 @@ import {OverlayMask} from './OverlayMask'
 import {DapperScrollbars} from '../DapperScrollbars/DapperScrollbars'
 
 // Utils
-import {createPortalElement, destroyPortalElement} from '../../Utils'
+import {usePortal} from '../../Utils/portals'
 
 // Types
 import {StandardFunctionProps, InfluxColors} from '../../Types'
@@ -33,8 +26,6 @@ export interface OverlayProps extends StandardFunctionProps {
   transitionDuration?: number
 }
 
-const overlayPortalName = 'overlay'
-
 export const OverlayRoot: FunctionComponent<OverlayProps> = ({
   id,
   testID = 'overlay',
@@ -44,24 +35,7 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
   transitionDuration = 360,
   renderMaskElement = (style: CSSProperties) => <OverlayMask style={style} />,
 }) => {
-  const [portalID, setPortalID] = useState<string>('')
-
-  useLayoutEffect((): (() => void) => {
-    const newPortalID = `cf-${overlayPortalName}-portal-${uuid.v4()}`
-    !portalID && setPortalID(newPortalID)
-
-    createPortalElement(newPortalID, overlayPortalName)
-
-    return (): void => {
-      destroyPortalElement(newPortalID)
-    }
-  }, [])
-
-  const portalElement = document.getElementById(portalID)
-
-  if (!portalElement) {
-    return null
-  }
+  const {addElementToPortal} = usePortal()
 
   const transitionConfig = {
     duration: transitionDuration,
@@ -116,7 +90,7 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
     </>
   )
 
-  return createPortal(overlay, portalElement)
+  return addElementToPortal(overlay)
 }
 
 OverlayRoot.displayName = 'Overlay'

--- a/src/Components/Popover/Base/Popover.scss
+++ b/src/Components/Popover/Base/Popover.scss
@@ -5,10 +5,6 @@
   ------------------------------------------------------------------------------
 */
 
-.cf-popover-portal {
-  @include portal-style($cf-z--popovers);
-}
-
 .cf-popover {
   position: fixed;
   z-index: 9999;
@@ -23,7 +19,7 @@
   background-color: $g2-kevlar;
   border-radius: $cf-radius + $cf-border;
   position: relative;
-  
+
   .cf-popover__solid & {
     box-shadow: 0 2px 5px 0.6px rgba($g0-obsidian, 0.2);
   }
@@ -50,7 +46,12 @@
   ------------------------------------------------------------------------------
 */
 
-@mixin popoverColorModifier($solidColor, $outlineColor, $glowColor, $textColor) {
+@mixin popoverColorModifier(
+  $solidColor,
+  $outlineColor,
+  $glowColor,
+  $textColor
+) {
   // Solid Type
   &.cf-popover__solid .cf-popover--contents {
     background-color: $solidColor;
@@ -70,7 +71,12 @@
 }
 
 .cf-popover__default {
-  @include popoverColorModifier($g6-smoke, $g11-sidewalk, $g8-storm, $g15-platinum);
+  @include popoverColorModifier(
+    $g6-smoke,
+    $g11-sidewalk,
+    $g8-storm,
+    $g15-platinum
+  );
 }
 .cf-popover__primary {
   @include popoverColorModifier($c-pool, $c-pool, $c-ocean, $g20-white);
@@ -79,7 +85,12 @@
   @include popoverColorModifier($c-star, $c-comet, $c-star, $g20-white);
 }
 .cf-popover__success {
-  @include popoverColorModifier($c-rainforest, $c-honeydew, $c-rainforest, $g20-white);
+  @include popoverColorModifier(
+    $c-rainforest,
+    $c-honeydew,
+    $c-rainforest,
+    $g20-white
+  );
 }
 .cf-popover__warning {
   @include popoverColorModifier($c-pineapple, $c-thunder, $c-tiger, $g3-castle);

--- a/src/Components/RightClick/Base/RightClick.scss
+++ b/src/Components/RightClick/Base/RightClick.scss
@@ -5,10 +5,6 @@
   ------------------------------------------------------------------------------
 */
 
-.cf-right-click-portal {
-  @include portal-style($cf-z--right-click);
-}
-
 .cf-right-click {
   position: fixed;
   z-index: 9999;

--- a/src/Components/RightClick/Base/RightClick.tsx
+++ b/src/Components/RightClick/Base/RightClick.tsx
@@ -7,14 +7,12 @@ import React, {
   MouseEvent,
   forwardRef,
 } from 'react'
-import {createPortal} from 'react-dom'
-import uuid from 'uuid'
 
 // Components
 import {RightClickMenu, RightClickMenuRef} from './RightClickMenu'
 
 // Utils
-import {createPortalElement, destroyPortalElement} from '../../../Utils/index'
+import {usePortal} from '../../../Utils/portals'
 
 // Styles
 import './RightClick.scss'
@@ -41,8 +39,6 @@ export interface RightClickProps extends StandardFunctionProps {
 
 export type RightClickRef = RightClickMenuRef
 
-const rightClickPortalName = 'right-click'
-
 export const RightClickRoot = forwardRef<RightClickRef, RightClickProps>(
   (
     {
@@ -60,18 +56,13 @@ export const RightClickRoot = forwardRef<RightClickRef, RightClickProps>(
     ref
   ) => {
     const [expanded, setExpanded] = useState<boolean>(false)
-    const [portalID, setPortalID] = useState<string>('')
+    const {addElementToPortal} = usePortal()
     const mouseOffset = useRef<Coordinates>({x: 0, y: 0})
 
     useEffect((): (() => void) => {
-      const newPortalID = `cf-${rightClickPortalName}-portal-${uuid.v4()}`
-      setPortalID(newPortalID)
-
-      createPortalElement(newPortalID, rightClickPortalName)
       handleAddEventListeners()
 
       return (): void => {
-        destroyPortalElement(newPortalID)
         handleRemoveEventListeners()
       }
     }, [])
@@ -124,9 +115,7 @@ export const RightClickRoot = forwardRef<RightClickRef, RightClickProps>(
       triggerRef.current.removeEventListener('contextmenu', handleTriggerClick)
     }
 
-    const portalElement = document.getElementById(portalID)
-
-    if (!portalElement || !expanded) {
+    if (!expanded) {
       return null
     }
 
@@ -146,7 +135,7 @@ export const RightClickRoot = forwardRef<RightClickRef, RightClickProps>(
       </RightClickMenu>
     )
 
-    return createPortal(rightClickMenu, portalElement)
+    return addElementToPortal(rightClickMenu)
   }
 )
 

--- a/src/Sandbox/Portals.md
+++ b/src/Sandbox/Portals.md
@@ -1,0 +1,15 @@
+# Interplay of all portals
+
+This sandbox tests how all the portal-based components interact with each other. Notes on how stacking order is determined:
+
+- Notifications always appear on top
+- Portal elements receive an incrementally higher `z-index` as they are added to the portal
+  - This means portal elements will stack in the order they are added
+
+### Example
+
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->

--- a/src/Sandbox/Portals.stories.tsx
+++ b/src/Sandbox/Portals.stories.tsx
@@ -35,14 +35,23 @@ alertStories.add(
     const triggerRefA = useRef<HTMLDivElement>(null)
     const triggerRefB = useRef<HTMLDivElement>(null)
     const triggerRefC = useRef<HTMLDivElement>(null)
-    const [overlayState, setOverlayState] = useState<boolean>(false)
+    const [firstOverlayState, setFirstOverlayState] = useState<boolean>(false)
+    const [secondOverlayState, setSecondOverlayState] = useState<boolean>(false)
 
-    const handleDismissOverlay = (): void => {
-      setOverlayState(false)
+    const handleDismissFirstOverlay = (): void => {
+      setFirstOverlayState(false)
     }
 
-    const handleShowOverlay = (): void => {
-      setOverlayState(true)
+    const handleShowFirstOverlay = (): void => {
+      setFirstOverlayState(true)
+    }
+
+    const handleDismissSecondOverlay = (): void => {
+      setSecondOverlayState(false)
+    }
+
+    const handleShowSecondOverlay = (): void => {
+      setSecondOverlayState(true)
     }
 
     return (
@@ -57,7 +66,7 @@ alertStories.add(
           contents={() => (
             <div
               className="mockComponent mockButton"
-              onClick={handleShowOverlay}
+              onClick={handleShowFirstOverlay}
             >
               Show Overlay
             </div>
@@ -70,11 +79,11 @@ alertStories.add(
         >
           I am notifying you!
         </Notification>
-        <Overlay visible={overlayState}>
+        <Overlay visible={firstOverlayState}>
           <Overlay.Container maxWidth={500}>
             <Overlay.Header
               title="Overlay Example"
-              onDismiss={handleDismissOverlay}
+              onDismiss={handleDismissFirstOverlay}
             />
             <Overlay.Body>
               <p>I should be below the Notification</p>
@@ -91,16 +100,24 @@ alertStories.add(
                 contents={() => <>I'm a nested popover!</>}
               />
               <RightClick triggerRef={triggerRefC}>
-                <RightClick.MenuItem
-                  onClick={() => {
-                    /* eslint-disable */
-                    console.log('boosh!')
-                    /* eslint-enable */
-                  }}
-                >
-                  Boosh!
+                <RightClick.MenuItem onClick={handleShowSecondOverlay}>
+                  Show another overlay
                 </RightClick.MenuItem>
               </RightClick>
+            </Overlay.Body>
+          </Overlay.Container>
+        </Overlay>
+        <Overlay visible={secondOverlayState}>
+          <Overlay.Container maxWidth={300}>
+            <Overlay.Header
+              title="Another Overlay"
+              onDismiss={handleDismissSecondOverlay}
+            />
+            <Overlay.Body>
+              <p>
+                I should be on top of the previous Overlay but still underneath
+                the Notification
+              </p>
             </Overlay.Body>
           </Overlay.Container>
         </Overlay>

--- a/src/Sandbox/Portals.stories.tsx
+++ b/src/Sandbox/Portals.stories.tsx
@@ -1,0 +1,115 @@
+// Libraries
+import React, {useRef} from 'react'
+import marked from 'marked'
+
+// Storybook
+import {storiesOf} from '@storybook/react'
+import {withKnobs} from '@storybook/addon-knobs'
+import {useState} from '@storybook/addons'
+
+// Components
+import {Popover} from '../Components/Popover'
+import {Overlay} from '../Components/Overlay'
+import {Notification} from '../Components/Notification'
+import {RightClick} from '../Components/RightClick'
+
+// Types
+import {
+  ComponentColor,
+  IconFont,
+  ComponentSize,
+  Gradients,
+  Appearance,
+} from '../Types'
+
+// Notes
+import PortalsReadme from './Portals.md'
+
+const alertStories = storiesOf('Sandbox|Portal Elements', module).addDecorator(
+  withKnobs
+)
+
+alertStories.add(
+  'Interplay of all portals',
+  () => {
+    const triggerRefA = useRef<HTMLDivElement>(null)
+    const triggerRefB = useRef<HTMLDivElement>(null)
+    const triggerRefC = useRef<HTMLDivElement>(null)
+    const [overlayState, setOverlayState] = useState<boolean>(false)
+
+    const handleDismissOverlay = (): void => {
+      setOverlayState(false)
+    }
+
+    const handleShowOverlay = (): void => {
+      setOverlayState(true)
+    }
+
+    return (
+      <div className="story--example">
+        <div className="mockComponent mockButton" ref={triggerRefA}>
+          Click Me
+        </div>
+        <Popover
+          triggerRef={triggerRefA}
+          appearance={Appearance.Outline}
+          color={ComponentColor.Primary}
+          contents={() => (
+            <div
+              className="mockComponent mockButton"
+              onClick={handleShowOverlay}
+            >
+              Show Overlay
+            </div>
+          )}
+        />
+        <Notification
+          icon={IconFont.CrownSolid}
+          size={ComponentSize.Small}
+          gradient={Gradients.PolarExpress}
+        >
+          I am notifying you!
+        </Notification>
+        <Overlay visible={overlayState}>
+          <Overlay.Container maxWidth={500}>
+            <Overlay.Header
+              title="Overlay Example"
+              onDismiss={handleDismissOverlay}
+            />
+            <Overlay.Body>
+              <p>I should be below the Notification</p>
+              <div className="mockComponent mockButton" ref={triggerRefB}>
+                Another Popover
+              </div>
+              <div className="mockComponent mockButton" ref={triggerRefC}>
+                Right Click Me
+              </div>
+              <Popover
+                triggerRef={triggerRefB}
+                appearance={Appearance.Solid}
+                color={ComponentColor.Success}
+                contents={() => <>I'm a nested popover!</>}
+              />
+              <RightClick triggerRef={triggerRefC}>
+                <RightClick.MenuItem
+                  onClick={() => {
+                    /* eslint-disable */
+                    console.log('boosh!')
+                    /* eslint-enable */
+                  }}
+                >
+                  Boosh!
+                </RightClick.MenuItem>
+              </RightClick>
+            </Overlay.Body>
+          </Overlay.Container>
+        </Overlay>
+      </div>
+    )
+  },
+  {
+    readme: {
+      content: marked(PortalsReadme),
+    },
+  }
+)

--- a/src/Styles/portals.scss
+++ b/src/Styles/portals.scss
@@ -1,0 +1,13 @@
+@import './variables';
+
+/*
+   Reset
+   -----------------------------------------------------------------------------
+*/
+
+.cf-portal {
+  z-index: $cf-z--portal;
+  position: fixed;
+  top: 0;
+  left: 0;
+}

--- a/src/Styles/portals.scss
+++ b/src/Styles/portals.scss
@@ -10,4 +10,12 @@
   position: fixed;
   top: 0;
   left: 0;
+
+  // NOTE: If for some reason there are more than 50 elements in the portal the
+  // z-index stacking will breakdown
+  @for $i from 1 through 50 {
+    & > *:nth-child(#{$i}):not(.cf-notification-container) {
+      z-index: #{$i * 10};
+    }
+  }
 }

--- a/src/Styles/shared.scss
+++ b/src/Styles/shared.scss
@@ -3,3 +3,4 @@
 @import './helpers.scss';
 @import './icon.scss';
 @import './typography.scss';
+@import './portals.scss';

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -89,16 +89,12 @@ $c-pulsar: #513cc6;
    Might not actually need any of these yet
 */
 
-$cf-z--portal: 9000;
-$cf-z--notifications: 9999;
-$cf-z--right-click: 9980;
-$cf-z--popovers: 9960;
-$cf-z--draggable-resizer-mask: 9950;
-$cf-z--overlays: 9940;
 $cf-z--nav-toggle: 9999;
+$cf-z--draggable-resizer-mask: 9950;
+$cf-z--notifications: 9900;
 $cf-z--nav-menu: 9900;
 $cf-z--nav-mask: 9890;
-$cf-z--drag-n-drop: 5000;
+$cf-z--portal: 9000;
 $cf-z--tabs-dropdown: 8000;
 
 /*
@@ -544,13 +540,6 @@ $cf-scrollbar-offset: 3px;
 }
 @mixin panel-shadow {
   box-shadow: 0 1px 4px 1px rgba($g0-obsidian, 0.2);
-}
-
-@mixin portal-style($z) {
-  z-index: $z;
-  position: fixed;
-  top: 0;
-  left: 0;
 }
 
 @mixin funnel-page-background() {

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -544,7 +544,7 @@ $cf-scrollbar-offset: 3px;
 
 @mixin funnel-page-background() {
   z-index: $funnel-page--graphic-z;
-  // background-image: url('./Images/FunnelPageGraphic.svg');
+  background-image: url('./Images/FunnelPageGraphic.svg');
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -89,6 +89,7 @@ $c-pulsar: #513cc6;
    Might not actually need any of these yet
 */
 
+$cf-z--portal: 9000;
 $cf-z--notifications: 9999;
 $cf-z--right-click: 9980;
 $cf-z--popovers: 9960;
@@ -554,7 +555,7 @@ $cf-scrollbar-offset: 3px;
 
 @mixin funnel-page-background() {
   z-index: $funnel-page--graphic-z;
-  background-image: url('./Images/FunnelPageGraphic.svg');
+  // background-image: url('./Images/FunnelPageGraphic.svg');
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -219,54 +219,6 @@ export const getScrollbarColorsFromTheme = (
   }
 }
 
-export const createPortalElement = (
-  id: string,
-  portalName: string,
-  classNames?: string,
-  addEventListener?: (element: HTMLElement) => void
-): void => {
-  const portalExists = document.getElementById(id)
-  if (portalExists) {
-    return
-  }
-
-  const additionalClassNames = classNames ? ' ' + classNames : ''
-
-  const portalElement = document.createElement('div')
-  portalElement.setAttribute(
-    'class',
-    `cf-${portalName}-portal${additionalClassNames}`
-  )
-  portalElement.setAttribute('id', id)
-
-  document.body.appendChild(portalElement)
-
-  if (addEventListener) {
-    updatePortalEventListener(id, addEventListener)
-  }
-}
-
-export const destroyPortalElement = (id: string): void => {
-  const portalElement = document.getElementById(id)
-
-  if (portalElement) {
-    portalElement.remove()
-  } else {
-    console.error('cannot portal find element')
-  }
-}
-
-export const updatePortalEventListener = (
-  id: string,
-  changeEventListener: (element: HTMLElement) => void
-): void => {
-  const portalElement = document.getElementById(id)
-
-  if (portalElement) {
-    changeEventListener(portalElement)
-  }
-}
-
 export const getDictionary = (): string[] => {
   const hipsterIpsum =
     "Ennui yr chartreuse poutine, cronut fixie brooklyn twee PBR&B irony authentic biodiesel hammock normcore gochujang. Lo-fi roof party brooklyn 90's keytar pop-up butcher. Polaroid fixie skateboard mixtape, actually church-key listicle meditation four dollar toast tilde snackwave. Tofu asymmetrical YOLO waistcoat narwhal taxidermy lyft flexitarian kitsch tbh vape small batch. Trust fund plaid hot chicken, typewriter aesthetic sriracha thundercats kitsch marfa truffaut.Tbh DIY banjo, health goth franzen aesthetic hashtag cray readymade.Pug everyday carry health goth, keffiyeh migas pop - up vape farm - to - table chicharrones fashion axe banjo echo park austin flannel polaroid.Brunch deep v health goth, crucifix ramps bespoke whatever intelligentsia. 90's brunch bitters artisan green juice chicharrones. Fingerstache ramps photo booth thundercats heirloom brooklyn neutra etsy man bun affogato marfa waistcoat. Beard pinterest franzen umami bitters chicharrones tumeric roof party deep v gastropub.Four dollar toast everyday carry actually, art party prism bushwick tbh celiac wolf.Celiac deep v blue bottle, iPhone kale chips hoodie raclette.Messenger bag sustainable enamel pin tofu brooklyn vice plaid.Enamel pin flexitarian lyft, chicharrones sriracha gluten - free tilde cloud bread bespoke godard.Jianbing ennui paleo etsy migas forage. Fingerstache tumblr food truck quinoa shabby chic schlitz heirloom pour - over.Chillwave tumeric venmo, +1 brooklyn pop - up gastropub kogi 8 - bit.Drinking vinegar letterpress flexitarian tumeric tofu yr vinyl edison bulb fam cliche ennui.Butcher pitchfork knausgaard 90's. Offal sartorial aesthetic, art party adaptogen truffaut literally. Forage pitchfork kickstarter you probably haven't heard of them, scenester retro schlitz salvia ennui kale chips etsy. Pabst gastropub occupy vinyl, shabby chic poke tumeric cred coloring book everyday carry artisan sriracha knausgaard put a bird on it bitters. Tofu yr banjo, artisan marfa cloud bread seitan +1 ugh pork belly chia. Health goth jean shorts brooklyn polaroid pickled bicycle rights salvia af, cliche occupy dreamcatcher unicorn. Seitan meh bitters affogato, kale chips copper mug meggings microdosing godard jianbing brunch direct trade. Banh mi literally schlitz, meggings master cleanse mlkshk bushwick artisan dreamcatcher 90's humblebrag."

--- a/src/Utils/portals.ts
+++ b/src/Utils/portals.ts
@@ -1,5 +1,6 @@
-import {ReactPortal} from 'react'
+import {ReactPortal, ReactNode} from 'react'
 import {createPortal} from 'react-dom'
+import {VerticalAlignment, Alignment} from '../Types'
 
 const portalElementID = 'cf-portal'
 
@@ -23,12 +24,61 @@ const getPortalElement = (): HTMLElement => {
   return portal
 }
 
-export const usePortals = () => {
+const createNotificationContainer = (
+  x: Alignment,
+  y: VerticalAlignment
+): HTMLElement => {
+  const container = document.createElement('div')
+  container.setAttribute(
+    'class',
+    `cf-notification-container cf-notification__${x} cf-notification__${y}`
+  )
+  container.setAttribute('id', `cf-notification-container-${x}-${y}`)
+
   const portal = getPortalElement()
 
-  const addElementToPortal = (element: JSX.Element): ReactPortal => {
+  portal.appendChild(container)
+
+  return container
+}
+
+const getNotificationContainer = (
+  x: Alignment,
+  y: VerticalAlignment
+): HTMLElement => {
+  let container = document.getElementById(`cf-notification-container-${x}-${y}`)
+
+  if (!container) {
+    container = createNotificationContainer(x, y)
+  }
+
+  return container
+}
+
+export const usePortal = () => {
+  const portal = getPortalElement()
+
+  const addElementToPortal = (element: ReactNode): ReactPortal => {
     return createPortal(element, portal)
   }
 
-  return [addElementToPortal]
+  const addNotificationToPortal = (
+    element: ReactNode,
+    x: Alignment,
+    y: VerticalAlignment
+  ): ReactPortal => {
+    const container = getNotificationContainer(x, y)
+
+    return createPortal(element, container)
+  }
+
+  const addEventListenerToPortal = portal.addEventListener
+  const removeEventListenerToPortal = portal.removeEventListener
+
+  return {
+    addElementToPortal,
+    addNotificationToPortal,
+    addEventListenerToPortal,
+    removeEventListenerToPortal,
+  }
 }

--- a/src/Utils/portals.ts
+++ b/src/Utils/portals.ts
@@ -1,0 +1,34 @@
+import {ReactPortal} from 'react'
+import {createPortal} from 'react-dom'
+
+const portalElementID = 'cf-portal'
+
+const createPortalElement = (): HTMLElement => {
+  const portalElement = document.createElement('div')
+  portalElement.setAttribute('class', portalElementID)
+  portalElement.setAttribute('id', portalElementID)
+
+  document.body.appendChild(portalElement)
+
+  return portalElement
+}
+
+const getPortalElement = (): HTMLElement => {
+  let portal = document.getElementById(portalElementID)
+
+  if (!portal) {
+    portal = createPortalElement()
+  }
+
+  return portal
+}
+
+export const usePortals = () => {
+  const portal = getPortalElement()
+
+  const addElementToPortal = (element: JSX.Element): ReactPortal => {
+    return createPortal(element, portal)
+  }
+
+  return [addElementToPortal]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,3 +61,6 @@ export * from './Components/Typography/index'
 export * from './Types/index'
 export * from './Constants/index'
 export * from './Components/RBAC'
+
+// Utilities
+export {usePortal} from './Utils/portals'


### PR DESCRIPTION
### Problem

- Having a dedicated portal element for every instance of a portal-based component can result in a lot of re-rendering

### Changes

- Since the previous decision was to enable portal-based components to be used independently of the rest of Clockface, this changeset preserves that goal
- Introduce `usePortal` hook and export alongside components
  - Refactor portal-based components to use `usePortal` hook
  - `usePortal` creates a portal element as soon as it is needed, then it remains in place for all subsequent components to use.
  - Ensures that a single portal element is always visible
- Refactor `z-index` variables
  - Notifications will always be on top
  - Elements sent to the portal will stack in the order they were sent
    - This follows the users journey and feels natural
- Create storybook section called "Sandbox" for stories that test interplay between multiple types of components

### Bonus

- Since there is an ever-present portal element, components that rely on mount/unmount transitions animate much more smoothly

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
