### PR TITLE
fix: PaginationItem button width should respect the content so it fits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/PaginationNav/PaginationItem.tsx
+++ b/src/Components/PaginationNav/PaginationItem.tsx
@@ -13,7 +13,6 @@ import {
   StandardFunctionProps,
   ComponentColor,
   ComponentSize,
-  ButtonShape,
 } from '../../Types'
 
 export interface PaginationItemProps extends StandardFunctionProps {
@@ -37,7 +36,7 @@ export const PaginationItem = forwardRef<
       page,
       isActive,
       onClick,
-      size = ComponentSize.Medium,
+      size = ComponentSize.Small,
     },
     ref
   ) => {
@@ -62,9 +61,8 @@ export const PaginationItem = forwardRef<
           color={ComponentColor.Tertiary}
           onClick={onClick}
           active={isActive}
-          shape={ButtonShape.Square}
           text={page}
-        ></Button>
+        />
       </li>
     )
   }

--- a/src/Components/PaginationNav/PaginationItem.tsx
+++ b/src/Components/PaginationNav/PaginationItem.tsx
@@ -9,11 +9,7 @@ import {Button} from '../Button/Composed/Button'
 import './Pagination.scss'
 
 // Types
-import {
-  StandardFunctionProps,
-  ComponentColor,
-  ComponentSize,
-} from '../../Types'
+import {StandardFunctionProps, ComponentColor, ComponentSize} from '../../Types'
 
 export interface PaginationItemProps extends StandardFunctionProps {
   page?: string


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/12181

### Changes

The button that makes up the PaginationItem needs to accommodate the content and be of the right width. 

### Screenshots



<img width="532" alt="Capture d’écran, le 2021-11-03 à 11 03 55 AM" src="https://user-images.githubusercontent.com/18511823/140167283-8ea8e2d3-67e8-4f58-b5a3-366a58160a68.png">


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
