### PR TITLE
fix: make paginationTruncationItem.tsx component status disabled

### DIFF
--- a/src/Components/PaginationNav/paginationTruncationItem.tsx
+++ b/src/Components/PaginationNav/paginationTruncationItem.tsx
@@ -8,10 +8,11 @@ import './Pagination.scss'
 
 // Types
 import {
-  StandardFunctionProps,
+  ButtonShape,
   ComponentColor,
   ComponentSize,
-  ButtonShape,
+  ComponentStatus,
+  StandardFunctionProps,
 } from '../../Types'
 
 export interface PaginationTruncationItemProps extends StandardFunctionProps {
@@ -53,6 +54,7 @@ export const PaginationTruncationItem = forwardRef<
           onClick={onClick}
           shape={ButtonShape.Square}
           text={'...'}
+          status={ComponentStatus.Disabled}
         ></Button>
       </li>
     )

--- a/src/Components/PaginationNav/paginationTruncationItem.tsx
+++ b/src/Components/PaginationNav/paginationTruncationItem.tsx
@@ -55,7 +55,8 @@ export const PaginationTruncationItem = forwardRef<
           shape={ButtonShape.Square}
           text={'...'}
           status={ComponentStatus.Disabled}
-        ></Button>
+          style={{background: 'transparent'}}
+        />
       </li>
     )
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2036

### Changes

I added the `status = ComponentStatus.disabled` so that the ellipses can not be clicked. 

### Screenshots

<img width="441" alt="Screen Shot 2021-09-13 at 9 12 09 AM" src="https://user-images.githubusercontent.com/18511823/133119435-a653315b-007d-4c06-bed1-6a4f8e474ceb.png">


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
