### PR TITLE
fix: color picker input invalidate more than one '#'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Utils/Tests/hexCodeValidation.test.ts
+++ b/src/Utils/Tests/hexCodeValidation.test.ts
@@ -4,7 +4,7 @@ describe('the validateHexCode function', () => {
   it('returns null when valid', () => {
     expect(validateHexCode('#DEAD0D')).toBeNull()
     expect(validateHexCode('#1337AD')).toBeNull()
-    expect(validateHexCode('#BG62CF')).toBeNull()
+    expect(validateHexCode('#BA62CF')).toBeNull()
   })
 
   it('does not allow empty strings', () => {

--- a/src/Utils/hexCodeValidation.ts
+++ b/src/Utils/hexCodeValidation.ts
@@ -5,6 +5,8 @@ export const VALID_HEX_LENGTH = 7
 export const validateHexCode: ValidationFunction = (
   color: string
 ): string | null => {
+  console.log('color')
+
   // Cannot be blank
   if (!color || !color.length) {
     return 'Please enter a hexcode'
@@ -28,13 +30,19 @@ export const validateHexCode: ValidationFunction = (
   }
 
   // Cannot contain invalid characters
-  const invalidChars = color.replace(/[abcdefgABCDEFG#0123456789]/g, '')
+  const invalidChars = color.replace(/[abcdefABCDEF#0123456789]/g, '')
   if (invalidChars.length) {
     return 'Invalid hexcode'
+  }
+
+  // Can not have more than one # symbol
+  const numberOfHashes = (color.match(/#/g) || []).length
+  if (numberOfHashes > 1) {
+    return 'Can not contain more than one #'
   }
 
   // Valid hexcode exists
   return null
 }
 
-export const invalidHexCharacters = /[^abcdefgABCDEFG#0123456789]/g
+export const invalidHexCharacters = /[^abcdefABCDEF#0123456789]/g

--- a/src/Utils/hexCodeValidation.ts
+++ b/src/Utils/hexCodeValidation.ts
@@ -5,7 +5,6 @@ export const VALID_HEX_LENGTH = 7
 export const validateHexCode: ValidationFunction = (
   color: string
 ): string | null => {
-
   // Cannot be blank
   if (!color || !color.length) {
     return 'Please enter a hexcode'

--- a/src/Utils/hexCodeValidation.ts
+++ b/src/Utils/hexCodeValidation.ts
@@ -5,7 +5,6 @@ export const VALID_HEX_LENGTH = 7
 export const validateHexCode: ValidationFunction = (
   color: string
 ): string | null => {
-  console.log('color')
 
   // Cannot be blank
   if (!color || !color.length) {


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3716

### Changes

// Describe what you changed

The input validation for the color input now invalidates a string that has more than one `#` and if character G / g is typed. 
### Screenshots

<img width="392" alt="Screen Shot 2022-02-01 at 12 13 09 PM" src="https://user-images.githubusercontent.com/18511823/152035150-3cfcf7e5-4c55-47bc-88a1-b80ec426643c.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
