### PR TITLE
Range Slider With Value Exposed Option

### DIFF
--- a/src/Components/Inputs/Composed/RangeSlider.scss
+++ b/src/Components/Inputs/Composed/RangeSlider.scss
@@ -111,6 +111,13 @@ $slider-hover: $g17-whisper;
 .cf-range-slider__vertical {
   height: 50px;
   transform: rotate(270deg);
+
+  .cf-range-slider--max {
+    transform: rotate(90deg);
+    display: flex;
+    align-items: flex-end;
+    flex-direction: column;
+  }
 }
 
 .cf-range-slider {
@@ -135,12 +142,14 @@ $slider-hover: $g17-whisper;
   font-weight: $cf-font-weight--medium;
   @extend %no-user-select;
 
-  &:first-of-type {
+  &.cf-range-slider--min {
     text-align: left;
   }
 
-  &:last-of-type {
+  &.cf-range-slider--max {
     text-align: right;
+    display: flex;
+    justify-content: flex-end;
   }
 }
 
@@ -181,10 +190,10 @@ $slider-hover: $g17-whisper;
   .cf-range-slider--label {
     font-size: $fontSize;
 
-    &:first-of-type {
+    &.cf-range-slider--min {
       margin-right: $padding;
     }
-    &:last-of-type {
+    &.cf-range-slider--max {
       margin-left: $padding;
     }
   }

--- a/src/Components/Inputs/Composed/RangeSlider.scss
+++ b/src/Components/Inputs/Composed/RangeSlider.scss
@@ -151,6 +151,16 @@ $slider-hover: $g17-whisper;
     display: flex;
     justify-content: flex-end;
   }
+
+  &.cf-range-slider--valmax-label {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  &.cf-range-slider--valmax-label__with-value {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .cf-range-slider--focus {

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -55,6 +55,8 @@ export interface RangeSliderProps extends StandardFunctionProps {
   labelSuffix?: string
   /** Determines orientation of range slider */
   orientation?: ComponentOrientation
+  /** Determines whether to display value  */
+  displayValue?: boolean
 }
 
 export type RangeSliderRef = HTMLInputElement
@@ -80,6 +82,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       labelSuffix,
       autocomplete,
       orientation = ComponentOrientation.Horizontal,
+      displayValue = false,
     },
     ref
   ) => {
@@ -120,10 +123,6 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       transform: 'rotate(270deg)',
     }
 
-    const verticalLabelMaxStyle = {
-      transform: 'rotate(90deg)',
-    }
-
     const cleanedValue = valueWithBounds(value, min, max)
 
     const rangeSliderClassName =
@@ -144,6 +143,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           }
           hidden={hideLabels}
           testID={`${testID}--min`}
+          className="cf-range-slider--min"
         />
         <Input
           id={id}
@@ -162,18 +162,32 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           autocomplete={autocomplete}
         />
         <div className="cf-range-slider--focus" />
-        <RangeSliderLabel
-          value={max}
-          prefix={labelPrefix}
-          suffix={labelSuffix}
+        <div
+          className="cf-range-slider--label cf-range-slider--max"
           style={
-            orientation === ComponentOrientation.Vertical
-              ? verticalLabelMaxStyle
-              : labelStyle
+            orientation === ComponentOrientation.Horizontal ? labelStyle : {}
           }
-          hidden={hideLabels}
-          testID={`${testID}--max`}
-        />
+        >
+          {displayValue && (
+            <RangeSliderLabel
+              value={cleanedValue}
+              prefix={labelPrefix}
+              suffix={labelSuffix}
+              hidden={hideLabels}
+              testID={`${testID}--val`}
+            />
+          )}
+          <div>
+            {displayValue && <span>/</span>}
+            <RangeSliderLabel
+              value={max}
+              prefix={labelPrefix}
+              suffix={labelSuffix}
+              hidden={hideLabels}
+              testID={`${testID}--max`}
+            />
+          </div>
+        </div>
       </div>
     )
   }
@@ -203,6 +217,7 @@ interface RangeSliderLabelProps {
   hidden?: boolean
   style?: CSSProperties
   testID: string
+  className?: string
 }
 
 const RangeSliderLabel: FunctionComponent<RangeSliderLabelProps> = ({
@@ -212,13 +227,16 @@ const RangeSliderLabel: FunctionComponent<RangeSliderLabelProps> = ({
   hidden,
   style,
   testID,
+  className = '',
 }) => {
   if (hidden) {
     return null
   }
-
+  const labelClass = classnames('cf-range-slider--label', {
+    [`${className}`]: className,
+  })
   return (
-    <span className="cf-range-slider--label" style={style} data-testid={testID}>
+    <span className={labelClass} style={style} data-testid={testID}>
       {prefix}
       {value}
       {suffix}

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -115,12 +115,14 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       labelCharLength += labelSuffix.length
     }
 
-    const labelStyle = {
-      flex: `0 0 ${labelCharLength * 11}px`,
-    }
-
     const verticalLabelStyle = {
       transform: 'rotate(270deg)',
+    }
+
+    const horizontalLabelValMaxStyle = {
+      display: 'grid',
+      gridTemplateColumns: `${labelCharLength * 10}px ${labelCharLength *
+        10}px`,
     }
 
     const cleanedValue = valueWithBounds(value, min, max)
@@ -139,7 +141,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           style={
             orientation === ComponentOrientation.Vertical
               ? verticalLabelStyle
-              : labelStyle
+              : {}
           }
           hidden={hideLabels}
           testID={`${testID}--min`}
@@ -165,7 +167,9 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
         <div
           className="cf-range-slider--label cf-range-slider--max"
           style={
-            orientation === ComponentOrientation.Horizontal ? labelStyle : {}
+            orientation === ComponentOrientation.Horizontal
+              ? horizontalLabelValMaxStyle
+              : {}
           }
         >
           {displayValue && (

--- a/src/Components/Inputs/Composed/RangeSlider.tsx
+++ b/src/Components/Inputs/Composed/RangeSlider.tsx
@@ -97,6 +97,16 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       'cf-range-slider__fill': fill,
     })
 
+    const valmaxClassName = classnames(
+      'cf-range-slider--label cf-range-slider--max',
+      {
+        [`cf-range-slider--valmax-label__with-value`]:
+          orientation === ComponentOrientation.Horizontal && displayValue,
+        [`cf-range-slider--valmax-label`]:
+          orientation === ComponentOrientation.Horizontal && !displayValue,
+      }
+    )
+
     const inputStyle = generateRangeSliderTrackFillStyle(
       fill,
       min,
@@ -106,23 +116,8 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
       status
     )
 
-    let labelCharLength = String(max).length
-
-    if (labelPrefix) {
-      labelCharLength += labelPrefix.length
-    }
-    if (labelSuffix) {
-      labelCharLength += labelSuffix.length
-    }
-
     const verticalLabelStyle = {
       transform: 'rotate(270deg)',
-    }
-
-    const horizontalLabelValMaxStyle = {
-      display: 'grid',
-      gridTemplateColumns: `${labelCharLength * 10}px ${labelCharLength *
-        10}px`,
     }
 
     const cleanedValue = valueWithBounds(value, min, max)
@@ -164,14 +159,7 @@ export const RangeSlider = forwardRef<RangeSliderRef, RangeSliderProps>(
           autocomplete={autocomplete}
         />
         <div className="cf-range-slider--focus" />
-        <div
-          className="cf-range-slider--label cf-range-slider--max"
-          style={
-            orientation === ComponentOrientation.Horizontal
-              ? horizontalLabelValMaxStyle
-              : {}
-          }
-        >
+        <div className={valmaxClassName}>
           {displayValue && (
             <RangeSliderLabel
               value={cleanedValue}

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -909,6 +909,7 @@ inputsComposedStories.add(
               )
             ]
           }
+          displayValue={boolean('displayValue', false)}
         />
         <div className="story--test-buttons">
           <button onClick={handleLogRef}>Log Ref</button>

--- a/src/Components/Inputs/Documentation/Inputs.stories.tsx
+++ b/src/Components/Inputs/Documentation/Inputs.stories.tsx
@@ -871,7 +871,7 @@ inputsComposedStories.add(
       /* eslint-enable */
     }
 
-    const exampleRangeSliderStyle = {width: '275px'}
+    const exampleRangeSliderStyle = {width: '375px'}
 
     return (
       <div className="story--example">


### PR DESCRIPTION
Closes #

### Changes
Enables an option that allows the user to have a displayed value counter next to the range slider max value, as a fraction
// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
