### PR TITLE
fix: hide submenu when submenu item clicked

### DIFF
--- a/src/Components/TreeNav/TreeNavSubMenu.tsx
+++ b/src/Components/TreeNav/TreeNavSubMenu.tsx
@@ -31,7 +31,7 @@ export const TreeNavSubMenu = forwardRef<
       {triggerRef && (
         <Popover
           enableDefaultStyles={true}
-          contents={() => <div>{children}</div>}
+          contents={onHide => <div onClick={onHide}>{children}</div>}
           triggerRef={triggerRef}
           position={PopoverPosition.ToTheRightTop}
           className="cf-popover__nav"


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3027

### Changes

Trigger the `onHide` upon clicking items in the TreeNavSubMenu

### Screenshots

https://user-images.githubusercontent.com/18511823/138395554-2ca1be74-bde7-4961-b2f7-b95a7cb56c46.mov


### Checklist

Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
