### PR TITLE
feat: scrollbar size prop for Page component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Page/PageContents.tsx
+++ b/src/Components/Page/PageContents.tsx
@@ -13,6 +13,8 @@ export interface PageContentsProps extends StandardFunctionProps {
   fullWidth?: boolean
   /** Allows contents to scroll on overflow */
   scrollable?: boolean
+  /** Scrollbar size */
+  scrollbarSize?: ComponentSize
   /** If scrollable is true, this toggles whether the scrollbar is always visible */
   autoHideScrollbar?: boolean
   /** Controls the gutters (left and right margins) */
@@ -33,6 +35,7 @@ export const PageContents = forwardRef<PageContentsRef, PageContentsProps>(
       testID = 'page-contents',
       autoHideScrollbar = false,
       gutters = ComponentSize.Medium,
+      scrollbarSize = ComponentSize.Small,
     },
     ref
   ) => {
@@ -60,6 +63,7 @@ export const PageContents = forwardRef<PageContentsRef, PageContentsProps>(
           testID={testID}
           autoHide={autoHideScrollbar}
           className={pageContentsClass}
+          size={scrollbarSize}
         >
           {kids}
         </DapperScrollbars>


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3078

### Changes

Just exposes the props of the `DapperScrollBar` to the `Page` component.

// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
