### PR TITLE
chore: clean up css around clearable text field

### DIFF
--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -104,56 +104,57 @@
 /** default size is small, there are
 alternate css for the other sizes */
 .cf-input-clear-btn {
-  right: 4px;
-  top: 4px;
-  background: inherit;
-  border: none;
-  transform: translateX(-100%) !important;
-
   &.cf-dismiss-button {
-    top: 4px;
-    right: -17px;
+    background: inherit;
+    border: none;
     transform: none;
+    opacity: 0.7;
+
+    &:after {
+      content: none;
+    }
+
+    &:hover,
+    &:focus,
+    &:active,
+    &:active:hover,
+    &:visited,
+    &:disabled,
+    &:disabled:hover {
+      background: transparent;
+      border: none;
+      box-shadow: none;
+    }
+
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
   }
 
   &.xsmall {
-    width: 16px;
-    height: 16px;
-    right: -12px;
-    top: 3px;
-
     & .cf-dismiss-button--x {
       &:before,
       &:after {
-        width: 9px;
+        width: floor($cf-form-xs-font);
       }
     }
   }
 
   &.medium {
-    width: 25px;
-    height: 25px;
-    right: -18px;
-    top: 6px;
-
     & .cf-dismiss-button--x {
       &:before,
       &:after {
-        width: 16px;
+        width: floor($cf-form-md-font * 1.2);
       }
     }
   }
 
   &.large {
-    width: 32px;
-    height: 32px;
-    right: -25px;
-    top: 6px;
-
     & .cf-dismiss-button--x {
       &:before,
       &:after {
-        width: 20px;
+        width: floor($cf-form-lg-font * 1.2);
       }
     }
   }

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -20,6 +20,7 @@ import './Input.scss'
 // Types
 import {
   AutoComplete,
+  ComponentColor,
   ComponentSize,
   ComponentStatus,
   IconFont,
@@ -186,13 +187,13 @@ export const Input = forwardRef<InputRef, InputProps>(
       xsmall: size === ComponentSize.ExtraSmall,
     })
 
-    console.log('hello there')
-
     const clearElement = onClear && value && (
       <DismissButton
         onClick={onClear}
         className={clearClasses}
         titleText="clear this text field"
+        color={ComponentColor.Tertiary}
+        size={size}
       />
     )
 


### PR DESCRIPTION
Closes #

### Changes

// Describe what you changed

Cleaned up hardcode into design tokens.

Changed up color

fixed icon sizing.



We should refactor this to use squareButton like the visibilityInput does when we have clockface 3.0. Currently, it is not going to work because the IconFont.Remove is not centered but once with the new iconset from clockface 3.0 we should be able to reduce the bulk of the css by simply swapping the dismissButton with the squareButton.  



### Screenshots

// Add screenshots here if relevant

Default State Medium 
![Screen Shot 2021-10-13 at 11 35 04 PM](https://user-images.githubusercontent.com/12561526/137246796-c200fcd9-1171-4b7e-81d8-55825899d0c5.png)

Hover State Medium
![Screen Shot 2021-10-13 at 11 35 07 PM](https://user-images.githubusercontent.com/12561526/137246793-f5f53a64-ee72-40a9-92dc-f92738d12771.png)

Default State Large
![Screen Shot 2021-10-13 at 11 46 46 PM](https://user-images.githubusercontent.com/12561526/137248058-30f8877a-4261-4472-bac4-44f690b067e1.png)


Hover State Large
![Screen Shot 2021-10-13 at 11 46 49 PM](https://user-images.githubusercontent.com/12561526/137248053-5476a07a-4dd3-4443-8830-560cdba8ffa5.png)

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
