### PR TITLE
fix: fix scrollto positioning issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.10",
+  "version": "3.1.12",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/List/List.tsx
+++ b/src/Components/List/List.tsx
@@ -168,16 +168,30 @@ const calculateSelectedPosition = (
     return 0
   }
 
-  const itemHeight = 24
+  const heights = {
+    xs: 28,
+    sm: 36,
+    md: 48,
+    lg: 56,
+  }
+
   const items = React.Children.map(children, child =>
     _.get(child, 'props.selected', false)
   )
+
+  const sizes = React.Children.map(children, child =>
+    _.get(child, 'props.size', 'xs')
+  ) as string[]
 
   if (!items) {
     return 0
   }
 
   const itemIndex = items.findIndex(item => item === true)
+
+  const DEFAULT_ITEM_HEIGHT = 28
+  const itemHeight =
+    itemIndex >= 0 ? heights[sizes[itemIndex]] : DEFAULT_ITEM_HEIGHT
 
   return itemHeight * itemIndex
 }

--- a/src/Components/List/List.tsx
+++ b/src/Components/List/List.tsx
@@ -160,19 +160,24 @@ export const ListRoot = forwardRef<ListRef, ListProps>(
 
 ListRoot.displayName = 'List'
 
+const EXTRASMALL_LIST_ITEM_HEIGHT = 28
+const SMALL_LIST_ITEM_HEIGHT = 36
+const MEDIUM_LIST_ITEM_HEIGHT = 48
+const LARGE_LIST_ITEM_HEIGHT = 56
+
+const LIST_ITEM_HEIGHTS_MAP = {
+  xs: EXTRASMALL_LIST_ITEM_HEIGHT,
+  sm: SMALL_LIST_ITEM_HEIGHT,
+  md: MEDIUM_LIST_ITEM_HEIGHT,
+  lg: LARGE_LIST_ITEM_HEIGHT,
+}
+
 const calculateSelectedPosition = (
   scrollToSelected: boolean,
   children: ReactNode
 ): number => {
   if (!children || !scrollToSelected) {
     return 0
-  }
-
-  const heights = {
-    xs: 28,
-    sm: 36,
-    md: 48,
-    lg: 56,
   }
 
   const items = React.Children.map(children, child =>
@@ -188,10 +193,12 @@ const calculateSelectedPosition = (
   }
 
   const itemIndex = items.findIndex(item => item === true)
-
   const DEFAULT_ITEM_HEIGHT = 28
+
   const itemHeight =
-    itemIndex >= 0 ? heights[sizes[itemIndex]] : DEFAULT_ITEM_HEIGHT
+    itemIndex >= 0
+      ? LIST_ITEM_HEIGHTS_MAP[sizes[itemIndex]]
+      : DEFAULT_ITEM_HEIGHT
 
   return itemHeight * itemIndex
 }


### PR DESCRIPTION
## Issue
As the height of a list item was hard-coded to `24px`, the calculation of `scrollTo` position became out of sync for `xs` because of the extra headers in the list as well as the mismatch of the height of the actual item. I think a good solution would be to use refs for list items but we'd have to take performance into consideration.

For other sizes, the height was still `24` which was absolutely inaccurate and I measured all the sizes and made a map for each of the respective sizes and now the out of sync issue is still there but is very minimal.

## BEFORE
![BEFORE](https://user-images.githubusercontent.com/1637395/149566541-f219c848-f4f9-4870-8cea-f2dc59c6d6a8.gif)


## AFTER
![AFTER](https://user-images.githubusercontent.com/1637395/149566559-d5091d5d-16ad-402d-946e-3b05b444540b.gif)

