### PR TITLE
feat: expose min height that allows container to be visible and onscroll

### DIFF
--- a/src/Components/Page/Documentation/page.stories.tsx
+++ b/src/Components/Page/Documentation/page.stories.tsx
@@ -155,6 +155,7 @@ pageStories.add(
               select('gutters', mapEnumKeys(ComponentSize), 'Small')
             ]
           }
+          visibleHeight={`${number('Visible Scrollable Height', 100)}px`}
         >
           <div
             className="mockComponent pageContents"

--- a/src/Components/Page/Page.scss
+++ b/src/Components/Page/Page.scss
@@ -98,7 +98,8 @@
   align-items: center;
   text-align: center;
   justify-content: center;
-  flex: 0 0 ($cf-nav-menu--size - (($cf-nav-menu--size - $cf-form-sm-height) / 2));
+  flex: 0 0
+    ($cf-nav-menu--size - (($cf-nav-menu--size - $cf-form-sm-height) / 2));
 
   &.cf-page-control-bar__no-children {
     display: none;
@@ -106,7 +107,6 @@
 }
 
 .cf-page-control-bar--left {
-
   > * {
     margin-right: $cf-marg-a;
   }
@@ -125,10 +125,11 @@
   }
 }
 
-.cf-page-control-bar--center:not(.cf-page-control-bar__no-children) + .cf-page-control-bar--right {
-  flex: 0 0 ($cf-nav-menu--size - (($cf-nav-menu--size - $cf-form-sm-height) / 2));
+.cf-page-control-bar--center:not(.cf-page-control-bar__no-children)
+  + .cf-page-control-bar--right {
+  flex: 0 0
+    ($cf-nav-menu--size - (($cf-nav-menu--size - $cf-form-sm-height) / 2));
 }
-
 
 @media screen and (min-width: $cf-nav-menu--breakpoint) {
   .cf-page-control-bar--fluid,
@@ -149,7 +150,8 @@
   }
 
   .cf-page-control-bar--right,
-  .cf-page-control-bar--center:not(.cf-page-control-bar__no-children) + .cf-page-control-bar--right {
+  .cf-page-control-bar--center:not(.cf-page-control-bar__no-children)
+    + .cf-page-control-bar--right {
     justify-content: flex-end;
     text-align: right;
     flex: 1 0 30%;
@@ -260,7 +262,7 @@
   .cf-page-contents__fixed {
     padding: 0 $gutter;
   }
-  
+
   &.cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fluid,
   &.cf-page-contents.cf-dapper-scrollbars .cf-page-contents__fixed {
     padding-bottom: $gutter;

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -3,7 +3,10 @@ import React, {forwardRef} from 'react'
 import classnames from 'classnames'
 
 // Components
-import {DapperScrollbars} from '../DapperScrollbars/DapperScrollbars'
+import {
+  DapperScrollbars,
+  FusionScrollHandler,
+} from '../DapperScrollbars/DapperScrollbars'
 
 // Types
 import {StandardFunctionProps, ComponentSize} from '../../Types'
@@ -17,6 +20,10 @@ export interface PageContentsProps extends StandardFunctionProps {
   autoHideScrollbar?: boolean
   /** Controls the gutters (left and right margins) */
   gutters?: ComponentSize
+  /** Exposes custom onScroll handler */
+  onScroll?: FusionScrollHandler
+  /** Allows user to customize visible height of container */
+  visibleHeight?: string
 }
 
 export type PageContentsRef = HTMLDivElement
@@ -33,6 +40,8 @@ export const PageContents = forwardRef<PageContentsRef, PageContentsProps>(
       testID = 'page-contents',
       autoHideScrollbar = false,
       gutters = ComponentSize.Medium,
+      onScroll,
+      visibleHeight = '100px',
     },
     ref
   ) => {
@@ -56,10 +65,11 @@ export const PageContents = forwardRef<PageContentsRef, PageContentsProps>(
       return (
         <DapperScrollbars
           id={id}
-          style={style}
+          style={{...style, minHeight: visibleHeight}}
           testID={testID}
           autoHide={autoHideScrollbar}
           className={pageContentsClass}
+          onScroll={onScroll}
         >
           {kids}
         </DapperScrollbars>


### PR DESCRIPTION
Closes #523 

### Changes
This exposes a minHeight prop that allows us to actually see the container when we have it scrollable. Before it was completely hidden. This was a bug IMO, but i could be missing something. Putting it here to look it over, but as far as i could tell, allowing the user to input the minHeight both adds flexibility to the component and addresses an issue here. 
// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
