### PR TITLE
feat: make accordion be aware of having no body and apply style chang…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+### 2.11.9 (2021-09-23)
+
+- [#672](https://github.com/influxdata/clockface/pull/672): accordion can have no icon, when there is no body, there is no icon and no interactive styling
+
 ### 2.11.8 (2021-9-08)
 
 - [#668](https://github.com/influxdata/clockface/pull/668): regenerate icon fonts

--- a/src/Components/Accordion/Accordion.scss
+++ b/src/Components/Accordion/Accordion.scss
@@ -49,6 +49,9 @@
   align-items: center;
   outline: none;
   padding: $cf-form-md-padding;
+}
+
+.cf-accordion--header--clickable {
   cursor: pointer;
   &:hover,
   &:focus {

--- a/src/Components/Accordion/Accordion.tsx
+++ b/src/Components/Accordion/Accordion.tsx
@@ -7,12 +7,11 @@ import './Accordion.scss'
 import {Direction, StandardFunctionProps} from '../../Types'
 
 export interface AccordionProps extends StandardFunctionProps {
-  /** Determines whether the expand Icon is at the left or right */
+  /** Determines whether the expand Icon is at the left, right or doesn't exist. If there is no accordionBody, no icons are shown*/
   iconPlacement?: Direction
   /** Determines whether the accordion is expanded by default or not */
   expanded?: boolean
   /** Prevents any interaction with this element, including the onClick function */
-
   disabled?: boolean
   /** Function to be called when the accordion is expanded or collapsed */
   onChange?: () => void
@@ -25,6 +24,7 @@ export const AccordionContext = React.createContext<
       iconPlacementPosition: Direction
       isDisabled: boolean
       onChange: () => void
+      hasBody: boolean
     }
   | undefined
 >(undefined)
@@ -93,6 +93,7 @@ export const AccordionRoot = forwardRef<AccordionRef, AccordionProps>(
     )
 
     const [header, ...body] = React.Children.toArray(children)
+    const hasBody = body.length ? true : false
 
     /* eslint-disable */
     const onChangeFunction = () => {
@@ -102,13 +103,13 @@ export const AccordionRoot = forwardRef<AccordionRef, AccordionProps>(
         return
       }
     }
-
     const contextState = {
       isExpanded,
       setExpanded,
-      iconPlacementPosition,
+      iconPlacementPosition: hasBody ? iconPlacementPosition : Direction.None,
       isDisabled,
       onChange: onChangeFunction,
+      hasBody: hasBody,
     }
 
     return (

--- a/src/Components/Accordion/AccordionHeader.tsx
+++ b/src/Components/Accordion/AccordionHeader.tsx
@@ -29,6 +29,7 @@ export const AccordionHeader = forwardRef<
     [`cf-accordion--header--active`]: context.isExpanded,
     [`${className}`]: className,
     [`cf-accordion--header--disabled`]: context.isDisabled,
+    [`cf-accordion--header--clickable`]: context.hasBody && !context.isDisabled,
   })
 
   const handleKeyUp = (e: KeyboardEvent<HTMLDivElement>): void => {

--- a/src/Components/Accordion/AccordionHeader.tsx
+++ b/src/Components/Accordion/AccordionHeader.tsx
@@ -26,7 +26,7 @@ export const AccordionHeader = forwardRef<
   })
 
   const AccordionHeaderClassName = classnames(`cf-accordion--header`, {
-    [`cf-accordion--header--active`]: context.isExpanded,
+    [`cf-accordion--header--active`]: context.isExpanded && context.hasBody,
     [`${className}`]: className,
     [`cf-accordion--header--disabled`]: context.isDisabled,
     [`cf-accordion--header--clickable`]: context.hasBody && !context.isDisabled,

--- a/src/Components/Accordion/Documentation/Accordion.stories.tsx
+++ b/src/Components/Accordion/Documentation/Accordion.stories.tsx
@@ -21,10 +21,12 @@ import {
   Direction,
   InputToggleType,
   JustifyContent,
+  HeadingElement,
 } from '../../../Types'
 import {FlexBox} from '../../FlexBox'
 import {AccordionBodyItem} from '../AccordionBodyItem'
 import {mapEnumKeys} from '../../../Utils/storybook'
+import {Heading} from '../../Typography'
 
 const accordionStories = storiesOf(
   'Components|Accordion/Examples',
@@ -454,7 +456,12 @@ accordionFamilyStories.add(
           style={object('style', {})}
         >
           <Accordion.AccordionHeader>
-            <span>Cheese Ipsum</span>
+            <Heading
+              element={HeadingElement.H6}
+              appearance={HeadingElement.Div}
+            >
+              Cheese Ipsum
+            </Heading>
           </Accordion.AccordionHeader>
           <Accordion.AccordionBodyItem>
             <span>
@@ -469,6 +476,17 @@ accordionFamilyStories.add(
             </span>
           </Accordion.AccordionBodyItem>
         </Accordion>
+        <Accordion disabled={disabled}>
+          <Accordion.AccordionHeader>
+            <Heading
+              element={HeadingElement.H6}
+              appearance={HeadingElement.Div}
+            >
+              Accordion with No Body Item
+            </Heading>
+          </Accordion.AccordionHeader>
+        </Accordion>
+
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>
         </div>

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -162,6 +162,7 @@ export enum DropdownItemType {
 export enum Direction {
   Left = 'left',
   Right = 'right',
+  None = 'none',
 }
 
 export enum ButtonShape {


### PR DESCRIPTION

Closes #670 


If IconPlacement = None, no icon is shown.

If there is no accordion body, accordion does not get hover state, does not get icon .. etc so that it is clear that it is not interactive. 

https://user-images.githubusercontent.com/12561526/134421873-cb337b71-2581-45ae-ab75-b2ea34435866.mp4



### Changes

// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
