### PR TITLE
Improve TreeNav testIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 2.3.5 (Unreleased)
 
+- [#541](https://github.com/influxdata/clockface/pull/541): Improve `testID` usability in `TreeNav` component
+
 #### 2.3.4 (2020-08-17)
 
 - [#540](https://github.com/influxdata/clockface/pull/540): Fix critical bugs in `usePortal` hook

--- a/src/Components/TreeNav/TreeNav.tsx
+++ b/src/Components/TreeNav/TreeNav.tsx
@@ -77,7 +77,11 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
     if (onToggleClick) {
       const toggleIcon = expanded ? IconFont.Minimize : IconFont.Maximize
       toggleElement = (
-        <div className="cf-tree-nav--toggle" onClick={onToggleClick}>
+        <div
+          className="cf-tree-nav--toggle"
+          onClick={onToggleClick}
+          data-testid={`${testID}-toggle`}
+        >
           <Icon glyph={toggleIcon} />
         </div>
       )
@@ -113,6 +117,7 @@ export const TreeNavRoot = forwardRef<TreeNavRef, TreeNavProps>(
         {toggleElement}
         <div
           className="cf-tree-nav--mobile-toggle"
+          data-testid={`${testID}-mobile-toggle`}
           onClick={handleMobileToggleClick}
         >
           <div className="cf-tree-nav--hamburger" />

--- a/src/Components/TreeNav/TreeNavSubItem.tsx
+++ b/src/Components/TreeNav/TreeNavSubItem.tsx
@@ -40,7 +40,11 @@ export const TreeNavSubItem: FunctionComponent<TreeNavSubItemProps> = ({
   }
 
   let labelElement = (
-    <div className="cf-tree-nav--sub-item-label" onClick={handleClick}>
+    <div
+      className="cf-tree-nav--sub-item-label"
+      onClick={handleClick}
+      data-testid={testID}
+    >
       {label}
     </div>
   )
@@ -54,12 +58,7 @@ export const TreeNavSubItem: FunctionComponent<TreeNavSubItemProps> = ({
   }
 
   return (
-    <div
-      id={id}
-      className={treeNavSubItemClass}
-      style={style}
-      data-testid={testID}
-    >
+    <div id={id} className={treeNavSubItemClass} style={style}>
       {labelElement}
     </div>
   )


### PR DESCRIPTION
Closes #539 
Closes #538 

### Changes

- Add `testID`s to the toggle and mobile toggle elements of `TreeNav`
- Ensure the `testID` on `TreeNavSubItem` is not duplicated when a link element is passed in

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
