### PR TITLE
Fix usePortal Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-#### 2.3.4 (Unreleased)
+#### 2.3.5 (Unreleased)
 
+#### 2.3.4 (2020-08-17)
+
+- [#540](https://github.com/influxdata/clockface/pull/540): Fix critical bugs in `usePortal` hook
 - [#535](https://github.com/influxdata/clockface/pull/535): Pass back optional event object to `ListItem` click handler
 
 #### 2.3.3 (2020-08-11)

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -75,7 +75,7 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
       contents,
       className,
       triggerRef,
-      forceToTop,
+      forceToTop = false,
       caretSize = 8,
       visible,
       disabled = false,

--- a/src/Components/Popover/Base/Popover.tsx
+++ b/src/Components/Popover/Base/Popover.tsx
@@ -55,6 +55,8 @@ export interface PopoverProps extends StandardFunctionProps {
   triggerRef: RefObject<any>
   /** Adds reasonable styles to popover dialog contents so you do not have to */
   enableDefaultStyles?: boolean
+  /** Ensures the popover appears above all other portal elements */
+  forceToTop?: boolean
 }
 
 export type PopoverRef = PopoverDialogRef
@@ -73,6 +75,7 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
       contents,
       className,
       triggerRef,
+      forceToTop,
       caretSize = 8,
       visible,
       disabled = false,
@@ -246,7 +249,7 @@ export const PopoverRoot = forwardRef<PopoverRef, PopoverProps>(
       />
     )
 
-    return addElementToPortal(popover)
+    return addElementToPortal(popover, forceToTop)
   }
 )
 

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -129,7 +129,9 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
 
     useLayoutEffect((): (() => void) => {
       handleUpdateStyles()
-      observer.observe(triggerRef.current)
+      if (triggerRef.current) {
+        observer.observe(triggerRef.current)
+      }
       // The third argument in addEventListener is "false" by default and controls bubbling
       // scroll events do not bubble by default so setting this to "true"
       // allows the listener to pick up scroll events from nested scrollable elements

--- a/src/Components/Popover/Base/PopoverDialog.tsx
+++ b/src/Components/Popover/Base/PopoverDialog.tsx
@@ -158,11 +158,13 @@ export const PopoverDialog = forwardRef<PopoverDialogRef, PopoverDialogProps>(
     // Ensure dialog element is in focus on mount
     // in order to enable escape key behavior
     useEffect(() => {
-      const okayToPullFocus = !document.activeElement
+      const okayToPullFocus =
+        document.activeElement?.tagName !== 'INPUT' &&
+        document.activeElement?.tagName !== 'SELECT'
       if (dialogRef.current && okayToPullFocus) {
         dialogRef.current.focus()
       }
-    }, [])
+    }, [dialogRef])
 
     return (
       <ClickOutside onClickOutside={onClickOutside}>

--- a/src/Components/Popover/Documentation/Popover.md
+++ b/src/Components/Popover/Documentation/Popover.md
@@ -5,13 +5,21 @@ Popovers are similar to Overlays in that they are triggered by a (usually) small
 This component can be configured to operate entirely on hover interactions which, makes it essentially a tooltip. The popover dialog will initially appear according to the `position` prop, but if for some reason the dialog would go off the viewport it will be intelligently repositioned to appear wholly in the viewport.
 
 ### Usage
+
 ```tsx
-import {Popover, PopoverPosition, PopoverInteraction} from '@influxdata/clockface'
+import {
+  Popover,
+  PopoverPosition,
+  PopoverInteraction,
+} from '@influxdata/clockface'
 ```
+
 First you will need to create a `ref` for your trigger element:
+
 ```tsx
 private triggerRef: createRef<HTMLDivElement>()
 ```
+
 ```tsx
 <div ref={triggerRef}>Trigger Element</div>
 <Popover
@@ -25,10 +33,10 @@ private triggerRef: createRef<HTMLDivElement>()
 
 The requisite event handlers are automatically bound to the trigger element. Make sure your trigger element does not have event handlers that will conflict with `Popover`.
 
-
 ### Included Dismiss Button
 
 if you want to have an explicit dismiss button in the top right corner of the popover, you can use this component:
+
 ```tsx
 <Popover
   contents={onHide => (
@@ -38,14 +46,17 @@ if you want to have an explicit dismiss button in the top right corner of the po
   )}
 />
 ```
+
 Make sure to use the available `onHide` argument and pass it into your dismiss button
 
 ### Example
+
 <!-- STORY -->
 
 ### Want more control over style within a Popover?
 
 By default `Popover` will apply reasonable default styles to the dialog to save you time. However you may be building a more specialized design and want more control. Rather than fight the default styles you can simply turn them off:
+
 ```tsx
 <Popover enableDefaultStyles={false} />
 ```
@@ -53,6 +64,10 @@ By default `Popover` will apply reasonable default styles to the dialog to save 
 ### Gotchas
 
 By default all `Popover` instances will be in focus when they appear so that pressing the `Escape` key dismisses them. If a `Popover` has its state controlled externally via the `visible` prop then the `Escape` key listener is disabled in deference.
+
+### WARNING: `forceToTop`
+
+This prop should only be used as a last resort. It should be avoided at all costs. If true, the `Popover` will have its `z-index` set to `9999`. If this prop is `true` on multiple portal elements they will collide and be extremely difficult to manage.
 
 <!-- STORY HIDE START -->
 

--- a/src/Utils/portals.tsx
+++ b/src/Utils/portals.tsx
@@ -1,4 +1,4 @@
-import {ReactPortal, ReactNode} from 'react'
+import React, {ReactPortal, ReactNode} from 'react'
 import {createPortal} from 'react-dom'
 import {VerticalAlignment, Alignment} from '../Types'
 
@@ -8,6 +8,7 @@ const createPortalElement = (): HTMLElement => {
   const portalElement = document.createElement('div')
   portalElement.setAttribute('class', portalElementID)
   portalElement.setAttribute('id', portalElementID)
+  portalElement.setAttribute('tabindex', '1')
 
   document.body.appendChild(portalElement)
 
@@ -58,8 +59,17 @@ const getNotificationContainer = (
 export const usePortal = () => {
   const portal = getPortalElement()
 
-  const addElementToPortal = (element: ReactNode): ReactPortal => {
-    return createPortal(element, portal)
+  const addElementToPortal = (
+    element: ReactNode,
+    forceToTop?: boolean
+  ): ReactPortal => {
+    let registeredElement = element
+
+    if (forceToTop) {
+      registeredElement = <div style={{zIndex: 9999}}>{element}</div>
+    }
+
+    return createPortal(registeredElement, portal)
   }
 
   const addNotificationToPortal = (
@@ -72,8 +82,13 @@ export const usePortal = () => {
     return createPortal(element, container)
   }
 
-  const addEventListenerToPortal = portal.addEventListener
-  const removeEventListenerFromPortal = portal.removeEventListener
+  const addEventListenerToPortal = (eventType: string, func: any) => {
+    portal.addEventListener(eventType, func)
+  }
+
+  const removeEventListenerFromPortal = (eventType: string, func: any) => {
+    portal.removeEventListener(eventType, func)
+  }
 
   return {
     addElementToPortal,


### PR DESCRIPTION
Closes #537

### Changes

- Rework how event listeners get added to portals
- Allow elements passed in to `usePortal` to be forced to the top
  - Only needed this for 1 instance in InfluxDB
  - Not very elegant but allows e2e test to pass
- Make popovers less likely to lose focus
- Guard against trigger not yet existing before applying intersection observer

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
