### PR TITLE
revert: revert commit 493f0b, which upgraded marked from 0.7.0 => 4.0.10 and broke storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 3.1.15 (TBD)
+- [722](https://github.com/influxdata/clockface/pull/722): Revert update to marked dependency that broke storybooks
+
+### 3.1.14 (2021-02-01)
+- [721](https://github.com/influxdata/clockface/pull/721): Fix color picker's validation to only allow one #
+
+### 3.1.13 (2021-01-19)
+- [715](https://github.com/influxdata/clockface/pull/715): Fix issue with pencil icon on resource cards
+
 ### 3.1.12 (2021-01-14)
 
 - [717](https://github.com/influxdata/clockface/pull/717): Fix scrollTo positioning issue in List

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 3.1.15 (TBD)
+### 3.1.15 (2021-02-01)
 - [722](https://github.com/influxdata/clockface/pull/722): Revert update to marked dependency that broke storybooks
 
 ### 3.1.14 (2021-02-01)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jest": "^24.9.0",
     "lodash": "^4.17.21",
     "markdown-loader": "^5.0.0",
-    "marked": "^4.0.10",
+    "marked": "^0.7.0",
     "moment": "2.19.3",
     "prettier": "^1.19.1",
     "pretty-quick": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,11 +8979,6 @@ marked@^0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
-marked@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
-  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
-
 marksy@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/marksy/-/marksy-8.0.0.tgz#b595f121fd47058df9dda1448f6ee156ab48810a"


### PR DESCRIPTION
### Changes

Fixes storybook by undoing this PR https://github.com/influxdata/clockface/pull/719

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
