### PR TITLE
adding a prevalidation mode for usecases when you want validation on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.6.4 (Unreleased)
+
+- [#592](https://github.com/influxdata/clockface/pull/592): Add prevalidation mode for formValidationElement
+
+
 ### 2.6.3 (2021-3-15)
 
 - [#582](https://github.com/influxdata/clockface/pull/582): Add icons

--- a/src/Components/Form/Documentation/Form.stories.tsx
+++ b/src/Components/Form/Documentation/Form.stories.tsx
@@ -360,6 +360,7 @@ formStories.add(
             helpText={text('helpText', 'Help Text')}
             required={boolean('required', true)}
             validationFunc={mockValidationFunc}
+            prevalidate={boolean('prevalidate', false)}
           >
             {status => (
               <Input

--- a/src/Components/Form/Documentation/Form.stories.tsx
+++ b/src/Components/Form/Documentation/Form.stories.tsx
@@ -72,6 +72,10 @@ const mockValidationFunc = (value: string): string | null => {
     return 'Field cannot be empty'
   }
 
+  if (value.length >= 21) {
+    return 'Must be 20 characters or less'
+  }
+
   return null
 }
 

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -33,6 +33,8 @@ export interface FormValidationElementProps extends StandardFunctionProps {
   required?: boolean
   /** Useful for associating a label with an input */
   htmlFor?: string
+  /** Pre-validation mode ( Validation happens ) */
+  prevalidate?: boolean
 }
 
 export type FormValidationElementRef = HTMLLabelElement
@@ -55,11 +57,12 @@ export const FormValidationElement = forwardRef<
       className,
       validationFunc,
       onStatusChange,
+      prevalidate = false,
       testID = 'form--validation-element',
     },
     ref
   ) => {
-    const shouldPerformValidation = useRef<boolean>(false)
+    const shouldPerformValidation = useRef<boolean>(prevalidate)
 
     let errorMessage = null
     let status = ComponentStatus.Default


### PR DESCRIPTION
…initial render

Closes #

https://github.com/influxdata/clockface/issues/591

### Changes

// Describe what you changed
As it is now, validation does not happen until a user interacts with the input.

Added a pre-validation mode (boolean prop) to allow validations to happen on initial render. 

Example usecase:
 - If a user is prompted to change a bad variable, we want to load the input form with an error state rather to prompt them to fix it. 
 
 @TCL735 has a great explanation for the use case if needed more clarity. 

### Screenshots

// Add screenshots here if relevant
<img width="1046" alt="Screen Shot 2021-03-15 at 6 37 04 PM" src="https://user-images.githubusercontent.com/12561526/111231727-1eb00800-85c0-11eb-9900-f27d586ba7f1.png">


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
