### PR TITLE
fix: try just woff2

### DIFF
--- a/src/Styles/icon.scss
+++ b/src/Styles/icon.scss
@@ -7,9 +7,9 @@
 
 @font-face {
   font-family: 'icomoon';
-  src: url('./Fonts/icomoon.woff2') format('woff2');
-  font-weight: normal;
   font-style: normal;
+  font-weight: normal;
+  src: url('./Fonts/icomoon.woff2') format('woff2');
 }
 
 .cf-icon {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2629

Let's make icomoon look like Rubik and IBMPlexMono because those two don't throw errors.

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
