### PR TITLE
chore: make curly braces required

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     }
   },
   "rules": {
+    "curly": ["error", "all"],
     "no-console": ["error", {"allow": ["warn", "error"]}],
     "no-empty": "off",
     "getter-return": "off",


### PR DESCRIPTION
eslint: makes curly braces required

```js

// not so good, very easy to introduce bugs, relies on machines to save us
if (condition)
  exit(0)

// more thoughtful approach
if (condition) {
  exit(0)
}