### PR TITLE
fix: change to onhover rather than on click

### DIFF
--- a/src/Components/TreeNav/TreeNavSubMenu.tsx
+++ b/src/Components/TreeNav/TreeNavSubMenu.tsx
@@ -3,7 +3,11 @@ import React, {forwardRef, useRef} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {PopoverPosition, StandardFunctionProps} from '../../Types'
+import {
+  PopoverInteraction,
+  PopoverPosition,
+  StandardFunctionProps,
+} from '../../Types'
 import {Popover} from '../Popover'
 
 export type TreeNavSubMenuProps = StandardFunctionProps
@@ -32,6 +36,8 @@ export const TreeNavSubMenu = forwardRef<
         <Popover
           enableDefaultStyles={true}
           contents={onHide => <div onClick={onHide}>{children}</div>}
+          hideEvent={PopoverInteraction.Hover}
+          showEvent={PopoverInteraction.Hover}
           triggerRef={triggerRef}
           position={PopoverPosition.ToTheRightTop}
           className="cf-popover__nav"


### PR DESCRIPTION
Closes #688 

### Changes

// Describe what you changed

When collapsed, the nav item used to trigger on click; now it triggers on hover for better discoverability

### Screenshots

// Add screenshots here if relevant

https://user-images.githubusercontent.com/12561526/139694688-f98bd831-8b35-45c3-8c5a-4459389e6ea0.mp4


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
