### PR TITLE
Button disabled text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.9.0 (2021-6-01)
+- [#632](https://github.com/influxdata/clockface/pull/632): Add disabledText field to Button-based components
+
+
 ### 2.8.0 (2021-5-20)
 - [#625](https://github.com/influxdata/clockface/pull/625): bump y18n from 4.0.0 to 4.0.3
 - [#619](https://github.com/influxdata/clockface/pull/619): bump ua-parser-js from 0.7.21 to 0.7.28

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -89,7 +89,7 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
     )
 
     const titleTextToBeUsed =
-      status == ComponentStatus.Disabled && disabledTitleText
+      status === ComponentStatus.Disabled && disabledTitleText
         ? disabledTitleText
         : titleText
 

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -28,6 +28,8 @@ export interface ButtonBaseProps extends StandardFunctionProps {
   onMouseLeave?: (e?: MouseEvent<HTMLButtonElement>) => void
   /** Text to be displayed on hover tooltip */
   titleText?: string
+  /** Text to be displayed on hover tooltip when the button is disabled */
+  disabledTitleText?: string
   /** Keyboard control tab order  */
   tabIndex?: number
   /** Button color */
@@ -55,6 +57,7 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
       children,
       tabIndex,
       titleText,
+      disabledTitleText,
       className,
       onMouseOut,
       onMouseOver,
@@ -85,6 +88,9 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
       }
     )
 
+    const titleTextToBeUsed =
+      status == ComponentStatus.Disabled ? disabledTitleText : titleText
+
     return (
       <button
         className={buttonBaseClass}
@@ -94,7 +100,7 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
         onMouseOver={onMouseOver}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        title={titleText}
+        title={titleTextToBeUsed}
         tabIndex={!!tabIndex ? tabIndex : 0}
         type={type}
         data-testid={testID}

--- a/src/Components/Button/Base/ButtonBase.tsx
+++ b/src/Components/Button/Base/ButtonBase.tsx
@@ -89,7 +89,9 @@ export const ButtonBase = forwardRef<ButtonBaseRef, ButtonBaseProps>(
     )
 
     const titleTextToBeUsed =
-      status == ComponentStatus.Disabled ? disabledTitleText : titleText
+      status == ComponentStatus.Disabled && disabledTitleText
+        ? disabledTitleText
+        : titleText
 
     return (
       <button

--- a/src/Components/Button/Composed/Button.tsx
+++ b/src/Components/Button/Composed/Button.tsx
@@ -39,6 +39,7 @@ export const Button = forwardRef<ButtonRef, ButtonProps>(
       onClick,
       tabIndex,
       titleText,
+      disabledTitleText,
       className,
       onMouseOut,
       onMouseOver,
@@ -79,6 +80,7 @@ export const Button = forwardRef<ButtonRef, ButtonProps>(
         onMouseLeave={onMouseLeave}
         className={className}
         titleText={titleText || text}
+        disabledTitleText={disabledTitleText}
         tabIndex={!!tabIndex ? tabIndex : 0}
       >
         <IconAndText

--- a/src/Components/Button/Composed/CTAButton.tsx
+++ b/src/Components/Button/Composed/CTAButton.tsx
@@ -41,6 +41,7 @@ export const CTAButton = forwardRef<CTAButtonRef, CTAButtonProps>(
       onClick,
       tabIndex,
       titleText,
+      disabledTitleText,
       className,
       onMouseOut,
       onMouseOver,
@@ -64,6 +65,7 @@ export const CTAButton = forwardRef<CTAButtonRef, CTAButtonProps>(
       <ButtonBase
         className={CTAButtonClass}
         titleText={titleText}
+        disabledTitleText={disabledTitleText}
         tabIndex={tabIndex}
         onClick={onClick}
         onMouseOut={onMouseOut}

--- a/src/Components/Button/Composed/ConfirmationButton.tsx
+++ b/src/Components/Button/Composed/ConfirmationButton.tsx
@@ -69,6 +69,7 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
   tabIndex,
   className,
   titleText,
+  disabledTitleText,
   onConfirm,
   returnValue,
   popoverStyle,
@@ -136,6 +137,7 @@ export const ConfirmationButton: FunctionComponent<ConfirmationButtonProps> = ({
         className={className}
         placeIconAfterText={placeIconAfterText}
         titleText={titleText || text}
+        disabledTitleText={disabledTitleText}
         tabIndex={tabIndex}
         testID={`${testID}--button`}
         ref={triggerRef}

--- a/src/Components/Button/Composed/DismissButton.tsx
+++ b/src/Components/Button/Composed/DismissButton.tsx
@@ -30,6 +30,7 @@ export const DismissButton = forwardRef<DismissButtonRef, DismissButtonProps>(
       onClick,
       tabIndex,
       titleText,
+      disabledTitleText,
       className,
       onMouseOut,
       onMouseOver,
@@ -52,6 +53,7 @@ export const DismissButton = forwardRef<DismissButtonRef, DismissButtonProps>(
       <ButtonBase
         tabIndex={tabIndex}
         titleText={titleText}
+        disabledTitleText={disabledTitleText}
         shape={ButtonShape.Square}
         color={color}
         className={SquareButtonClass}

--- a/src/Components/Button/Composed/LinkButton.tsx
+++ b/src/Components/Button/Composed/LinkButton.tsx
@@ -36,6 +36,7 @@ export interface LinkButtonProps
   target?: LinkTarget | string
   /** Describes the relationship between this document and the linked document */
   rel?: LinkRel
+  disabledTitleText?: string
 }
 
 export type LinkButtonRef = HTMLAnchorElement
@@ -60,6 +61,7 @@ export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
       color = ComponentColor.Default,
       status = ComponentStatus.Default,
       placeIconAfterText,
+      disabledTitleText,
     },
     ref
   ) => {
@@ -75,6 +77,11 @@ export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
       }
     )
 
+    const titleTextToBeUsed =
+      status == ComponentStatus.Disabled && disabledTitleText
+        ? disabledTitleText
+        : titleText
+
     return (
       <a
         id={id}
@@ -82,7 +89,7 @@ export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
         rel={rel}
         href={href}
         style={style}
-        title={titleText}
+        title={titleTextToBeUsed}
         color={color}
         target={target}
         tabIndex={tabIndex}

--- a/src/Components/Button/Composed/LinkButton.tsx
+++ b/src/Components/Button/Composed/LinkButton.tsx
@@ -78,7 +78,7 @@ export const LinkButton = forwardRef<LinkButtonRef, LinkButtonProps>(
     )
 
     const titleTextToBeUsed =
-      status == ComponentStatus.Disabled && disabledTitleText
+      status === ComponentStatus.Disabled && disabledTitleText
         ? disabledTitleText
         : titleText
 

--- a/src/Components/Button/Composed/SquareButton.tsx
+++ b/src/Components/Button/Composed/SquareButton.tsx
@@ -29,6 +29,7 @@ export const SquareButton = forwardRef<SquareButtonRef, SquareButtonProps>(
     {
       className,
       titleText,
+      disabledTitleText,
       tabIndex,
       onClick,
       style,
@@ -51,6 +52,7 @@ export const SquareButton = forwardRef<SquareButtonRef, SquareButtonProps>(
       <ButtonBase
         className={className}
         titleText={titleText}
+        disabledTitleText={disabledTitleText}
         ref={ref}
         tabIndex={!!tabIndex ? tabIndex : 0}
         onClick={onClick}

--- a/src/Components/Button/Documentation/Button.stories.tsx
+++ b/src/Components/Button/Documentation/Button.stories.tsx
@@ -80,6 +80,7 @@ buttonComposedStories.add(
             ]
           }
           titleText={text('titleText', 'Title Text')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Default')
@@ -147,6 +148,7 @@ buttonComposedStories.add(
           onClick={() => alert('clicked')}
           icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Zap')]}
           titleText={text('titleText', 'Title Text')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Default')
@@ -220,6 +222,7 @@ buttonComposedStories.add(
           onConfirm={value => alert(`returnValue: ${value}`)}
           returnValue={text('returnValue', '')}
           icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Trash')]}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           titleText={text('titleText', 'Title Text')}
           color={
             ComponentColor[
@@ -273,6 +276,7 @@ buttonComposedStories.add(
           <DismissButton
             ref={buttonRef}
             onClick={() => alert('Clicked!')}
+            disabledTitleText={text('disabledTitleText', 'Disabled Text')}
             color={
               ComponentColor[
                 select('color', mapEnumKeys(ComponentColor), 'Danger')
@@ -322,6 +326,7 @@ buttonComposedStories.add(
         <CTAButton
           ref={buttonRef}
           onClick={() => alert('Clicked!')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Secondary')
@@ -370,6 +375,7 @@ buttonBaseStories.add(
           ref={buttonRef}
           onClick={() => alert('clicked')}
           titleText={text('titleText', 'Title Text')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Default')
@@ -431,6 +437,7 @@ buttonComposedStories.add(
           icon={IconFont[select('icon', mapEnumKeys(IconFont), 'Zap')]}
           text={text('text', 'Yeehaw')}
           titleText={text('titleText', 'Title Text')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Default')
@@ -493,6 +500,7 @@ buttonComposedStories.add(
           }
           text={text('text', 'Yeehaw')}
           titleText={text('titleText', 'Title Text')}
+          disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           color={
             ComponentColor[
               select('color', mapEnumKeys(ComponentColor), 'Primary')
@@ -635,6 +643,7 @@ buttonComposedStories.add(
             onConfirm={value => alert(`returnValue: ${value}`)}
             icon={IconFont.Trash}
             titleText={text('titleText', 'Title Text')}
+            disabledTitleText={text('disabledTitleText', 'Disabled Text')}
             color={
               ComponentColor[
                 select('color', mapEnumKeys(ComponentColor), 'Default')

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -155,6 +155,7 @@ dropdownFamilyStories.add(
               ]
             }
             title={text('title', 'Hover Title Text')}
+            disabledTitleText={text('disabledTitleText', 'Disabled Text')}
           >
             {text('children (text)', 'I am a button!')}
           </Dropdown.Button>

--- a/src/Components/Dropdowns/DropdownButton.tsx
+++ b/src/Components/Dropdowns/DropdownButton.tsx
@@ -35,6 +35,7 @@ export interface DropdownButtonProps extends StandardFunctionProps {
   icon?: IconFont
   /** Text to be displayed on hover tooltip */
   title?: string
+  disabledTitleText?: string
 }
 
 export type DropdownButtonRef = ButtonBaseRef
@@ -51,6 +52,7 @@ export const DropdownButton = forwardRef<
       style,
       color = ComponentColor.Default,
       title,
+      disabledTitleText,
       active = false,
       testID = 'dropdown--button',
       status = ComponentStatus.Default,
@@ -88,6 +90,7 @@ export const DropdownButton = forwardRef<
         onClick={onClick}
         className={dropdownButtonClass}
         titleText={title}
+        disabledTitleText={disabledTitleText}
       >
         {!!icon && <Icon glyph={icon} className="cf-dropdown--icon" />}
         <span className="cf-dropdown--selected">{children}</span>


### PR DESCRIPTION
Closes #122 

### Changes
You can pass in an optional disabledTitleText as a prop to button and button-adjacent components. 

When a button component is in the status of 'disabled', it will show disabledTitleText instead of regular title text.
If there is no disabledTitleText defined, it will show regular title text
// Describe what you changed

### Screenshots
![disabledtitletext](https://user-images.githubusercontent.com/12561526/119578333-28e54400-bd71-11eb-8f0e-a1d0708fd1b2.gif)

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
