### PR TITLE
fix(clockface): relax engine requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 2.3.2 (Unreleased)
 
+- [#531](https://github.com/influxdata/clockface/pull/531): Relax Yarn engine requirement
 - [#530](https://github.com/influxdata/clockface/pull/530): Optimize portal-based components to share a single portal element
 - [#530](https://github.com/influxdata/clockface/pull/530): Introduce `usePortal` hook to interact with the Clockface portal system
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "github:influxdata/clockface"
   },
   "engines": {
-    "yarn": "^1.22.4"
+    "yarn": ">=1.16.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
### Changes
Relaxes the Yarn engine version requirement to `>=1.16.0` to prevent breaking CI.

### Checklist
Check all that apply

- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
