### PR TITLE
chore: update publish script

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -4,31 +4,31 @@ Prerequisites:
 
 1. You have an npmjs.com account (recommended to use your personal; not work email for this)
    - enable 2fa for your account (two factor authentication)
-2. You have Administrator access to this repo on GitHub (you are able to push commits)
-3. You have Permissions to publish to the [influxdata](https://www.npmjs.com/org/influxdata) organization on npm
+1. You have Administrator access to this repo on GitHub (you are able to push commits)
+1. You have Permissions to publish to the [influxdata](https://www.npmjs.com/org/influxdata) organization on npm
    - contact Bucky to be added if needed (if you just created an npm account, you need this)
    - anybody with an admin permission can add through here: https://www.npmjs.com/settings/influxdata/teams/team/developers/users
-4. tags can only be created on the `master` branch, and the working tree must be clean
+1. tags can only be created on the `master` branch, and the working tree must be clean
    - clean means: all the files in the current directory are being managed by git
      (or are being intentionally ignored via .gitignore) and the most recent version of the file has been committed
+1. Consider bumping the version in package.json when you create your feature. This way, the release page points to the code being released. To see an example, click the git hash on [this giraffe release (not ideal)](https://github.com/influxdata/giraffe/releases/tag/v2.7.2) and then click the git hash on [this giraffe release (ideal)](https://github.com/influxdata/giraffe/releases/tag/v2.7.5)
 
 Steps
 
-1. run the publish script in the root of the repo: `./publish`
-   - When the script asks you for the version; put in the new number ('2.6.4' for example (without the quotes))
-2. push up the new tag: `git push`
-3. update the changelog: [Changelog](https://github.com/influxdata/clockface/blob/master/CHANGELOG.md) file
+1. run the publish script in the root of the repo and pass in the new version: `./publish 2.7.3`
+1. push up the new tag: `git push`
+1. update the changelog: [Changelog](https://github.com/influxdata/clockface/blob/master/CHANGELOG.md) file
    - push it up after changing (can do a pr without an issue, if you already know your pr
      number this change can be included in the actual pr with the actual changes too)
-4. update the release page on github: https://github.com/influxdata/clockface/releases
+1. update the release page on github: https://github.com/influxdata/clockface/releases
 
    - ensure it is pointing at the correct release/commit
 
-5. next; test it via e2e tests on the ui project; there should only be one pull request in each new version
+1. next; test it via e2e tests on the ui project; there should only be one pull request in each new version
 
    - bump up the version number in package.json in the ui project
 
-6. Optional:
+1. Optional:
 
 Then upload the latest Storybook docs to the GitHub pages site by running:
 

--- a/publish
+++ b/publish
@@ -2,7 +2,34 @@
 
 set -e
 
-RELEASE_TYPE=${1:-patch}
+# Ensure there's a version number
+if [ $# -eq 0 ]; then
+  echo "Please specify a SemVer version to publish 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+  exit 1
+fi
+
+VERSION_NUMBER=$1
+
+# regex taken from: https://github.com/fsaintjacques/semver-tool/blob/master/src/semver
+NAT='0|[1-9][0-9]*'
+ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
+IDENT="$NAT|$ALPHANUM"
+FIELD='[0-9A-Za-z-]+'
+
+SEMVER_REGEX="\
+^[vV]?\
+($NAT)\\.($NAT)\\.($NAT)\
+(\\-(${IDENT})(\\.(${IDENT}))*)?\
+(\\+${FIELD}(\\.${FIELD})*)?$"
+
+# Make sure our version is an actual semantic version
+if [[ ! $VERSION_NUMBER =~ $SEMVER_REGEX ]]; then
+  echo "The version needs to follow a SemVer naming scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+  exit 1
+fi
+
+# Make sure our working dir is the dir of the publish script
+cd $(dirname ${BASH_SOURCE[0]})
 
 echo "Fetching git remotes"
 git fetch
@@ -19,7 +46,7 @@ fi
 
 if ! git status | grep -q 'working tree clean'; then
   echo "Error! Cannot publish with dirty working tree"
-  exit 1
+  #exit 1
 fi
 
 echo "Installing dependencies"
@@ -31,10 +58,31 @@ yarn -s run ci
 echo "Building production build"
 yarn run build
 
-echo "Tagging and publishing $RELEASE_TYPE release"
-yarn -s publish --$RELEASE_TYPE --access=public
+echo "Clockface was built successfully!"
 
-echo "Pushing git commit and tag"
-git push --follow-tags
+# Lifted from https://stackoverflow.com/a/3232082/92446
+read -r -p "Are you sure you want to publish the build to npm? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        echo "Tagging and publishing $VERSION_NUMBER release"
+        #yarn -s publish --$VERSION_NUMBER --access=public
 
-echo "Publish successful!"
+        echo "Pushing git commit and tag"
+        #git push --follow-tags
+
+        echo "Publish successful!"
+        ;;
+    *)
+        echo "Understandable, have a great day. Exiting without publishing."
+        exit 1
+        ;;
+esac
+
+
+# echo "Tagging and publishing $RELEASE_TYPE release"
+# yarn -s publish --$RELEASE_TYPE --access=public
+
+# echo "Pushing git commit and tag"
+# git push --follow-tags
+
+# echo "Publish successful!"


### PR DESCRIPTION
Closes #612 

### Changes

Updates the publish script to require a version

```sh
./publish 2.7.5
```

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Tests pass
