### PR TITLE
fix: allow currentPage to be set externally

### DIFF
--- a/src/Components/PaginationNav/PaginationNav.tsx
+++ b/src/Components/PaginationNav/PaginationNav.tsx
@@ -149,23 +149,23 @@ export const Pagination = forwardRef<PaginationNavRef, PaginationNavProps>(
     }, [totalPages, pageRangeOffset, size, hideDirectionIcon])
 
     useEffect(() => {
-      setActivePage(activePage)
-      if (activePage > breakpoints.secondBreakpoint) {
+      setActivePage(currentPage)
+      if (currentPage > breakpoints.secondBreakpoint) {
         setBreakpoints(
           computePageSpread(
-            activePage,
+            currentPage,
             resizeBasedOnParentSize(size, pageRangeOffset)
           )
         )
-      } else if (activePage < breakpoints.firstBreakpoint) {
+      } else if (currentPage < breakpoints.firstBreakpoint) {
         setBreakpoints(
           computePageSpread(
-            activePage,
+            currentPage,
             resizeBasedOnParentSize(size, pageRangeOffset)
           )
         )
       }
-    }, [activePage])
+    }, [currentPage])
 
     const checkActive = (page: number) => {
       return activePage === page ? true : false


### PR DESCRIPTION
Related: https://github.com/influxdata/ui/issues/1548

### Changes

Changed the `useEffect` to watch for changes to `currentPage` prop instead of `activePage` from state. This allows for an external component to change `currentPage` and the pagination component will set the active page correctly. Previously the active page would not change.

### Screenshots


https://user-images.githubusercontent.com/6411855/120870201-2ba02000-c54d-11eb-9d83-8a914f158d1e.mov



### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
