### PR TITLE
fix:  labels on toggle buttons are now clickable

### DIFF
--- a/src/Components/Button/Documentation/ButtonBase.md
+++ b/src/Components/Button/Documentation/ButtonBase.md
@@ -2,7 +2,11 @@
 
 The Base Button is intended for custom use cases. It renders children inside itself to facilitate many use cases.
 
+Note that if you are looking for radio buttons, look in Components->Inputs -> Multiple Choice Form.
+our Implementation of Radio Buttons are Toggle Buttons.
+
 ### Usage
+
 ```tsx
 import {ButtonBase} from '@influxdata/clockface'
 ```

--- a/src/Components/Inputs/Toggle.tsx
+++ b/src/Components/Inputs/Toggle.tsx
@@ -163,8 +163,17 @@ export const Toggle = forwardRef<ToggleRef, ToggleProps>(
 
     const title = disabled ? disabledTitleText : titleText
 
+    // putting onClick handler on the containing div,
+    // so that clicking on the children will toggle as well
+    // (b/c of the explicit onclick handler, the 'for' linking the labels
+    // to the input does not toggle the button at all)
     return (
-      <div className={toggleClass} style={style} ref={containerRef}>
+      <div
+        className={toggleClass}
+        style={style}
+        ref={containerRef}
+        onClick={handleClick}
+      >
         <input
           id={id}
           ref={ref}
@@ -187,7 +196,6 @@ export const Toggle = forwardRef<ToggleRef, ToggleProps>(
           onBlur={handleInputBlur}
           htmlFor={id}
           onFocus={handleInputFocus}
-          onClick={handleClick}
           onKeyUp={handleKeyUp}
           tabIndex={tabIndex}
           className="cf-toggle--visual-input"


### PR DESCRIPTION
      also adding pretty-quick
         - you can just call 'yarn pretty-quick' at the command line, and only the files you changed will get prettier run on them;
	 it is so much quicker and easier to use  (takes 5-10 seconds instead of 2-3 minutes)

Closes #566 

### Changes

   the on-click listener is now on the entire div; so that clicking on the children will toggle as well
    (b/c of the explicit onclick handler, the 'for' linking the labels to the input does not toggle the button at all)


