### PR TITLE
Revert "fix:  labels on toggle buttons are now clickable"

### DIFF
--- a/src/Components/Button/Documentation/ButtonBase.md
+++ b/src/Components/Button/Documentation/ButtonBase.md
@@ -2,11 +2,7 @@
 
 The Base Button is intended for custom use cases. It renders children inside itself to facilitate many use cases.
 
-Note that if you are looking for radio buttons, look in Components->Inputs -> Multiple Choice Form.
-our Implementation of Radio Buttons are Toggle Buttons.
-
 ### Usage
-
 ```tsx
 import {ButtonBase} from '@influxdata/clockface'
 ```

--- a/src/Components/Inputs/Toggle.tsx
+++ b/src/Components/Inputs/Toggle.tsx
@@ -161,17 +161,8 @@ export const Toggle = forwardRef<ToggleRef, ToggleProps>(
 
     const title = disabled ? disabledTitleText : titleText
 
-    // putting onClick handler on the containing div,
-    // so that clicking on the children will toggle as well
-    // (b/c of the explicit onclick handler, the 'for' linking the labels
-    // to the input does not toggle the button at all)
     return (
-      <div
-        className={toggleClass}
-        style={style}
-        ref={containerRef}
-        onClick={handleClick}
-      >
+      <div className={toggleClass} style={style} ref={containerRef}>
         <input
           id={id}
           ref={ref}
@@ -194,6 +185,7 @@ export const Toggle = forwardRef<ToggleRef, ToggleProps>(
           onBlur={handleInputBlur}
           htmlFor={id}
           onFocus={handleInputFocus}
+          onClick={handleClick}
           onKeyUp={handleKeyUp}
           tabIndex={tabIndex}
           className="cf-toggle--visual-input"


### PR DESCRIPTION
This commit introduced a bug to the Toggle component that causes the `onChange` event to fire twice. Reverting for now.
