### PR TITLE
chore: raising z-index of overlays so they are on top of everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -92,7 +92,7 @@ $c-pulsar: #513cc6;
 $cf-z--nav-toggle: 9999;
 $cf-z--draggable-resizer-mask: 9950;
 $cf-z--notifications: 9900;
-$cf-z--portal: 9200;
+$cf-z--portal: 12000;
 $cf-z--nav-menu: 9100;
 $cf-z--nav-mask: 9000;
 $cf-z--tabs-dropdown: 8000;


### PR DESCRIPTION
changed z-index of overlays from 9200 to 12000; so it will be on top of everything 
(including tooltips from giraffe, which are at 9999)

also bumping the version number.

very minor, small surgical change