### PR TITLE
fix(inputs): handle checkbox clicks/changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 #### 2.3.5 (Unreleased)
-
+- [#554](https://github.com/influxdata/clockface/pull/554): Allow click/change handling on checkbox Input
 - [#551](https://github.com/influxdata/clockface/pull/551): Introduce `TimeInput` component
 - [#550](https://github.com/influxdata/clockface/pull/550): Introduce `ButtonGroup` component
 - [#550](https://github.com/influxdata/clockface/pull/550): Make `ConfirmationButton` appear in active state while popover is visible


### PR DESCRIPTION
### Changes

When an input checkbox is clicked it targets a div instead of the
actual input. This change uses a ref to the input to forward clicks on
the div to the input.


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
