### PR TITLE
chore: added resolution to force version 9.0.6 and greater of immer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.1.9 (2021-12-08)
+- [708](https://github.com/influxdata/clockface/pull/708): Force version 9.0.6+ of immer
+
 ### 3.1.8 (2021-12-02)
 - [707](https://github.com/influxdata/clockface/pull/707): Fixed sass / dart warning about division
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",
@@ -107,5 +107,8 @@
     "fix": "eslint --fix 'src/**/*.{ts,tsx}'; prettier --config .prettierrc.json --check 'src/**/*.{ts,tsx}'",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "publishStorybook": "storybook-to-ghpages --out=.out"
+  },
+  "resolutions": {
+    "immer": "^9.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8020,10 +8020,10 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@8.0.1, immer@^9.0.6:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.7.tgz#b6156bd7db55db7abc73fd2fdadf4e579a701075"
+  integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
### Changes

Adds a [yarn resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) for immer. 

### Checklist

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
