### PR TITLE
add spacing to input field so that last few chars don't get hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.9.0 (2021-6-01)
 - [#632](https://github.com/influxdata/clockface/pull/632): Add disabledText field to Button-based components
+- [#633](https://github.com/influxdata/clockface/pull/633): Add spacng to input so no characters are hidden
 
 
 ### 2.8.0 (2021-5-20)

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -156,6 +156,10 @@
     height: $height;
   }
 
+  .cf-input__indicator {
+    padding-right: $height;
+  }
+
   &.cf-input__has-icon .cf-input-field {
     padding-left: $height;
   }
@@ -208,22 +212,6 @@
     $cf-form-lg-padding,
     $cf-form-lg-height
   );
-}
-
-.cf-input__indicator-xs {
-  padding-right: $cf-form-xs-height !important;
-}
-
-.cf-input__indicator-sm {
-  padding-right: $cf-form-sm-height !important;
-}
-
-.cf-input__indicator-md {
-  padding-right: $cf-form-md-height !important;
-}
-
-.cf-input__indicator-lg {
-  padding-right: $cf-form-lg-height !important;
 }
 
 /*

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -210,6 +210,22 @@
   );
 }
 
+.cf-input__indicator-xs {
+  padding-right: $cf-form-xs-height !important;
+}
+
+.cf-input__indicator-sm {
+  padding-right: $cf-form-sm-height !important;
+}
+
+.cf-input__indicator-md {
+  padding-right: $cf-form-md-height !important;
+}
+
+.cf-input__indicator-lg {
+  padding-right: $cf-form-lg-height !important;
+}
+
 /*
   Error State
   ------------------------------------------------------------------------------

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -146,6 +146,11 @@ export const Input = forwardRef<InputRef, InputProps>(
       [`${className}`]: className,
     })
 
+    const inputFieldClass = classnames('cf-input-field', {
+      [`cf-input__indicator-${size}`]:
+        status === ComponentStatus.Default ? '' : size,
+    })
+
     const handleInputFocus = (e: ChangeEvent<HTMLInputElement>): void => {
       setFocus(true)
 
@@ -207,7 +212,7 @@ export const Input = forwardRef<InputRef, InputProps>(
           onKeyPress={onKeyPress}
           onKeyUp={onKeyUp}
           onKeyDown={onKeyDown}
-          className="cf-input-field"
+          className={inputFieldClass}
           disabled={status === ComponentStatus.Disabled}
           maxLength={maxLength}
           tabIndex={tabIndex}

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -147,8 +147,7 @@ export const Input = forwardRef<InputRef, InputProps>(
     })
 
     const inputFieldClass = classnames('cf-input-field', {
-      [`cf-input__indicator-${size}`]:
-        status === ComponentStatus.Default ? '' : size,
+      [`cf-input__indicator`]: status !== ComponentStatus.Default,
     })
 
     const handleInputFocus = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/src/Components/Inputs/StatusIndicator.scss
+++ b/src/Components/Inputs/StatusIndicator.scss
@@ -27,7 +27,10 @@
   right: $cf-border;
   bottom: $cf-border;
   border-radius: 0 $cf-radius-sm $cf-radius-sm 0;
-  @include gradient-h(rgba($cf-input-background--default, 0), $cf-input-background--default);
+  @include gradient-h(
+    rgba($cf-input-background--default, 0),
+    $cf-input-background--default
+  );
   transition: opacity 0.25s ease;
   border-right-color: $cf-input-background--default;
   border-right-style: solid;
@@ -73,8 +76,8 @@
   font-size: $fontSize;
 
   .cf-status-indicator--shadow {
-    width: ($dimensions - $cf-border) + $dimensions * 0.6;
-    border-right-width: $dimensions * 0.6;
+    width: ($dimensions - $cf-border) + $dimensions * 0.3;
+    border-right-width: $dimensions * 0.3;
   }
 }
 


### PR DESCRIPTION
Closes #631 

### Changes

With Inputs, when status is not default, we add padding to the right equal to the size of the status indicator (the error symbol, valid symbol .. etc). This way no part of the last few characters will be hidden. I also reduced the range of the shadow effect of the status indicator so that the shadow doesn't cover the characters either.


// Describe what you changed

### Screenshots
![inputFix](https://user-images.githubusercontent.com/12561526/119753613-e6486800-be53-11eb-8511-7eb025674873.gif)

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
