### PR TITLE
fix: dropdown line height

### DIFF
--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -44,7 +44,6 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   box-shadow: 0 2px 5px 0.6px rgba($g0-obsidian, 0.2);
 }
 
-
 .cf-dropdown-menu--contents {
   font-size: 0;
   user-select: none;
@@ -62,7 +61,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
 @mixin dropdownItemStyles() {
   padding: $dropdown-item--padding-v $dropdown-item--padding-h;
   font-size: $cf-form-sm-font;
-  line-height: $cf-form-sm-font;
+  line-height: $cf-form-sm-line-height;
   font-weight: $cf-font-weight--medium;
   text-align: left;
 }
@@ -95,8 +94,9 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   }
 
   &.cf-dropdown-item__checkbox,
-  &.cf-dropdown-item__checkbox.cf-dropdown-link-item > a  {
-    padding-left: $dropdown-item--padding-h + $dropdown-item--checkbox-size + $dropdown-item--padding-v;
+  &.cf-dropdown-item__checkbox.cf-dropdown-link-item > a {
+    padding-left: $dropdown-item--padding-h + $dropdown-item--checkbox-size +
+      $dropdown-item--padding-v;
   }
 
   &:hover,
@@ -255,7 +255,7 @@ $dropdown-item--padding-v: $cf-marg-a + $cf-border;
   $dividerA,
   $dividerB,
   $dividerText,
-  $checkbox,
+  $checkbox
 ) {
   @include gradient-h($backgroundA, $backgroundB);
 

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -223,14 +223,17 @@ $cf-form-xs-font: 12px;
 $cf-form-sm-height: 30px;
 $cf-form-sm-padding: 10px;
 $cf-form-sm-font: 13px;
+$cf-form-sm-line-height: 15px;
 
 $cf-form-md-height: 38px;
 $cf-form-md-padding: 14px;
 $cf-form-md-font: 14px;
+$cf-form-md-line-height: 16px;
 
 $cf-form-lg-height: 46px;
 $cf-form-lg-padding: 18px;
 $cf-form-lg-font: 17px;
+$cf-form-lg-line-height: 19px;
 
 /*
    Empty State


### PR DESCRIPTION
Closes #585 

### Changes
This adds a more appropriate line height so that letters that extend up/down are visible and not cut off. 
// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
