### PR TITLE
feat: create ability to set vertical range slider

### DIFF
--- a/src/Components/Inputs/Composed/RangeSlider.scss
+++ b/src/Components/Inputs/Composed/RangeSlider.scss
@@ -108,6 +108,12 @@ $slider-hover: $g17-whisper;
   }
 }
 
+.cf-range-slider__vertical {
+  width: 275px;
+  height: 50px;
+  transform: rotate(270deg);
+}
+
 .cf-range-slider {
   display: flex;
   align-items: center;
@@ -186,7 +192,7 @@ $slider-hover: $g17-whisper;
 
   input[type='range'] {
     height: $height;
-    
+
     &:focus {
       box-shadow: none;
     }
@@ -229,16 +235,36 @@ $slider-hover: $g17-whisper;
 }
 
 .cf-range-slider__xs {
-  @include rangeSliderSizeModifier($cf-form-xs-font, $cf-marg-a, $cf-form-xs-height, $cf-form-xs-padding);
+  @include rangeSliderSizeModifier(
+    $cf-form-xs-font,
+    $cf-marg-a,
+    $cf-form-xs-height,
+    $cf-form-xs-padding
+  );
 }
 .cf-range-slider__sm {
-  @include rangeSliderSizeModifier($cf-form-sm-font, ($cf-marg-a + 2), $cf-form-sm-height, $cf-form-sm-padding);
+  @include rangeSliderSizeModifier(
+    $cf-form-sm-font,
+    ($cf-marg-a + 2),
+    $cf-form-sm-height,
+    $cf-form-sm-padding
+  );
 }
 .cf-range-slider__md {
-  @include rangeSliderSizeModifier($cf-form-md-font, $cf-marg-b, $cf-form-md-height, $cf-form-md-padding);
+  @include rangeSliderSizeModifier(
+    $cf-form-md-font,
+    $cf-marg-b,
+    $cf-form-md-height,
+    $cf-form-md-padding
+  );
 }
 .cf-range-slider__lg {
-  @include rangeSliderSizeModifier($cf-form-lg-font, ($cf-marg-b + 2), $cf-form-lg-height, $cf-form-lg-padding);
+  @include rangeSliderSizeModifier(
+    $cf-form-lg-font,
+    ($cf-marg-b + 2),
+    $cf-form-lg-height,
+    $cf-form-lg-padding
+  );
 }
 
 /*

--- a/src/Components/Inputs/Composed/RangeSlider.scss
+++ b/src/Components/Inputs/Composed/RangeSlider.scss
@@ -109,7 +109,6 @@ $slider-hover: $g17-whisper;
 }
 
 .cf-range-slider__vertical {
-  width: 275px;
   height: 50px;
   transform: rotate(270deg);
 }

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -23,7 +23,7 @@ import {
   ComponentSize,
   AutoComplete,
   ComponentStatus,
-  ComponentDirection,
+  ComponentOrientation,
 } from '../../../Types'
 
 export interface RangeSliderProps extends StandardFunctionProps {
@@ -53,8 +53,8 @@ export interface RangeSliderProps extends StandardFunctionProps {
   labelPrefix?: string
   /** Adds a suffix to labels */
   labelSuffix?: string
-  /** Determines direction of range slider */
-  direction?: ComponentDirection
+  /** Determines orientation of range slider */
+  orientation?: ComponentOrientation
 }
 
 export type RangeSliderRef = HTMLInputElement
@@ -79,7 +79,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       labelPrefix,
       labelSuffix,
       autocomplete,
-      direction = ComponentDirection.Horizontal,
+      orientation = ComponentOrientation.Horizontal,
     },
     ref
   ) => {
@@ -127,7 +127,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
     const cleanedValue = valueWithBounds(value, min, max)
 
     const rangeSliderClassName =
-      direction === ComponentDirection.Vertical
+      orientation === ComponentOrientation.Vertical
         ? `${rangeSliderClass} cf-range-slider__vertical`
         : rangeSliderClass
 
@@ -138,7 +138,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           prefix={labelPrefix}
           suffix={labelSuffix}
           style={
-            direction === ComponentDirection.Vertical
+            orientation === ComponentOrientation.Vertical
               ? verticalLabelStyle
               : labelStyle
           }
@@ -167,7 +167,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           prefix={labelPrefix}
           suffix={labelSuffix}
           style={
-            direction === ComponentDirection.Vertical
+            orientation === ComponentOrientation.Vertical
               ? verticalLabelMaxStyle
               : labelStyle
           }

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -23,6 +23,7 @@ import {
   ComponentSize,
   AutoComplete,
   ComponentStatus,
+  ComponentDirection,
 } from '../../../Types'
 
 export interface RangeSliderProps extends StandardFunctionProps {
@@ -52,6 +53,8 @@ export interface RangeSliderProps extends StandardFunctionProps {
   labelPrefix?: string
   /** Adds a suffix to labels */
   labelSuffix?: string
+  /** Determines direction of range slider */
+  direction?: ComponentDirection
 }
 
 export type RangeSliderRef = HTMLInputElement
@@ -76,6 +79,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       labelPrefix,
       labelSuffix,
       autocomplete,
+      direction = ComponentDirection.Horizontal,
     },
     ref
   ) => {
@@ -112,15 +116,32 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       flex: `0 0 ${labelCharLength * 11}px`,
     }
 
+    const verticalLabelStyle = {
+      transform: 'rotate(270deg)',
+    }
+
+    const verticalLabelMaxStyle = {
+      transform: 'rotate(90deg)',
+    }
+
     const cleanedValue = valueWithBounds(value, min, max)
 
+    const rangeSliderClassName =
+      direction === ComponentDirection.Vertical
+        ? `${rangeSliderClass} cf-range-slider__vertical`
+        : rangeSliderClass
+
     return (
-      <div className={rangeSliderClass} style={style}>
+      <div className={rangeSliderClassName} style={style}>
         <RangeSliderLabel
           value={min}
           prefix={labelPrefix}
           suffix={labelSuffix}
-          style={labelStyle}
+          style={
+            direction === ComponentDirection.Vertical
+              ? verticalLabelStyle
+              : labelStyle
+          }
           hidden={hideLabels}
           testID={`${testID}--min`}
         />
@@ -145,7 +166,11 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           value={max}
           prefix={labelPrefix}
           suffix={labelSuffix}
-          style={labelStyle}
+          style={
+            direction === ComponentDirection.Vertical
+              ? verticalLabelMaxStyle
+              : labelStyle
+          }
           hidden={hideLabels}
           testID={`${testID}--max`}
         />

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -46,6 +46,7 @@ import {
   ComponentStatus,
   ComponentSize,
   ComponentColor,
+  ComponentDirection,
   IconFont,
   AutoComplete,
   FlexDirection,
@@ -870,7 +871,7 @@ inputsComposedStories.add(
       /* eslint-enable */
     }
 
-    const exampleRangeSliderStyle = {width: '100%'}
+    const exampleRangeSliderStyle = {width: '275px'}
 
     return (
       <div className="story--example">
@@ -897,6 +898,11 @@ inputsComposedStories.add(
           status={
             ComponentStatus[
               select('status', mapEnumKeys(ComponentStatus), 'Default')
+            ]
+          }
+          direction={
+            ComponentDirection[
+              select('direction', mapEnumKeys(ComponentDirection), 'Horizontal')
             ]
           }
         />

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -46,7 +46,7 @@ import {
   ComponentStatus,
   ComponentSize,
   ComponentColor,
-  ComponentDirection,
+  ComponentOrientation,
   IconFont,
   AutoComplete,
   FlexDirection,
@@ -900,9 +900,13 @@ inputsComposedStories.add(
               select('status', mapEnumKeys(ComponentStatus), 'Default')
             ]
           }
-          direction={
-            ComponentDirection[
-              select('direction', mapEnumKeys(ComponentDirection), 'Horizontal')
+          orientation={
+            ComponentOrientation[
+              select(
+                'orientation',
+                mapEnumKeys(ComponentOrientation),
+                'Horizontal'
+              )
             ]
           }
         />

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -53,6 +53,10 @@ export enum ComponentStatus {
   Disabled = 'disabled',
 }
 
+export enum ComponentDirection {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
 export interface Color {
   hex: string
   name: string

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -53,7 +53,7 @@ export enum ComponentStatus {
   Disabled = 'disabled',
 }
 
-export enum ComponentDirection {
+export enum ComponentOrientation {
   Horizontal = 'horizontal',
   Vertical = 'vertical',
 }


### PR DESCRIPTION
Closes #

### Changes
Adds ability to have vertical range slider by passing in Vertical as part of new ComponentDirection enum
// Describe what you changed

### Screenshots
![Screen Shot 2021-01-25 at 9 56 30 AM](https://user-images.githubusercontent.com/29473622/105730134-9ed8bc00-5ef3-11eb-9f67-0afbd4808628.png)
![Screen Shot 2021-01-25 at 9 56 23 AM](https://user-images.githubusercontent.com/29473622/105730136-9f715280-5ef3-11eb-85ca-6e6e29ee9665.png)
![Screen Shot 2021-01-25 at 9 56 13 AM](https://user-images.githubusercontent.com/29473622/105730139-9f715280-5ef3-11eb-8529-cb67128da293.png)

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
