### PR TITLE
chore: improve lighthouse accessibility score

### DIFF
--- a/src/Components/EmptyState/EmptyStateText.tsx
+++ b/src/Components/EmptyState/EmptyStateText.tsx
@@ -16,7 +16,7 @@ export const EmptyStateText = forwardRef<
   })
 
   return (
-    <h4
+    <h2
       id={id}
       ref={ref}
       style={style}
@@ -24,7 +24,7 @@ export const EmptyStateText = forwardRef<
       className={emptyStateTextClass}
     >
       {children}
-    </h4>
+    </h2>
   )
 })
 

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -237,7 +237,7 @@ $cf-form-lg-font: 17px;
    -----------------------------------------------------------------------------
 */
 
-$cf-empty-state-text: $g9-mountain;
+$cf-empty-state-text: $g10-wolf;
 $cf-empty-state-highlight: $g13-mist;
 
 /*

--- a/src/Utils/portals.tsx
+++ b/src/Utils/portals.tsx
@@ -8,7 +8,6 @@ const createPortalElement = (): HTMLElement => {
   const portalElement = document.createElement('div')
   portalElement.setAttribute('class', portalElementID)
   portalElement.setAttribute('id', portalElementID)
-  portalElement.setAttribute('tabindex', 'null')
 
   document.body.appendChild(portalElement)
 

--- a/src/Utils/portals.tsx
+++ b/src/Utils/portals.tsx
@@ -8,7 +8,7 @@ const createPortalElement = (): HTMLElement => {
   const portalElement = document.createElement('div')
   portalElement.setAttribute('class', portalElementID)
   portalElement.setAttribute('id', portalElementID)
-  portalElement.setAttribute('tabindex', '1')
+  portalElement.setAttribute('tabindex', 'null')
 
   document.body.appendChild(portalElement)
 


### PR DESCRIPTION
Related: https://github.com/influxdata/ui/issues/520

### Changes

Made some small tweaks to improve the accessibility and best practice scores from lightouse. 

1) Changed EmptyState's header from an h4 to an h2 so that our headers decrease sequentially. 
1) Changed EmptyState's font color to improve contrast ratio
1) Removed the tabIndex=1 from portals.

Also see this UI PR: https://github.com/influxdata/ui/pull/764

### Checklist

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
