### PR TITLE
fix: Makes rollup copy src specific to avoid src/dest conflict issue

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ let plugins = [
     targets: [
       {src: 'src/Styles/Fonts', dest: 'dist'},
       {src: 'src/Styles/variables.scss', dest: 'dist'},
-      {src: '*/**/Images/*', dest: 'dist/Images'}
+      {src: 'src/**/Images/*', dest: 'dist/Images'}
     ],
   }),
   sourceMaps(),


### PR DESCRIPTION
Closes #562

### Changes

Changes the `src` argument to the Rollup `copy` plugin to be more specific. The glob `*/**/Images/*` is too generic and can match the `dest` argument `dist/Images` causing error "Source and destination must not be the same". 

The only image I found in the repo was under `src` directory so I changed the the glob to `src/**/Images/*`. 

![image](https://user-images.githubusercontent.com/6411855/104046691-50a68780-5195-11eb-80d4-789e5685d7dc.png)


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
