### PR TITLE
Feat/overlay escape key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 2.3.8 (Unreleased)
 
+- [#559](https://github.com/influxdata/clockface/pull/560): Add `onEscape` prop that takes in state handler and enables closing of overlays on escape keypress
+
 #### 2.3.7 (2020-12-02)
 
 - [#558](https://github.com/influxdata/clockface/pull/558): Update `Book`, `BookCode`, and `BookPencil` icons. Add `CurrencyEUR`, `CurrencyGBP`, `CurrencyUSD`, `Layers`, `Share`, `ShareSolid` and `Shield` icons

--- a/src/Components/Overlay/Documentation/Overlay.stories.tsx
+++ b/src/Components/Overlay/Documentation/Overlay.stories.tsx
@@ -13,6 +13,7 @@ import {
   select,
 } from '@storybook/addon-knobs'
 import {mapEnumKeys} from '../../../Utils/storybook'
+import {useState} from '@storybook/addons'
 
 // Components
 import {OverlayRoot as Overlay} from '../Overlay'
@@ -329,6 +330,69 @@ overlayExampleStories.add(
       </Overlay>
     </div>
   ),
+  {
+    readme: {
+      content: marked(ConfirmationOverlayReadme),
+    },
+  }
+)
+
+overlayExampleStories.add(
+  'Overlay with Escape Handler',
+  () => {
+    const [visible, setVisibility] = useState<boolean>(false)
+
+    const handleDismiss = (): void => {
+      setVisibility(false)
+    }
+
+    const handleShow = (): void => {
+      setVisibility(true)
+    }
+
+    const handleEscape = (): void => {
+      console.log('hi')
+    }
+
+    return (
+      <div className="story--example">
+        <div className="mockComponent mockButton" onClick={handleShow}>
+          Click Me
+        </div>
+        <Overlay
+          visible={visible}
+          onEscape={handleEscape}
+          renderMaskElement={style => (
+            <OverlayMask
+              style={style}
+              gradient={
+                Gradients[
+                  Gradients[
+                    select('gradient', mapEnumKeys(Gradients), 'GundamPilot')
+                  ]
+                ]
+              }
+            />
+          )}
+        >
+          <OverlayContainer maxWidth={number('maxWidth', 400)}>
+            <OverlayHeader title="Are you sure?" onDismiss={handleDismiss} />
+            <OverlayBody>
+              <p>
+                This action could cause a lot of things to break unexpectedly.
+                We're pretty sure you don't want to do this accidentally. What
+                will it be?
+              </p>
+            </OverlayBody>
+            <OverlayFooter>
+              <Button text="Cancel" onClick={handleDismiss} />
+              <Button text="Pull the Lever!" color={ComponentColor.Danger} />
+            </OverlayFooter>
+          </OverlayContainer>
+        </Overlay>
+      </div>
+    )
+  },
   {
     readme: {
       content: marked(ConfirmationOverlayReadme),

--- a/src/Components/Overlay/Documentation/Overlay.stories.tsx
+++ b/src/Components/Overlay/Documentation/Overlay.stories.tsx
@@ -350,10 +350,6 @@ overlayExampleStories.add(
       setVisibility(true)
     }
 
-    const handleEscape = (): void => {
-      console.log('hi')
-    }
-
     return (
       <div className="story--example">
         <div className="mockComponent mockButton" onClick={handleShow}>
@@ -361,7 +357,7 @@ overlayExampleStories.add(
         </div>
         <Overlay
           visible={visible}
-          onEscape={handleEscape}
+          onEscape={setVisibility}
           renderMaskElement={style => (
             <OverlayMask
               style={style}

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -59,10 +59,6 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
     }
   }
 
-  if (!visible) {
-    return null
-  }
-
   const OverlayRender = () => {
     useEffect((): (() => void) => {
       window.addEventListener('keydown', handleEscapeKey)
@@ -115,9 +111,8 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
       </>
     )
   }
-  const Overlay = <OverlayRender />
 
-  return addElementToPortal(Overlay)
+  return addElementToPortal(<OverlayRender />)
 }
 
 OverlayRoot.displayName = 'Overlay'

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent, CSSProperties} from 'react'
+import React, {FunctionComponent, CSSProperties, KeyboardEvent} from 'react'
 import {Transition} from 'react-spring/renderprops'
 import classnames from 'classnames'
 import * as easings from 'd3-ease'
@@ -16,6 +16,7 @@ import {StandardFunctionProps, InfluxColors} from '../../Types'
 
 // Styles
 import './Overlay.scss'
+import {useEffect} from '@storybook/addons'
 
 export interface OverlayProps extends StandardFunctionProps {
   /** Controls visibility of the overlay */
@@ -24,6 +25,9 @@ export interface OverlayProps extends StandardFunctionProps {
   renderMaskElement?: (style: CSSProperties) => JSX.Element
   /** Controls the transition timing */
   transitionDuration?: number
+
+  /** Controls custom handling functionality */
+  onEscape?: () => void
 }
 
 export const OverlayRoot: FunctionComponent<OverlayProps> = ({
@@ -33,9 +37,22 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
   children,
   className,
   transitionDuration = 360,
+  onEscape,
   renderMaskElement = (style: CSSProperties) => <OverlayMask style={style} />,
 }) => {
-  const {addElementToPortal} = usePortal()
+  const {
+    addElementToPortal,
+    addEventListenerToPortal,
+    removeEventListenerFromPortal,
+  } = usePortal()
+
+  useEffect((): (() => void) => {
+    addEventListenerToPortal('keydown', handleEscapeKey)
+
+    return (): void => {
+      removeEventListenerFromPortal('keydown', handleEscapeKey)
+    }
+  }, [])
 
   const transitionConfig = {
     duration: transitionDuration,
@@ -46,49 +63,57 @@ export const OverlayRoot: FunctionComponent<OverlayProps> = ({
     [`${className}`]: className,
   })
 
-  const overlay = (
-    <>
-      <Transition
-        items={visible}
-        from={{opacity: 0}}
-        enter={{opacity: 0.7}}
-        leave={{opacity: 0}}
-        config={transitionConfig}
-      >
-        {visible => visible && (props => renderMaskElement(props))}
-      </Transition>
-      <Transition
-        items={visible}
-        from={{opacity: 0, transform: 'translateY(44px)'}}
-        enter={{opacity: 1, transform: 'translateY(0)'}}
-        leave={{opacity: 0, transform: 'translateY(44px)'}}
-        config={transitionConfig}
-      >
-        {visible =>
-          visible &&
-          (props => (
-            <DapperScrollbars
-              className={overlayClass}
-              thumbStartColor={InfluxColors.White}
-              thumbStopColor={InfluxColors.Hydrogen}
-              noScrollX={true}
-              autoHide={false}
-              testID={testID}
-              id={id}
-            >
-              <div
-                className="cf-overlay--children"
-                data-testid={`${testID}--children`}
-                style={props}
+  const handleEscapeKey = (e: KeyboardEvent<Window>): void => {
+    if (e.keyCode === 27 && visible) {
+      onEscape && onEscape()
+    }
+  }
+
+  const overlay = () => {
+    return (
+      <>
+        <Transition
+          items={visible}
+          from={{opacity: 0}}
+          enter={{opacity: 0.7}}
+          leave={{opacity: 0}}
+          config={transitionConfig}
+        >
+          {visible => visible && (props => renderMaskElement(props))}
+        </Transition>
+        <Transition
+          items={visible}
+          from={{opacity: 0, transform: 'translateY(44px)'}}
+          enter={{opacity: 1, transform: 'translateY(0)'}}
+          leave={{opacity: 0, transform: 'translateY(44px)'}}
+          config={transitionConfig}
+        >
+          {visible =>
+            visible &&
+            (props => (
+              <DapperScrollbars
+                className={overlayClass}
+                thumbStartColor={InfluxColors.White}
+                thumbStopColor={InfluxColors.Hydrogen}
+                noScrollX={true}
+                autoHide={false}
+                testID={testID}
+                id={id}
               >
-                {children}
-              </div>
-            </DapperScrollbars>
-          ))
-        }
-      </Transition>
-    </>
-  )
+                <div
+                  className="cf-overlay--children"
+                  data-testid={`${testID}--children`}
+                  style={props}
+                >
+                  {children}
+                </div>
+              </DapperScrollbars>
+            ))
+          }
+        </Transition>
+      </>
+    )
+  }
 
   return addElementToPortal(overlay)
 }


### PR DESCRIPTION
### Changes
Enables overlay closing on escape keypress

// Describe what you changed
When you pass the state handler for the visible prop into the `onEscape` prop for overlays, it will now be able to close on escape press
### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
