### PR TITLE
Feat: dropdown enhancements

### DIFF
--- a/src/Components/Dropdowns/Dropdown.tsx
+++ b/src/Components/Dropdowns/Dropdown.tsx
@@ -30,18 +30,18 @@ export interface DropdownProps extends StandardFunctionProps {
   /** Optional method that is triggered when the user clicks outside of/away from the dropdown */
   onClickAway?: () => void
   /**
-   * optional way for the owner of this dropdown to set the menu status:
+   * optional way for the owner of this dropdown to set the menu to be open or closed:
    * 'open':  the menu will be open
    * 'closed': the menu will be closed
    * any other string will be ignored.
    *
-   * and the menu state (open/closed) only changes when this value changes.
+   * and the menu  (open/closed) only changes programmatically when this value changes.
    * so the owner is responsible for resetting this value
    * (if the string is set to 'open', and then the user closes it, and the code sets it to open again,
    * unless the code sets it to something else in between (like null or 'close'),
    * then nothing will happen- the menu will not open)
    * */
-  setMenuStatus?: MenuStatus
+  menuOpen?: MenuStatus
 }
 
 export type DropdownRef = HTMLDivElement
@@ -57,7 +57,7 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
       dropUp = false,
       className,
       onClickAway,
-      setMenuStatus,
+      menuOpen,
     },
     ref
   ) => {
@@ -76,13 +76,13 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
     }
 
     useEffect(() => {
-      if (setMenuStatus === MenuStatus.Closed) {
+      if (menuOpen === MenuStatus.Closed) {
         setExpandedState(false)
       }
-      if (setMenuStatus === MenuStatus.Open) {
+      if (menuOpen === MenuStatus.Open) {
         setExpandedState(true)
       }
-    }, [setMenuStatus])
+    }, [menuOpen])
 
     const dropdownClass = classnames('cf-dropdown', {
       [`${className}`]: className,

--- a/src/Components/Dropdowns/Dropdown.tsx
+++ b/src/Components/Dropdowns/Dropdown.tsx
@@ -12,6 +12,11 @@ import {StandardFunctionProps} from '../../Types'
 // Styles
 import './Dropdown.scss'
 
+enum MenuStatus {
+    Open = 'open',
+    Closed = 'closed'
+}
+
 export interface DropdownProps extends StandardFunctionProps {
   /** Component to render as the button (use Dropdown.Button) */
   button: (
@@ -25,18 +30,18 @@ export interface DropdownProps extends StandardFunctionProps {
   /** Optional method that is triggered when the user clicks outside of/away from the dropdown */
   onClickAway?: () => void
   /**
-   * optional way for the owner of this dropdown to set the menu state:
+   * optional way for the owner of this dropdown to set the menu status:
    * 'open':  the menu will be open
    * 'closed': the menu will be closed
    * any other string will be ignored.
    *
-   * and the menu state (open/closed) only changes when the string changes.
-   * so the owner is responsible for resetting the string
+   * and the menu state (open/closed) only changes when this value changes.
+   * so the owner is responsible for resetting this value
    * (if the string is set to 'open', and then the user closes it, and the code sets it to open again,
-   * unless the code sets it to something else in between (like 'ignore' or 'close'),
+   * unless the code sets it to something else in between (like null or 'close'),
    * then nothing will happen- the menu will not open)
    * */
-  menuOpen?: string
+  setMenuStatus?: MenuStatus
 }
 
 export type DropdownRef = HTMLDivElement
@@ -52,7 +57,7 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
       dropUp = false,
       className,
       onClickAway,
-      menuOpen,
+      setMenuStatus,
     },
     ref
   ) => {
@@ -71,13 +76,13 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
     }
 
     useEffect(() => {
-      if (menuOpen === 'closed') {
+      if (setMenuStatus === MenuStatus.Closed) {
         setExpandedState(false)
       }
-      if (menuOpen === 'open') {
+      if (setMenuStatus === MenuStatus.Open) {
         setExpandedState(true)
       }
-    }, [menuOpen])
+    }, [setMenuStatus])
 
     const dropdownClass = classnames('cf-dropdown', {
       [`${className}`]: className,

--- a/src/Components/Dropdowns/Dropdown.tsx
+++ b/src/Components/Dropdowns/Dropdown.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef, MouseEvent, useState} from 'react'
+import React, {forwardRef, MouseEvent, useState, useEffect} from 'react'
 import classnames from 'classnames'
 import _ from 'lodash'
 
@@ -22,6 +22,8 @@ export interface DropdownProps extends StandardFunctionProps {
   menu: (onCollapse?: () => void) => JSX.Element
   /** Renders the menu element above the button instead of below */
   dropUp?: boolean
+  onClickAway?: () => void
+  menuOpen?: string
 }
 
 export type DropdownRef = HTMLDivElement
@@ -36,6 +38,8 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
       button,
       dropUp = false,
       className,
+      onClickAway,
+      menuOpen,
     },
     ref
   ) => {
@@ -48,7 +52,20 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
 
     const handleCollapseMenu = (): void => {
       setExpandedState(false)
+      if (onClickAway) {
+        onClickAway()
+      }
     }
+
+    useEffect(() => {
+      console.log('menuOpened changed; it is:', menuOpen)
+      if (menuOpen === 'closed') {
+        setExpandedState(false)
+      }
+      if (menuOpen === 'open') {
+        setExpandedState(true)
+      }
+    }, [menuOpen])
 
     const dropdownClass = classnames('cf-dropdown', {
       [`${className}`]: className,

--- a/src/Components/Dropdowns/Dropdown.tsx
+++ b/src/Components/Dropdowns/Dropdown.tsx
@@ -22,7 +22,20 @@ export interface DropdownProps extends StandardFunctionProps {
   menu: (onCollapse?: () => void) => JSX.Element
   /** Renders the menu element above the button instead of below */
   dropUp?: boolean
+  /** Optional method that is triggered when the user clicks outside of/away from the dropdown */
   onClickAway?: () => void
+  /**
+   * optional way for the owner of this dropdown to set the menu state:
+   * 'open':  the menu will be open
+   * 'closed': the menu will be closed
+   * any other string will be ignored.
+   *
+   * and the menu state (open/closed) only changes when the string changes.
+   * so the owner is responsible for resetting the string
+   * (if the string is set to 'open', and then the user closes it, and the code sets it to open again,
+   * unless the code sets it to something else in between (like 'ignore' or 'close'),
+   * then nothing will happen- the menu will not open)
+   * */
   menuOpen?: string
 }
 
@@ -58,7 +71,6 @@ export const DropdownRoot = forwardRef<DropdownRef, DropdownProps>(
     }
 
     useEffect(() => {
-      console.log('menuOpened changed; it is:', menuOpen)
       if (menuOpen === 'closed') {
         setExpandedState(false)
       }

--- a/src/Components/Dropdowns/Dropdown.tsx
+++ b/src/Components/Dropdowns/Dropdown.tsx
@@ -13,8 +13,8 @@ import {StandardFunctionProps} from '../../Types'
 import './Dropdown.scss'
 
 enum MenuStatus {
-    Open = 'open',
-    Closed = 'closed'
+  Open = 'open',
+  Closed = 'closed',
 }
 
 export interface DropdownProps extends StandardFunctionProps {


### PR DESCRIPTION
supporting/required for 20195 in the ui repository

### Changes

 Adding 2 optional properties, if those properties are not there then the. dropdown works exactly as it did before these changes

from the documentation:

 onClickAway :  Optional method that is triggered when the user clicks outside of/away from the dropdown 

  menuOpen:  string
  
  optional way for the owner of this dropdown to set the menu state:
 'open':  the menu will be open
 'closed': the menu will be closed
 any other string will be ignored.

 and the menu state (open/closed) only changes when the string changes.
 so the owner is responsible for resetting the string
 (if the string is set to 'open', and then the user closes it, and the code sets it to open again,
 unless the owner/code sets it to something else in between (like 'ignore' or 'close'),
 then nothing will happen- the menu will not open)
 

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
