### PR TITLE
fix: changed to correct classname

### DIFF
--- a/src/Components/IndexList/IndexListHeaderCell.tsx
+++ b/src/Components/IndexList/IndexListHeaderCell.tsx
@@ -85,7 +85,7 @@ const SortIndicator: FunctionComponent<{sortable: boolean}> = ({sortable}) => {
   if (sortable) {
     return (
       <span className="cf-index-list--sort-arrow">
-        <span className="icon caret-down" />
+        <span className="cf-icon caret-down" />
       </span>
     )
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2086

ClassName for IndexList header for the arrow indicating sort direction was incorrect. Was originally `icon caret-down`, but is supposed to `cf-icon caret-down`. See `IndexList.scss` line 181.

## Before
![Screen Shot 2021-07-20 at 3 55 54 PM](https://user-images.githubusercontent.com/146112/126405554-61ee9763-e292-47e1-b5f8-17e671235503.png)



## After 
<img width="806" alt="Screen Shot 2021-07-20 at 6 43 53 PM" src="https://user-images.githubusercontent.com/39343323/126404750-e3741e2d-db40-48f4-abe0-c827e922761b.png">
