### PR TITLE
Feat/error resource name

### DIFF
--- a/src/Components/Popover/Composed/ErrorTooltip.scss
+++ b/src/Components/Popover/Composed/ErrorTooltip.scss
@@ -6,7 +6,6 @@
 */
 
 .cf-error-tooltip {
-  border-radius: 50%;
   color: $c-dreamsicle;
   font-weight: $cf-font-weight--black;
   display: inline-flex;

--- a/src/Components/Popover/Composed/ErrorTooltip.scss
+++ b/src/Components/Popover/Composed/ErrorTooltip.scss
@@ -1,7 +1,7 @@
 @import '../../../Styles/variables';
 
 /*
-  Question Mark Tooltip Styles
+  Error Tooltip Styles
   ------------------------------------------------------------------------------
 */
 

--- a/src/Components/Popover/Composed/ErrorTooltip.scss
+++ b/src/Components/Popover/Composed/ErrorTooltip.scss
@@ -1,0 +1,22 @@
+@import '../../../Styles/variables';
+
+/*
+  Question Mark Tooltip Styles
+  ------------------------------------------------------------------------------
+*/
+
+.cf-error-tooltip {
+  border-radius: 50%;
+  color: $c-dreamsicle;
+  font-weight: $cf-font-weight--black;
+  display: inline-flex;
+  justify-content: center;
+  position: relative;
+  user-select: none;
+  transition: color 0.25s ease;
+
+  &:hover {
+    cursor: help;
+    color: $c-tungsten;
+  }
+}

--- a/src/Components/Popover/Composed/ErrorTooltip.tsx
+++ b/src/Components/Popover/Composed/ErrorTooltip.tsx
@@ -1,0 +1,90 @@
+// Libraries
+import React, {forwardRef, useRef, RefObject, CSSProperties} from 'react'
+import classnames from 'classnames'
+import {Icon} from '../../Icon/Base/Icon'
+
+// Components
+import {Popover} from '../'
+
+// Types
+import {
+  StandardFunctionProps,
+  ComponentColor,
+  PopoverInteraction,
+  Appearance,
+  IconFont,
+  PopoverPosition,
+} from '../../../Types'
+
+// Styles
+import './ErrorTooltip.scss'
+
+export interface ErrorTooltipProps extends StandardFunctionProps {
+  /** Controls the size of the question mark circle */
+  diameter?: number
+  /** Contents to display in tooltip */
+  tooltipContents: JSX.Element | string
+  /** Useful for customizing the tooltip itself */
+  tooltipStyle?: CSSProperties
+  /** Useful for defining where tooltip should appear relative to the icon */
+  position?: PopoverPosition
+}
+
+export type ErrorTooltipRef = HTMLSpanElement
+
+export const ErrorTooltip = forwardRef<ErrorTooltipRef, ErrorTooltipProps>(
+  (
+    {
+      id,
+      style,
+      className,
+      tooltipStyle,
+      diameter = 17,
+      tooltipContents,
+      position = PopoverPosition.Above,
+      testID = 'error-tooltip',
+    },
+    ref
+  ) => {
+    const triggerRef: RefObject<HTMLDivElement> = useRef(null)
+    const color = ComponentColor.Danger
+    const circleClassName = classnames('cf-error-tooltip', {
+      [`${className}`]: className,
+    })
+
+    const iconStyle = {
+      lineHeight: `${diameter}px`,
+      fontSize: `${diameter}px`,
+      ...style,
+    }
+
+    return (
+      <span ref={ref}>
+        <div
+          className={circleClassName}
+          ref={triggerRef}
+          style={iconStyle}
+          data-testid={testID}
+        >
+          <Icon glyph={IconFont.AlertTriangle} />
+        </div>
+        <Popover
+          distanceFromTrigger={8}
+          triggerRef={triggerRef}
+          showEvent={PopoverInteraction.Hover}
+          hideEvent={PopoverInteraction.Hover}
+          contents={() => <>{tooltipContents}</>}
+          testID={`${testID}--tooltip`}
+          style={tooltipStyle}
+          color={color}
+          appearance={Appearance.Outline}
+          id={id}
+          position={position}
+          caretSize={6}
+        />
+      </span>
+    )
+  }
+)
+
+ErrorTooltip.displayName = 'ErrorTooltip'

--- a/src/Components/Popover/Documentation/ErrorTooltip.md
+++ b/src/Components/Popover/Documentation/ErrorTooltip.md
@@ -1,0 +1,36 @@
+# ErrorToolTip
+
+This composed version of a `Popover` is a compact way to denote and describe error state to the user, but only when they want to know the exact error.
+
+### Usage
+
+```tsx
+import {ErrorTooltip} from '@influxdata/clockface'
+```
+
+```tsx
+<ErrorTooltip
+  diameter={17}
+  tooltipContents={
+
+      // Contents go here, can be text or an element
+
+  }
+/>
+```
+
+##### Ref Type
+
+```tsx
+import {ErrorTooltip} from '@influxdata/clockface'
+```
+
+### Example
+
+<!-- STORY -->
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Popover/Documentation/Popover.stories.tsx
+++ b/src/Components/Popover/Documentation/Popover.stories.tsx
@@ -22,6 +22,7 @@ import {
   QuestionMarkTooltip,
   QuestionMarkTooltipRef,
 } from '../Composed/QuestionMarkTooltip'
+import {ErrorTooltip, ErrorTooltipRef} from '../Composed/ErrorTooltip'
 import {SquareButton} from '../../Button/Composed/SquareButton'
 import {Button, ButtonRef} from '../../Button/Composed/Button'
 import {DapperScrollbars} from '../../DapperScrollbars/DapperScrollbars'
@@ -44,6 +45,7 @@ import {getDictionary} from '../../../Utils'
 import PopoverReadme from './Popover.md'
 import ReflessPopoverReadme from './ReflessPopover.md'
 import QuestionMarkTooltipReadme from './QuestionMarkTooltip.md'
+import ErrorTooltipReadme from './ErrorTooltip.md'
 
 const popoverStories = storiesOf('Atomic|Popover/Base', module).addDecorator(
   withKnobs
@@ -351,6 +353,40 @@ composedPopoverStories.add(
   {
     readme: {
       content: marked(QuestionMarkTooltipReadme),
+    },
+  }
+)
+
+composedPopoverStories.add(
+  'ErrorToolTip',
+  () => {
+    const popoverRef = useRef<ErrorTooltipRef>(null)
+
+    const logRef = (): void => {
+      /* eslint-disable */
+      console.log(popoverRef.current)
+      /* eslint-enable */
+    }
+
+    return (
+      <div className="story--example">
+        <ErrorTooltip
+          ref={popoverRef}
+          diameter={number('diameter', 17)}
+          tooltipContents={text('tooltipContents', 'Some Error Message')}
+          className={text('className', '')}
+          style={object('style', {})}
+          tooltipStyle={object('tooltipStyle', {})}
+        />
+        <div className="story--test-buttons">
+          <button onClick={logRef}>Log Ref</button>
+        </div>
+      </div>
+    )
+  },
+  {
+    readme: {
+      content: marked(ErrorTooltipReadme),
     },
   }
 )

--- a/src/Components/ResourceList/Card/ResourceCardName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardName.scss
@@ -1,4 +1,4 @@
-@import "../../../Styles/variables.scss";
+@import '../../../Styles/variables.scss';
 
 /*
   Editable Name for Resource Cards
@@ -36,4 +36,18 @@
     cursor: pointer;
     color: $cf-link-default-hover;
   }
+}
+
+.cf-resource-name--text__error {
+  color: $c-dreamsicle;
+}
+.cf-resource-name--text__error__link {
+  &:hover {
+    cursor: pointer;
+    color: $c-tungsten;
+  }
+}
+
+.cf-resource-name--text-gap {
+  margin-right: $cf-marg-b;
 }

--- a/src/Components/ResourceList/Card/ResourceCardName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardName.tsx
@@ -2,8 +2,10 @@
 import React, {forwardRef, MouseEvent} from 'react'
 import classnames from 'classnames'
 
+import {ErrorTooltip} from '../../Popover/Composed/ErrorTooltip'
+
 // Types
-import {StandardFunctionProps} from '../../../Types'
+import {StandardFunctionProps, ComponentStatus} from '../../../Types'
 
 // Styles
 import './ResourceCardName.scss'
@@ -13,6 +15,10 @@ export interface ResourceCardNameProps extends StandardFunctionProps {
   name: string
   /** Fires when the name is clicked */
   onClick?: (e: MouseEvent<HTMLAnchorElement>) => void
+  /** error message to be displayeed IF the name component has an error status */
+  errorMessage?: string
+  /** Display error state or default state */
+  status?: ComponentStatus.Default | ComponentStatus.Error
 }
 
 export type ResourceCardNameRef = HTMLDivElement
@@ -20,32 +26,65 @@ export type ResourceCardNameRef = HTMLDivElement
 export const ResourceCardName = forwardRef<
   ResourceCardNameRef,
   ResourceCardNameProps
->(({id, name, style, testID = 'resource-name', onClick, className}, ref) => {
-  const resourceNameClass = classnames('cf-resource-name', {
-    [`${className}`]: className,
-  })
+>(
+  (
+    {
+      id,
+      name,
+      style,
+      testID = 'resource-name',
+      onClick,
+      className,
+      errorMessage = 'This value is invalid',
+      status = ComponentStatus.Default,
+    },
+    ref
+  ) => {
+    const isError = status === ComponentStatus.Error
 
-  const resourceNameLinkClass = classnames('cf-resource-name--text', {
-    'cf-resource-name--text__link': onClick,
-  })
+    const resourceNameClass = classnames('cf-resource-name', {
+      [`${className}`]: className,
+    })
 
-  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    if (onClick) {
-      onClick(e)
+    const resourceNameLinkClass = classnames('cf-resource-name--text', {
+      'cf-resource-name--text__link': onClick,
+      'cf-resource-name--text__error': isError,
+      'cf-resource-name--text__error__link': isError && onClick,
+    })
+
+    const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+      if (onClick) {
+        onClick(e)
+      }
     }
-  }
 
-  return (
-    <div id={id} ref={ref} style={style} className={resourceNameClass}>
-      <span
-        className={resourceNameLinkClass}
-        onClick={handleClick}
-        data-testid={testID}
-      >
-        <span>{name}</span>
-      </span>
-    </div>
-  )
-})
+    const tooltipStyle = {
+      padding: '8px', //$cf-marg-b
+      fontSize: '14px', //$cf-form-md-font
+    }
+
+    return (
+      <div id={id} ref={ref} style={style} className={resourceNameClass}>
+        <span
+          className={resourceNameLinkClass}
+          onClick={handleClick}
+          data-testid={testID}
+        >
+          <span className={'cf-resource-name--text-gap'}>{name}</span>
+          {isError && (
+            <ErrorTooltip
+              tooltipContents={<>{errorMessage}</>}
+              tooltipStyle={tooltipStyle}
+              style={{
+                //offset for the icon to be aligned to the name text
+                transform: 'translateY(-5%)',
+              }}
+            />
+          )}
+        </span>
+      </div>
+    )
+  }
+)
 
 ResourceCardName.displayName = 'ResourceCardName'

--- a/src/Components/ResourceList/Documentation/ResourceCard.stories.tsx
+++ b/src/Components/ResourceList/Documentation/ResourceCard.stories.tsx
@@ -45,6 +45,7 @@ import {
   FlexDirection,
   AlignItems,
   JustifyContent,
+  ComponentStatus,
 } from '../../../Types'
 
 // Notes
@@ -265,12 +266,24 @@ resourceListCardStories.add(
             ref={resourceCardNameRef1}
             name={text('name', 'Card Name')}
             onClick={() => alert('onClick fired!')}
+            errorMessage={text('errorMessage', 'Some Error')}
+            status={select(
+              'status',
+              [ComponentStatus.Default, ComponentStatus.Error],
+              ComponentStatus.Default
+            )}
           />
         </div>
         <div style={{margin: '30px'}}>
           <ResourceCardName
             ref={resourceCardNameRef2}
             name={text('name', 'Card Name')}
+            errorMessage={text('errorMessage', 'Some Error')}
+            status={select(
+              'status',
+              [ComponentStatus.Default, ComponentStatus.Error],
+              ComponentStatus.Default
+            )}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #587 

### Changes

// Describe what you changed
I added a new composed popover called ErrorToolTip - it is a compact out of the box component that will allow devs to denote an error with an icon and provide explanation only when the users want to see it.

Using the ErrorToolTip component above, I added a functionality in the resource card name component to be able to denote an error state. If the error status is passed in as a prop, it will show the error tool tip. The error message is also a prop that the dev can pass in to customize the error message. 


### Screenshots

// Add screenshots here if relevant

![Screen Shot 2021-03-17 at 7 39 19 PM](https://user-images.githubusercontent.com/12561526/111552954-c7459f80-8759-11eb-9ea0-b912638e8324.png)
![Screen Shot 2021-03-17 at 7 37 19 PM](https://user-images.githubusercontent.com/12561526/111552964-c876cc80-8759-11eb-9ce1-ed5477af6b81.png)
![Screen Shot 2021-03-17 at 7 35 42 PM](https://user-images.githubusercontent.com/12561526/111553223-4f2ba980-875a-11eb-9488-9798b0a7811c.png)

![Screen Shot 2021-03-17 at 7 36 01 PM](https://user-images.githubusercontent.com/12561526/111552970-c9a7f980-8759-11eb-9116-60f068bb3b3c.png)


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

