### PR TITLE
chore: fix erroneous changelog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 3.1.9 (2021-12-08)
+### 3.1.10 (2021-12-08)
 - [709](https://github.com/influxdata/clockface/pull/709): Dependency upgrades
 
 ### 3.1.9 (2021-12-08)


### PR DESCRIPTION
### Changes

On the previous PR, I didn't update the changelog's version number. Oops, this fixes that.

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
