### PR TITLE
Feat/draggable resizer bar change

### DIFF
--- a/src/Components/DraggableResizer/Documentation/DraggableResizer.stories.tsx
+++ b/src/Components/DraggableResizer/Documentation/DraggableResizer.stories.tsx
@@ -4,7 +4,7 @@ import marked from 'marked'
 
 // Storybook
 import {storiesOf} from '@storybook/react'
-import {withKnobs, select, number} from '@storybook/addon-knobs'
+import {withKnobs, select, number, object} from '@storybook/addon-knobs'
 import {mapEnumKeys} from '../../../Utils/storybook'
 import {useState} from '@storybook/addons'
 
@@ -61,6 +61,7 @@ draggableResizerStories.add(
           handlePositions =>
             console.log(`this.setState({handlePositions: ${handlePositions}})`) // eslint-disable-line
         }
+
       >
         <DraggableResizer.Panel>
           <div className="mockCard" />
@@ -117,6 +118,8 @@ draggableResizerExamplesStories.add(
     const [position, updatePosition] = useState<number[]>([0.5])
     const draggableResizerPanelRef1 = createRef<DraggableResizerPanelRef>()
     const draggableResizerPanelRef2 = createRef<DraggableResizerPanelRef>()
+    const defaultBackgroundStyle = {backgroundColor: 'transparent'}
+    const defaultBarStyle = {backgroundColor: '#ffffff'}
 
     const logRef = (): void => {
       /* eslint-disable */
@@ -140,6 +143,8 @@ draggableResizerExamplesStories.add(
               ]
             ]
           }
+          handleBackgroundStyle={object('handleBackgroundStyle', defaultBackgroundStyle)}
+          handleBarStyle={object('handleBarStyle', defaultBarStyle)}
           handlePositions={position}
           onChangePositions={handlePositions => updatePosition(handlePositions)}
         >

--- a/src/Components/DraggableResizer/Documentation/DraggableResizer.stories.tsx
+++ b/src/Components/DraggableResizer/Documentation/DraggableResizer.stories.tsx
@@ -61,7 +61,6 @@ draggableResizerStories.add(
           handlePositions =>
             console.log(`this.setState({handlePositions: ${handlePositions}})`) // eslint-disable-line
         }
-
       >
         <DraggableResizer.Panel>
           <div className="mockCard" />
@@ -143,7 +142,10 @@ draggableResizerExamplesStories.add(
               ]
             ]
           }
-          handleBackgroundStyle={object('handleBackgroundStyle', defaultBackgroundStyle)}
+          handleBackgroundStyle={object(
+            'handleBackgroundStyle',
+            defaultBackgroundStyle
+          )}
           handleBarStyle={object('handleBarStyle', defaultBarStyle)}
           handlePositions={position}
           onChangePositions={handlePositions => updatePosition(handlePositions)}

--- a/src/Components/DraggableResizer/DraggableResizer.scss
+++ b/src/Components/DraggableResizer/DraggableResizer.scss
@@ -57,32 +57,43 @@
 }
 
 .cf-draggable-resizer--handle {
-  flex: 0 0 8px;
+  flex: 0 0 16px;
   background-color: transparent;
   position: relative;
-
-  &:before,
-  > .cf-draggable-resizer--gradient {
+  padding: 4px;
+  > .cf-draggable-resizer--handle-pill-1,
+  > .cf-draggable-resizer--gradient{
     content: '';
     background-color: $g5-pepper;
     position: absolute;
     top: 50%;
-    left: 50%;
+    left: 6px;
+    transform: translate(-50%, -50%);
+    border-radius: 2px;
+  }
+  > .cf-draggable-resizer--handle-pill-2,
+  > .cf-draggable-resizer--gradient-2 {
+    content: '';
+    background-color: $g5-pepper;
+    position: absolute;
+    top: 50%;
+    right: 4px;
     transform: translate(-50%, -50%);
     border-radius: 2px;
   }
   
-  &:before {
+  > .cf-draggable-resizer--handle-pill-1,
+  > .cf-draggable-resizer--handle-pill-2 {
     z-index: 1;
   }
 
-  > .cf-draggable-resizer--gradient {
+  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
     opacity: 0;
     z-index: 2;
     transition: opacity 0.25s ease, height 0.2s ease, width 0.2s ease;
   }
 
-  &:hover > .cf-draggable-resizer--gradient {
+  &:hover > .cf-draggable-resizer--gradient, &:hover > .cf-draggable-resizer--gradient-2 {
     opacity: 1;
   }
 
@@ -98,10 +109,11 @@
     cursor: row-resize;
   }
 
-  &:before,
-  > .cf-draggable-resizer--gradient {
-    width: 60px;
-    height: 4px;
+  > .cf-draggable-resizer--handle-pill-1,
+  > .cf-draggable-resizer--handle-pill-2,
+  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
+    width: 32px;
+    height: 2px;
   }
 }
 
@@ -111,23 +123,28 @@
     cursor: col-resize;
   }
 
-  &:before,
-  > .cf-draggable-resizer--gradient {
-    width: 4px;
-    height: 60px;
+  > .cf-draggable-resizer--handle-pill-1,
+  > .cf-draggable-resizer--handle-pill-2,
+  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
+    width: 2px;
+    height: 32px;
   }
 }
 
 // Handle Dragging State
 .cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2,
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
   opacity: 1;
 }
 
-.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
-  width: calc(100% - 60px);
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
+  width: calc(25% - 60px);
 }
 
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient {
-  height: calc(100% - 60px);
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
+  height: calc(25% - 60px);
 }

--- a/src/Components/DraggableResizer/DraggableResizer.scss
+++ b/src/Components/DraggableResizer/DraggableResizer.scss
@@ -61,8 +61,8 @@
   background-color: transparent;
   position: relative;
   padding: 4px;
-  > .cf-draggable-resizer--handle-pill-1,
-  > .cf-draggable-resizer--gradient {
+  > .cf-draggable-resizer--handle-pill1,
+  > .cf-draggable-resizer--gradient1 {
     content: '';
     background-color: $g5-pepper;
     position: absolute;
@@ -70,8 +70,8 @@
     transform: translate(-50%, -50%);
     border-radius: 2px;
   }
-  > .cf-draggable-resizer--handle-pill-2,
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--handle-pill2,
+  > .cf-draggable-resizer--gradient2 {
     content: '';
     background-color: $g5-pepper;
     position: absolute;
@@ -80,41 +80,41 @@
     border-radius: 2px;
   }
 
-  > .cf-draggable-resizer--handle-pill-1,
-  > .cf-draggable-resizer--handle-pill-2 {
+  > .cf-draggable-resizer--handle-pill1,
+  > .cf-draggable-resizer--handle-pill2 {
     z-index: 1;
   }
 
-  > .cf-draggable-resizer--handle-pill-1__vertical,
-  > .cf-draggable-resizer--gradient-1__vertical {
+  > .cf-draggable-resizer--handle-pill1--vertical,
+  > .cf-draggable-resizer--gradient1--vertical {
     top: 50%;
     left: 6px;
   }
-  > .cf-draggable-resizer--handle-pill-1__horizontal,
-  > .cf-draggable-resizer--gradient-1__horizontal {
+  > .cf-draggable-resizer--handle-pill1--horizontal,
+  > .cf-draggable-resizer--gradient1--horizontal {
     top: 6px;
     left: 50%;
   }
-  > .cf-draggable-resizer--handle-pill-2__vertical,
-  > .cf-draggable-resizer--gradient-2__vertical {
+  > .cf-draggable-resizer--handle-pill2--vertical,
+  > .cf-draggable-resizer--gradient2--vertical {
     top: 50%;
     right: 4px;
   }
-  > .cf-draggable-resizer--handle-pill-2__horizontal,
-  > .cf-draggable-resizer--gradient-2__horizontal {
+  > .cf-draggable-resizer--handle-pill2--horizontal,
+  > .cf-draggable-resizer--gradient2--horizontal {
     bottom: 4px;
     left: 50%;
   }
 
-  > .cf-draggable-resizer--gradient,
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient1,
+  > .cf-draggable-resizer--gradient2 {
     opacity: 0;
     z-index: 2;
     transition: opacity 0.25s ease, height 0.2s ease, width 0.2s ease;
   }
 
-  &:hover > .cf-draggable-resizer--gradient,
-  &:hover > .cf-draggable-resizer--gradient-2 {
+  &:hover > .cf-draggable-resizer--gradient1,
+  &:hover > .cf-draggable-resizer--gradient2 {
     opacity: 1;
   }
 
@@ -131,10 +131,10 @@
     cursor: row-resize;
   }
 
-  > .cf-draggable-resizer--handle-pill-1,
-  > .cf-draggable-resizer--handle-pill-2,
-  > .cf-draggable-resizer--gradient,
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--handle-pill1,
+  > .cf-draggable-resizer--handle-pill2,
+  > .cf-draggable-resizer--gradient1,
+  > .cf-draggable-resizer--gradient2 {
     width: 32px;
     height: 2px;
   }
@@ -146,10 +146,10 @@
     cursor: col-resize;
   }
 
-  > .cf-draggable-resizer--handle-pill-1,
-  > .cf-draggable-resizer--handle-pill-2,
-  > .cf-draggable-resizer--gradient,
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--handle-pill1,
+  > .cf-draggable-resizer--handle-pill2,
+  > .cf-draggable-resizer--gradient1,
+  > .cf-draggable-resizer--gradient2 {
     width: 2px;
     height: 32px;
   }
@@ -158,33 +158,33 @@
 // Handle Dragging State
 .cf-draggable-resizer--horizontal
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient1,
 .cf-draggable-resizer--vertical
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient1,
 .cf-draggable-resizer--horizontal
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient-2,
+  > .cf-draggable-resizer--gradient2,
 .cf-draggable-resizer--vertical
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient2 {
   opacity: 1;
 }
 
 .cf-draggable-resizer--horizontal
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient1,
 .cf-draggable-resizer--horizontal
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient2 {
   width: calc(25% - 60px);
 }
 
 .cf-draggable-resizer--vertical
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient1,
 .cf-draggable-resizer--vertical
   .cf-draggable-resizer--handle-dragging
-  > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient2 {
   height: calc(25% - 60px);
 }

--- a/src/Components/DraggableResizer/DraggableResizer.scss
+++ b/src/Components/DraggableResizer/DraggableResizer.scss
@@ -62,12 +62,11 @@
   position: relative;
   padding: 4px;
   > .cf-draggable-resizer--handle-pill-1,
-  > .cf-draggable-resizer--gradient{
+  > .cf-draggable-resizer--gradient {
     content: '';
     background-color: $g5-pepper;
     position: absolute;
-    top: 50%;
-    left: 6px;
+
     transform: translate(-50%, -50%);
     border-radius: 2px;
   }
@@ -76,29 +75,52 @@
     content: '';
     background-color: $g5-pepper;
     position: absolute;
-    top: 50%;
-    right: 4px;
+
     transform: translate(-50%, -50%);
     border-radius: 2px;
   }
-  
+
   > .cf-draggable-resizer--handle-pill-1,
   > .cf-draggable-resizer--handle-pill-2 {
     z-index: 1;
   }
 
-  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--handle-pill-1__vertical,
+  > .cf-draggable-resizer--gradient-1__vertical {
+    top: 50%;
+    left: 6px;
+  }
+  > .cf-draggable-resizer--handle-pill-1__horizontal,
+  > .cf-draggable-resizer--gradient-1__horizontal {
+    top: 6px;
+    left: 50%;
+  }
+  > .cf-draggable-resizer--handle-pill-2__vertical,
+  > .cf-draggable-resizer--gradient-2__vertical {
+    top: 50%;
+    right: 4px;
+  }
+  > .cf-draggable-resizer--handle-pill-2__horizontal,
+  > .cf-draggable-resizer--gradient-2__horizontal {
+    bottom: 4px;
+    left: 50%;
+  }
+
+  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient-2 {
     opacity: 0;
     z-index: 2;
     transition: opacity 0.25s ease, height 0.2s ease, width 0.2s ease;
   }
 
-  &:hover > .cf-draggable-resizer--gradient, &:hover > .cf-draggable-resizer--gradient-2 {
+  &:hover > .cf-draggable-resizer--gradient,
+  &:hover > .cf-draggable-resizer--gradient-2 {
     opacity: 1;
   }
 
   // Prevents adjacent handles from lighting up when one is being dragged
-  .cf-draggable-resizer--dragging &:not(.cf-draggable-resizer--handle-dragging):hover:after {
+  .cf-draggable-resizer--dragging
+    &:not(.cf-draggable-resizer--handle-dragging):hover:after {
     opacity: 0;
   }
 }
@@ -111,7 +133,8 @@
 
   > .cf-draggable-resizer--handle-pill-1,
   > .cf-draggable-resizer--handle-pill-2,
-  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient-2 {
     width: 32px;
     height: 2px;
   }
@@ -125,26 +148,43 @@
 
   > .cf-draggable-resizer--handle-pill-1,
   > .cf-draggable-resizer--handle-pill-2,
-  > .cf-draggable-resizer--gradient, > .cf-draggable-resizer--gradient-2 {
+  > .cf-draggable-resizer--gradient,
+  > .cf-draggable-resizer--gradient-2 {
     width: 2px;
     height: 32px;
   }
 }
 
 // Handle Dragging State
-.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
-.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2,
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
+.cf-draggable-resizer--horizontal
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--vertical
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--horizontal
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient-2,
+.cf-draggable-resizer--vertical
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient-2 {
   opacity: 1;
 }
 
-.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
-.cf-draggable-resizer--horizontal .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
+.cf-draggable-resizer--horizontal
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--horizontal
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient-2 {
   width: calc(25% - 60px);
 }
 
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient,
-.cf-draggable-resizer--vertical .cf-draggable-resizer--handle-dragging > .cf-draggable-resizer--gradient-2 {
+.cf-draggable-resizer--vertical
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient,
+.cf-draggable-resizer--vertical
+  .cf-draggable-resizer--handle-dragging
+  > .cf-draggable-resizer--gradient-2 {
   height: calc(25% - 60px);
 }

--- a/src/Components/DraggableResizer/DraggableResizer.scss
+++ b/src/Components/DraggableResizer/DraggableResizer.scss
@@ -177,6 +177,7 @@
 .cf-draggable-resizer--horizontal
   .cf-draggable-resizer--handle-dragging
   > .cf-draggable-resizer--gradient2 {
+  min-width: 32px;
   width: calc(25% - 60px);
 }
 
@@ -186,5 +187,6 @@
 .cf-draggable-resizer--vertical
   .cf-draggable-resizer--handle-dragging
   > .cf-draggable-resizer--gradient2 {
+  min-height: 32px;
   height: calc(25% - 60px);
 }

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useEffect,
   cloneElement,
+  CSSProperties,
 } from 'react'
 import classnames from 'classnames'
 
@@ -29,7 +30,10 @@ export interface DraggableResizerProps extends StandardFunctionProps {
   /** Returns the updated array of numbers between 0 - 1, used to manage state */
   onChangePositions: (positions: number[]) => void
   /** Gradient theme for handle */
-  handleGradient?: Gradients
+  handleGradient?: Gradients,
+  handleBackgroundStyle?: CSSProperties
+  handleBarStyle?: CSSProperties
+
 }
 
 export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
@@ -42,6 +46,8 @@ export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
   onChangePositions,
   testID = 'draggable-resizer',
   handleGradient = Gradients.PastelGothic,
+  handleBackgroundStyle,
+  handleBarStyle,
 }) => {
   const [dragIndex, setDragIndex] = useState<number>(NULL_DRAG)
 
@@ -160,7 +166,7 @@ export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
 
         const isLastPanel = i === panelsCount - 1
         const dragging = i === dragIndex
-
+        
         return (
           <>
             {cloneElement(child, {sizePercent: calculatePanelSize(i)})}
@@ -172,6 +178,8 @@ export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
                 dragging={dragging}
                 gradient={handleGradient}
                 orientation={handleOrientation}
+                style={handleBackgroundStyle}
+                handleBarStyle={handleBarStyle}
                 testID={`${testID}--handle`}
               />
             )}

--- a/src/Components/DraggableResizer/DraggableResizer.tsx
+++ b/src/Components/DraggableResizer/DraggableResizer.tsx
@@ -30,10 +30,9 @@ export interface DraggableResizerProps extends StandardFunctionProps {
   /** Returns the updated array of numbers between 0 - 1, used to manage state */
   onChangePositions: (positions: number[]) => void
   /** Gradient theme for handle */
-  handleGradient?: Gradients,
+  handleGradient?: Gradients
   handleBackgroundStyle?: CSSProperties
   handleBarStyle?: CSSProperties
-
 }
 
 export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
@@ -166,7 +165,7 @@ export const DraggableResizerRoot: FunctionComponent<DraggableResizerProps> = ({
 
         const isLastPanel = i === panelsCount - 1
         const dragging = i === dragIndex
-        
+
         return (
           <>
             {cloneElement(child, {sizePercent: calculatePanelSize(i)})}

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -21,6 +21,7 @@ export interface DraggableResizerHandleProps extends StandardFunctionProps {
   gradient: Gradients
   /** Orientation of handle */
   orientation: Orientation
+  handleBarStyle? : CSSProperties
 }
 
 export type DraggableResizerHandleRef = HTMLDivElement
@@ -42,6 +43,7 @@ export const DraggableResizerHandle = forwardRef<
       onStartDrag = () => {
         // do nothing
       },
+      handleBarStyle,
     },
     ref
   ) => {
@@ -67,12 +69,14 @@ export const DraggableResizerHandle = forwardRef<
       if (orientation == Orientation.Vertical) {
         return {
           background: `linear-gradient(to bottom,  ${colors.start} 0%,${colors.stop} 100%)`,
+          backgroundColor: '#FFFFFF'
         }
       }
 
       if (orientation === Orientation.Horizontal) {
         return {
           background: `linear-gradient(to right,  ${colors.start} 0%,${colors.stop} 100%)`,
+          backgroundColor: '#FFFFFF'
         }
       }
 
@@ -88,9 +92,17 @@ export const DraggableResizerHandle = forwardRef<
         data-testid={testID}
         style={style}
         id={id}
-      >
+      > 
+        <div className='cf-draggable-resizer--handle-pill-1'
+        style={handleBarStyle}></div>
         <div
           className="cf-draggable-resizer--gradient"
+          style={gradientStyle()}
+        />
+        <div className='cf-draggable-resizer--handle-pill-2'
+        style={handleBarStyle}></div>
+        <div
+          className="cf-draggable-resizer--gradient-2"
           style={gradientStyle()}
         />
       </div>

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -60,30 +60,30 @@ export const DraggableResizerHandle = forwardRef<
     )
 
     const DraggableResizerHandlePillOneClass = classnames(
-      'cf-draggable-resizer--handle-pill-1',
+      'cf-draggable-resizer--handle-pill1',
       {
-        [`cf-draggable-resizer--handle-pill-1__${orientation}`]: orientation,
+        [`cf-draggable-resizer--handle-pill1--${orientation}`]: orientation,
       }
     )
 
     const DraggableResizerHandlePillTwoClass = classnames(
-      'cf-draggable-resizer--handle-pill-2',
+      'cf-draggable-resizer--handle-pill2',
       {
-        [`cf-draggable-resizer--handle-pill-2__${orientation}`]: orientation,
+        [`cf-draggable-resizer--handle-pill2--${orientation}`]: orientation,
       }
     )
 
     const DraggableResizerGradientPillOneClass = classnames(
-      'cf-draggable-resizer--gradient',
+      'cf-draggable-resizer--gradient1',
       {
-        [`cf-draggable-resizer--gradient-1__${orientation}`]: orientation,
+        [`cf-draggable-resizer--gradient1--${orientation}`]: orientation,
       }
     )
 
     const DraggableResizerGradientPillTwoClass = classnames(
-      'cf-draggable-resizer--gradient-2',
+      'cf-draggable-resizer--gradient2',
       {
-        [`cf-draggable-resizer--gradient-2__${orientation}`]: orientation,
+        [`cf-draggable-resizer--gradient2--${orientation}`]: orientation,
       }
     )
 

--- a/src/Components/DraggableResizer/DraggableResizerHandle.tsx
+++ b/src/Components/DraggableResizer/DraggableResizerHandle.tsx
@@ -21,7 +21,7 @@ export interface DraggableResizerHandleProps extends StandardFunctionProps {
   gradient: Gradients
   /** Orientation of handle */
   orientation: Orientation
-  handleBarStyle? : CSSProperties
+  handleBarStyle?: CSSProperties
 }
 
 export type DraggableResizerHandleRef = HTMLDivElement
@@ -59,6 +59,34 @@ export const DraggableResizerHandle = forwardRef<
       }
     )
 
+    const DraggableResizerHandlePillOneClass = classnames(
+      'cf-draggable-resizer--handle-pill-1',
+      {
+        [`cf-draggable-resizer--handle-pill-1__${orientation}`]: orientation,
+      }
+    )
+
+    const DraggableResizerHandlePillTwoClass = classnames(
+      'cf-draggable-resizer--handle-pill-2',
+      {
+        [`cf-draggable-resizer--handle-pill-2__${orientation}`]: orientation,
+      }
+    )
+
+    const DraggableResizerGradientPillOneClass = classnames(
+      'cf-draggable-resizer--gradient',
+      {
+        [`cf-draggable-resizer--gradient-1__${orientation}`]: orientation,
+      }
+    )
+
+    const DraggableResizerGradientPillTwoClass = classnames(
+      'cf-draggable-resizer--gradient-2',
+      {
+        [`cf-draggable-resizer--gradient-2__${orientation}`]: orientation,
+      }
+    )
+
     const gradientStyle = (): CSSProperties | undefined => {
       if (!orientation || !gradient) {
         return
@@ -69,14 +97,14 @@ export const DraggableResizerHandle = forwardRef<
       if (orientation == Orientation.Vertical) {
         return {
           background: `linear-gradient(to bottom,  ${colors.start} 0%,${colors.stop} 100%)`,
-          backgroundColor: '#FFFFFF'
+          backgroundColor: '#FFFFFF',
         }
       }
 
       if (orientation === Orientation.Horizontal) {
         return {
           background: `linear-gradient(to right,  ${colors.start} 0%,${colors.stop} 100%)`,
-          backgroundColor: '#FFFFFF'
+          backgroundColor: '#FFFFFF',
         }
       }
 
@@ -92,17 +120,21 @@ export const DraggableResizerHandle = forwardRef<
         data-testid={testID}
         style={style}
         id={id}
-      > 
-        <div className='cf-draggable-resizer--handle-pill-1'
-        style={handleBarStyle}></div>
+      >
         <div
-          className="cf-draggable-resizer--gradient"
+          className={DraggableResizerHandlePillOneClass}
+          style={handleBarStyle}
+        ></div>
+        <div
+          className={DraggableResizerGradientPillOneClass}
           style={gradientStyle()}
         />
-        <div className='cf-draggable-resizer--handle-pill-2'
-        style={handleBarStyle}></div>
         <div
-          className="cf-draggable-resizer--gradient-2"
+          className={DraggableResizerHandlePillTwoClass}
+          style={handleBarStyle}
+        ></div>
+        <div
+          className={DraggableResizerGradientPillTwoClass}
           style={gradientStyle()}
         />
       </div>


### PR DESCRIPTION
Closes #615 

### Changes

// Describe what you changed
I've added two props to draggable resizer that will be passed down to the handle:
1. handleBackgroundStyle - you can pass CSS properties to change background color of the space between two panels where the resizer icon is
2. handleBarStyle - you can pass CSS properties to change the color of the resizer icon (two pills). 

The uses for these two are indicated in Julia's designs where we might want slightly different background colors and the icons color to go along with that background color. 

I've changed the look and the feel of the handle bar icon from 1 pill to 2 pills to add more affordance for resizing ability and also to make it look less like a scroll bar. 

### Screenshots

// Add screenshots here if relevant
![Explorer Example](https://user-images.githubusercontent.com/12561526/117395607-1fbd3180-aead-11eb-9f09-126a0968b4d4.gif)
![HorizontalExample](https://user-images.githubusercontent.com/12561526/117395640-29df3000-aead-11eb-8d3d-c1c2472c4683.gif)
![VerticalExample](https://user-images.githubusercontent.com/12561526/117395642-2a77c680-aead-11eb-8789-0a2bf1cd9e91.gif)

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
