### PR TITLE
chore: updated FormElement props and FormElementError to allow for custom testIDs to be passed in for the formelementerror

### DIFF
--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -23,6 +23,8 @@ export interface FormElementProps extends StandardFunctionProps {
   required?: boolean
   /** Useful for associating a label with an input */
   htmlFor?: string
+  /** ID for Error Message for Integration Tests */
+  errorMessageTestId?: string
 }
 
 export type FormElementRef = HTMLLabelElement & HTMLDivElement
@@ -41,6 +43,7 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
       labelAddOn,
       errorMessage,
       testID = 'form--element',
+      errorMessageTestId,
     },
     ref
   ) => {
@@ -57,7 +60,10 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
         )}
         {children}
         {!!errorMessage && (
-          <FormElementError testID={testID} message={errorMessage} />
+          <FormElementError
+            errorMessageTestId={errorMessageTestId}
+            message={errorMessage}
+          />
         )}
         {!!helpText && <FormHelpText text={helpText} />}
       </>

--- a/src/Components/Form/FormElement.tsx
+++ b/src/Components/Form/FormElement.tsx
@@ -61,7 +61,7 @@ export const FormElement = forwardRef<FormElementRef, FormElementProps>(
         {children}
         {!!errorMessage && (
           <FormElementError
-            errorMessageTestId={errorMessageTestId}
+            testID={errorMessageTestId}
             message={errorMessage}
           />
         )}

--- a/src/Components/Form/FormElementError.tsx
+++ b/src/Components/Form/FormElementError.tsx
@@ -8,6 +8,7 @@ import {StandardFunctionProps} from '../../Types'
 export interface FormElementErrorProps extends StandardFunctionProps {
   /** Text to be displayed on error */
   message?: string
+  errorMessageTestId?: string
 }
 
 export type FormElementErrorRef = HTMLSpanElement
@@ -22,7 +23,7 @@ export const FormElementError = forwardRef<
       style,
       className,
       message = '\u00a0\u00a0',
-      testID = 'form--element-error',
+      errorMessageTestId = 'form--element-error',
     },
     ref
   ) => {
@@ -35,7 +36,7 @@ export const FormElementError = forwardRef<
         id={id}
         ref={ref}
         style={style}
-        data-testid={testID}
+        data-testid={errorMessageTestId}
         className={formElementErrorClass}
       >
         {message}

--- a/src/Components/Form/FormElementError.tsx
+++ b/src/Components/Form/FormElementError.tsx
@@ -8,7 +8,6 @@ import {StandardFunctionProps} from '../../Types'
 export interface FormElementErrorProps extends StandardFunctionProps {
   /** Text to be displayed on error */
   message?: string
-  errorMessageTestId?: string
 }
 
 export type FormElementErrorRef = HTMLSpanElement
@@ -23,7 +22,7 @@ export const FormElementError = forwardRef<
       style,
       className,
       message = '\u00a0\u00a0',
-      errorMessageTestId = 'form--element-error',
+      testID = 'form--element-error',
     },
     ref
   ) => {
@@ -36,7 +35,7 @@ export const FormElementError = forwardRef<
         id={id}
         ref={ref}
         style={style}
-        data-testid={errorMessageTestId}
+        data-testid={testID}
         className={formElementErrorClass}
       >
         {message}


### PR DESCRIPTION
### Changes

Updated the FormElement to allow for an additional testID to be passed to the FormElement that will be propagated onto the FormErrorMessage. This will allow for more customized testing on error messages. 

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
