### PR TITLE
chore: make package.json version number match release number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
a fix was released last night that didn't bump the version in package.json. This makes sure they stay in sync.