### PR TITLE
feat: add display remaining feat for ProgressBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 3.1.2 (2021-11-05)
 
-- [700](https://github.com/influxdata/clockface/pull/700): Added displayRemaining boolean flag which allows you to view remaining value instead of used value.
+- [700](https://github.com/influxdata/clockface/pull/700): Added optional texts for `value` and `max` fields.
 
 ### 3.1.1 (2021-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 3.1.2 (2021-11-05)
+
+- [700](https://github.com/influxdata/clockface/pull/700): Added displayRemaining boolean flag which allows you to view remaining value instead of used value.
+
+
 ### 3.1.1 (2021-11-03)
 
 - [#694](https://github.com/influxdata/clockface/pull/694): changed list divider color and added more spacing for clearer hierarchy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@
 
 - [700](https://github.com/influxdata/clockface/pull/700): Added displayRemaining boolean flag which allows you to view remaining value instead of used value.
 
-
 ### 3.1.1 (2021-11-03)
 
 - [#694](https://github.com/influxdata/clockface/pull/694): changed list divider color and added more spacing for clearer hierarchy.
-- [#689](https://github.com/influxdata/clockface/pull/689): navbar items when collapsed activate onhover instead of onclick.  
-
+- [#689](https://github.com/influxdata/clockface/pull/689): navbar items when collapsed activate onhover instead of onclick.
 
 ### 3.1.0 (2021-11-03)
 

--- a/src/Components/ProgressBar/ProgressBar.scss
+++ b/src/Components/ProgressBar/ProgressBar.scss
@@ -29,3 +29,7 @@
   justify-content: space-between;
   font-size: $cf-text-base-0;
 }
+
+.cf-progress-bar-values--label {
+  font-size: $cf-text-tiny;
+}

--- a/src/Components/ProgressBar/ProgressBar.scss
+++ b/src/Components/ProgressBar/ProgressBar.scss
@@ -10,7 +10,7 @@
   height: 12px;
   box-sizing: border-box;
   padding: $cf-space-3xs 0;
-  background-color: $g0-obsidian;
+  background-color: $cf-grey-5;
   display: inline-flex;
   position: relative;
 }
@@ -19,6 +19,7 @@
   border-radius: 100px;
   height: 100%;
   position: relative;
+  margin-left: $cf-space-3xs;
 }
 
 .cf-progress-bar--text {

--- a/src/Components/ProgressBar/ProgressBar.scss
+++ b/src/Components/ProgressBar/ProgressBar.scss
@@ -30,7 +30,3 @@
   justify-content: space-between;
   font-size: $cf-text-base-0;
 }
-
-.cf-progress-bar-values--label {
-  font-size: $cf-text-tiny;
-}

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -27,6 +27,8 @@ export interface ProgressBarProps extends StandardFunctionProps {
   size?: ComponentSize
   /** Descriptive text for what is being valueed */
   label?: string
+  /** Displays remaining value instead of specified value */
+  displayRemaining?: boolean
 }
 
 export type ProgressBarRef = HTMLDivElement
@@ -43,6 +45,7 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
       className,
       color = InfluxColors.White,
       barGradient,
+      displayRemaining,
     },
     ref
   ) => {
@@ -71,7 +74,7 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
           <div className="cf-progress-bar--label">{label}</div>
           <div>
             <span className="cf-progress-bar--value" style={{color: color}}>
-              {value}
+              {displayRemaining ? max - value : value}
             </span>
             <span className="cf-progress-bar--max">/{max}</span>
           </div>

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -27,12 +27,10 @@ export interface ProgressBarProps extends StandardFunctionProps {
   size?: ComponentSize
   /** Descriptive text for what is being valueed */
   label?: string
-  /** Displays remaining value instead of specified value */
-  displayRemaining?: boolean
-  /** Prefix text for the values passed to be displayed */
-  valuesLabelPrefix?: string
-  /** Suffix text for the values passed to be displayed */
-  valuesLabelSuffix?: string
+  /** Optional Text for value */
+  valueText?: string
+  /** Optional Text for max */
+  maxText?: string
 }
 
 export type ProgressBarRef = HTMLDivElement
@@ -49,9 +47,8 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
       className,
       color = InfluxColors.White,
       barGradient,
-      displayRemaining,
-      valuesLabelPrefix,
-      valuesLabelSuffix,
+      valueText,
+      maxText,
     },
     ref
   ) => {
@@ -79,18 +76,10 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
         <div className="cf-progress-bar--text">
           <div className="cf-progress-bar--label">{label}</div>
           <div>
-            {!!valuesLabelPrefix && (
-              <span style={{color: color}}>{valuesLabelPrefix}</span>
-            )}
             <span className="cf-progress-bar--value" style={{color: color}}>
-              {displayRemaining ? max - value : value}
+              {valueText ?? value}
             </span>
-            <span className="cf-progress-bar--max">/{max}</span>
-            {!!valuesLabelSuffix && (
-              <span className="cf-progress-bar-values--label">
-                &nbsp;{valuesLabelSuffix}
-              </span>
-            )}
+            <span className="cf-progress-bar--max">/{maxText ?? max}</span>
           </div>
         </div>
       </div>

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -25,10 +25,16 @@ export interface ProgressBarProps extends StandardFunctionProps {
   max?: number
   /** Controls the size of the bar & text */
   size?: ComponentSize
+  /** Controls the size of the value text */
+  valueSize?: ComponentSize
   /** Descriptive text for what is being valueed */
   label?: string
   /** Displays remaining value instead of specified value */
   displayRemaining?: boolean
+  /** Prefix text for the values passed to be displayed */
+  valuesLabelPrefix?: string
+  /** Suffix text for the values passed to be displayed */
+  valuesLabelSuffix?: string
 }
 
 export type ProgressBarRef = HTMLDivElement
@@ -46,6 +52,8 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
       color = InfluxColors.White,
       barGradient,
       displayRemaining,
+      valuesLabelPrefix,
+      valuesLabelSuffix,
     },
     ref
   ) => {
@@ -73,10 +81,18 @@ export const ProgressBar = forwardRef<ProgressBarRef, ProgressBarProps>(
         <div className="cf-progress-bar--text">
           <div className="cf-progress-bar--label">{label}</div>
           <div>
+            {!!valuesLabelPrefix && (
+              <span style={{color: color}}>{valuesLabelPrefix}</span>
+            )}
             <span className="cf-progress-bar--value" style={{color: color}}>
               {displayRemaining ? max - value : value}
             </span>
             <span className="cf-progress-bar--max">/{max}</span>
+            {!!valuesLabelSuffix && (
+              <span className="cf-progress-bar-values--label">
+                &nbsp;{valuesLabelSuffix}
+              </span>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #

### Changes

Added `displayRemaining` boolean flag which allows you to view remaining value instead of used value.
Also add prefix and suffix to value/max labels.

### Screenshots
If `displayRemaining` boolean value is passed as `true` then following is the affect on the ProgressBar. Also added prefix and suffix to value/max labels.

BEFORE
![image](https://user-images.githubusercontent.com/1637395/140569115-f4fcd097-b7b9-4e38-9fa2-4f17bdbb9dd3.png)


AFTER
![image](https://user-images.githubusercontent.com/1637395/140576895-b73bc1d2-2eb9-47e2-9cc9-e0b584b483bb.png)



### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
