### PR TITLE
fix: resource card editable name pencil css fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.scss
@@ -19,8 +19,8 @@
   position: relative;
   display: flex;
   flex-wrap: nowrap;
-  align-items: center;
-  max-width: calc(100% - 100px);
+  justify-content: flex-start;
+  max-width: calc(100% - 130px);
 }
 
 /* Ensure placeholder text matches font weight of title */

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -158,7 +158,7 @@ export const ResourceCardEditableName = forwardRef<
             onClick={handleClick}
             data-testid={testID}
           >
-            <span>{name || noNameString}</span>
+            {name || noNameString}
           </span>
         </SpinnerContainer>
         <div

--- a/src/Components/ResourceList/Card/ResourceCardName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardName.scss
@@ -13,10 +13,12 @@
 }
 
 .cf-resource-name--text {
+  display: flex;
+  align-items: center;
+
   font-size: $cf-card--name-font-size;
   font-weight: $cf-card--name-font-weight;
   font-family: $cf-text-font;
-  display: inline-block;
   color: $g17-whisper;
   user-select: none;
 }


### PR DESCRIPTION
Part of https://github.com/influxdata/clockface/issues/702

### Changes

Changes the CSS so that the icon is always aligned with the **first line** of the name.

### Screenshots

<img width="618" alt="Screen Shot 2022-01-10 at 3 54 18 PM" src="https://user-images.githubusercontent.com/18511823/148851688-909822b2-7fc2-43be-a108-dacec21a805e.png">

<img width="456" alt="Screen Shot 2022-01-10 at 3 54 08 PM" src="https://user-images.githubusercontent.com/18511823/148851700-988ad36c-86b5-492f-87d7-3227b000a433.png">


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
