### PR TITLE
Fix: color specific opacity to generic opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+### 2.6.6 (2021-3-22)
+
+
+- [#597](https://github.com/influxdata/clockface/pull/594): Making the resourceCardName component's disabled state opacity generic
+- [#595](https://github.com/influxdata/clockface/pull/595): Adding an errorToolTip component and an Error state to existing resourceCardName component
+
 ### 2.6.5 (2021-3-19)
 
 - [#594](https://github.com/influxdata/clockface/pull/594): Additional testID for formelement error message (fixes 593)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-
 ### 2.6.6 (2021-3-22)
-
 
 - [#597](https://github.com/influxdata/clockface/pull/594): Making the resourceCardName component's disabled state opacity generic
 - [#595](https://github.com/influxdata/clockface/pull/595): Adding an errorToolTip component and an Error state to existing resourceCardName component
@@ -15,7 +13,6 @@
 ### 2.6.4 (2021-3-16)
 
 - [#592](https://github.com/influxdata/clockface/pull/592): Add prevalidation mode for formValidationElement
-
 
 ### 2.6.3 (2021-3-15)
 

--- a/src/Components/ResourceList/Card/ResourceCardName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardName.scss
@@ -29,7 +29,7 @@
   transition: color 0.25s ease;
 
   .cf-resource-card__disabled & {
-    color: rgba($cf-link-default, 0.5);
+    opacity: 0.5;
   }
 
   &:hover {


### PR DESCRIPTION
Closes #

### Changes

// Describe what you changed
For disabled cards, there used to be a color specific opacity defined in css that was overriding the disabled-error combo. For disabled states, changing to generic opacity vs color specific opacity

### Screenshots

<img width="770" alt="Screen Shot 2021-03-22 at 11 47 47 AM" src="https://user-images.githubusercontent.com/12561526/112018010-8c01f280-8b04-11eb-877f-4a144d73e93c.png">
<img width="786" alt="Screen Shot 2021-03-22 at 11 47 30 AM" src="https://user-images.githubusercontent.com/12561526/112018011-8c01f280-8b04-11eb-873e-006e5200f940.png">



### Checklist
Check all that apply


- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
