### PR TITLE
Adding support for help text -> error text conversion

### DIFF
--- a/src/Components/Form/Documentation/Form.stories.tsx
+++ b/src/Components/Form/Documentation/Form.stories.tsx
@@ -234,6 +234,7 @@ formStories.add(
         <Form.ElementError
           ref={formElementErrorRef}
           message={text('errorMessage', 'Error Message')}
+          withHelper={boolean('withHelper', false)}
         />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Form/Form.scss
+++ b/src/Components/Form/Form.scss
@@ -36,6 +36,12 @@
   @extend %no-user-select;
 }
 
+.cf-form--element-error-container {
+  position: relative;
+  height: 0px;
+  width: 100%;
+}
+
 .cf-form--label {
   width: 100%;
   color: $cf-label--default;
@@ -60,6 +66,7 @@
 }
 
 .cf-form--element-error {
+  position: absolute;
   line-height: 16px;
   color: $c-dreamsicle;
   margin: $cf-marg-a 0 0 0;

--- a/src/Components/Form/FormElementError.tsx
+++ b/src/Components/Form/FormElementError.tsx
@@ -8,6 +8,7 @@ import {StandardFunctionProps} from '../../Types'
 export interface FormElementErrorProps extends StandardFunctionProps {
   /** Text to be displayed on error */
   message?: string
+  withHelper?: boolean
 }
 
 export type FormElementErrorRef = HTMLSpanElement
@@ -23,6 +24,7 @@ export const FormElementError = forwardRef<
       className,
       message = '\u00a0\u00a0',
       testID = 'form--element-error',
+      withHelper = false,
     },
     ref
   ) => {
@@ -30,16 +32,21 @@ export const FormElementError = forwardRef<
       [`${className}`]: className,
     })
 
+    //When Helper text exists, we want error message to take up as much height as the helper text. When Helper text does not exist, we want error message to not shift spaces.
+    const withHelperStyle = withHelper ? {height: '20px'} : {}
+
     return (
-      <span
-        id={id}
-        ref={ref}
-        style={style}
-        data-testid={testID}
-        className={formElementErrorClass}
-      >
-        {message}
-      </span>
+      <div className="cf-form--element-error-container" style={withHelperStyle}>
+        <span
+          id={id}
+          ref={ref}
+          style={style}
+          data-testid={testID}
+          className={formElementErrorClass}
+        >
+          {message}
+        </span>
+      </div>
     )
   }
 )

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -80,6 +80,8 @@ export const FormValidationElement = forwardRef<
       onStatusChange(status)
     }
 
+    const withHelper = helpText ? true : false
+
     const formValidationElementClass = classnames('cf-form--element', {
       [`${className}`]: className,
     })
@@ -99,8 +101,10 @@ export const FormValidationElement = forwardRef<
           </FormLabel>
         )}
         {children(status)}
-        {!!errorMessage && <FormElementError message={errorMessage} />}
-        {!!helpText && <FormHelpText text={helpText} />}
+        {!!errorMessage && (
+          <FormElementError message={errorMessage} withHelper={withHelper} />
+        )}
+        {!!helpText && !errorMessage && <FormHelpText text={helpText} />}
       </label>
     )
   }


### PR DESCRIPTION
Closes #232

### Changes

// Describe what you changed
I added new styling container on top of the form error message so that when an error message appears, it does not take up spacing.

### Screenshots

https://user-images.githubusercontent.com/12561526/116012070-24e0cd80-a5dd-11eb-83b4-38986f2f2930.mov

There is one caveat. This means that developers using clockface have to add in the right spacing after the input element so that this does not happen:

![Screen Shot 2021-04-25 at 3 33 44 PM](https://user-images.githubusercontent.com/12561526/116012088-4477f600-a5dd-11eb-8881-5570cb9c7ac5.png)

Or I can make it so that it has built in spacing out of the box.  @mavarius do you have thoughts on which one might be preferable? 

I see good reasons for having pre-defined spacing to prevent the overlap (easy out of the box) and also not having it (more freedom). 

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
