### PR TITLE
feat: optional full screen overlay w/ a fullscreen prop

### DIFF
--- a/src/Components/Overlay/Documentation/Overlay.stories.tsx
+++ b/src/Components/Overlay/Documentation/Overlay.stories.tsx
@@ -69,6 +69,7 @@ overlayStories.add(
         )}
       >
         <OverlayContainer
+          fullScreen={boolean('fullScreen', false)}
           maxWidth={400}
           margin={
             ComponentSize[
@@ -122,6 +123,7 @@ overlayStories.add(
           <button onClick={logRef}>Log Ref</button>
         </div>
         <OverlayContainer
+          fullScreen={boolean('fullScreen', false)}
           maxWidth={number('maxWidth', 800)}
           ref={overlayContainerRef}
         >

--- a/src/Components/Overlay/Overlay.scss
+++ b/src/Components/Overlay/Overlay.scss
@@ -53,6 +53,15 @@
   &__lg {
     margin: $cf-page--gutter-lg;
   }
+
+  &__full {
+    width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    margin: 0;
+  }
 }
 
 .cf-overlay--header {

--- a/src/Components/Overlay/Overlay.scss
+++ b/src/Components/Overlay/Overlay.scss
@@ -56,7 +56,7 @@
 
   &__full {
     width: 100vw;
-    height: 100vh;
+    min-height: 100vh;
     position: fixed;
     top: 0;
     left: 0;

--- a/src/Components/Overlay/OverlayContainer.tsx
+++ b/src/Components/Overlay/OverlayContainer.tsx
@@ -10,6 +10,7 @@ export interface OverlayContainerProps extends StandardFunctionProps {
   maxWidth?: number
   /** Margins on all sides of overlay */
   margin?: ComponentSize
+  fullScreen?: boolean
 }
 
 export type OverlayContainerRef = HTMLDivElement
@@ -27,16 +28,19 @@ export const OverlayContainer = forwardRef<
       children,
       maxWidth = 800,
       className,
+      fullScreen,
     },
     ref
   ) => {
     const overlayContainerClass = classnames('cf-overlay--container', {
       [`cf-overlay--container__${margin}`]: margin,
+      ['cf-overlay--container__full']: fullScreen,
       [`${className}`]: className,
     })
 
-    const overlayContainerStyle = {maxWidth: `${maxWidth}px`, ...style}
-
+    const overlayContainerStyle = fullScreen
+      ? {...style}
+      : {maxWidth: `${maxWidth}px`, ...style}
     return (
       <div
         id={id}


### PR DESCRIPTION
Closes #201

### Changes

// Describe what you changed
Added a new prop to overlay 'fullScreen', if true, it will make the overlay span the entire width and height of the screen.

### Screenshots
![Screen Shot 2021-04-13 at 3 44 16 PM](https://user-images.githubusercontent.com/12561526/114611830-6b463c00-9c6f-11eb-8d16-2547b2d08617.png)
![Screen Shot 2021-04-13 at 3 44 23 PM](https://user-images.githubusercontent.com/12561526/114611838-6d0fff80-9c6f-11eb-9694-c1fb7cddf28a.png)

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
