### PR TITLE
feat: add new component Creatable Type Ahead Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+### 3.2.0 (2022-02-07)
+
+- [724](https://github.com/influxdata/clockface/pull/724): Add a new component `CreatableTypeAheadDropdown`
+
 ### 3.1.15 (2021-02-01)
+
 - [722](https://github.com/influxdata/clockface/pull/722): Revert update to marked dependency that broke storybooks
 
 ### 3.1.14 (2021-02-01)
+
 - [721](https://github.com/influxdata/clockface/pull/721): Fix color picker's validation to only allow one #
 
 ### 3.1.13 (2021-01-19)
+
 - [715](https://github.com/influxdata/clockface/pull/715): Fix issue with pencil icon on resource cards
 
 ### 3.1.12 (2021-01-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 - [724](https://github.com/influxdata/clockface/pull/724): Add a new component `CreatableTypeAheadDropdown`
 
-### 3.1.15 (2021-02-01)
+### 3.1.15 (2022-02-01)
 
 - [722](https://github.com/influxdata/clockface/pull/722): Revert update to marked dependency that broke storybooks
 
-### 3.1.14 (2021-02-01)
+### 3.1.14 (2022-02-01)
 
 - [721](https://github.com/influxdata/clockface/pull/721): Fix color picker's validation to only allow one #
 
-### 3.1.13 (2021-01-19)
+### 3.1.13 (2022-01-19)
 
 - [715](https://github.com/influxdata/clockface/pull/715): Fix issue with pencil icon on resource cards
 
-### 3.1.12 (2021-01-14)
+### 3.1.12 (2022-01-14)
 
 - [717](https://github.com/influxdata/clockface/pull/717): Fix scrollTo positioning issue in List
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.1.15",
+  "version": "3.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/ColorPicker/ColorPicker.scss
+++ b/src/Components/ColorPicker/ColorPicker.scss
@@ -94,22 +94,3 @@ $color-picker--margin: 0;
     padding-left: $cf-marg-d - $cf-marg-a;
   }
 }
-
-.cf-color-picker--selected {
-  pointer-events: none;
-  z-index: 2;
-  position: absolute;
-  top: 50%;
-  left: $cf-marg-c;
-  transform: translate(-50%, -50%);
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: $cf-border solid $g5-pepper;
-  transition: background-color $cf-transition-default,
-    border-color $cf-transition-default;
-
-  .cf-input:hover + & {
-    border-color: $g7-graphite;
-  }
-}

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -165,7 +165,7 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
 
 ColorPicker.displayName = 'ColorPicker'
 
-const ColorPreview: FunctionComponent<{color: string}> = ({color}) => {
+export const ColorPreview: FunctionComponent<{color: string}> = ({color}) => {
   return (
     <div
       className="cf-color-picker--selected"

--- a/src/Components/ColorPicker/ColorPicker.tsx
+++ b/src/Components/ColorPicker/ColorPicker.tsx
@@ -7,6 +7,7 @@ import _ from 'lodash'
 import {Input} from '../Inputs/Input'
 import {Button} from '../Button/Composed/Button'
 import {ColorPickerSwatch, ColorPickerSwatchRef} from './ColorPickerSwatch'
+import {ColorPreview} from './ColorPreview'
 import {FormElementError} from '../Form/FormElementError'
 
 // Constants
@@ -164,17 +165,6 @@ export const ColorPicker = forwardRef<ColorPickerSwatchRef, ColorPickerProps>(
 )
 
 ColorPicker.displayName = 'ColorPicker'
-
-export const ColorPreview: FunctionComponent<{color: string}> = ({color}) => {
-  return (
-    <div
-      className="cf-color-picker--selected"
-      style={{backgroundColor: color}}
-    />
-  )
-}
-
-ColorPreview.displayName = 'ColorPickerPreview'
 
 const ErrorMessage: FunctionComponent<{
   testID: string

--- a/src/Components/ColorPicker/ColorPreview.scss
+++ b/src/Components/ColorPicker/ColorPreview.scss
@@ -19,7 +19,8 @@
   transition: background-color $cf-transition-default,
     border-color $cf-transition-default;
 
-  .cf-input:hover + & {
+  .cf-input:hover + &,
+  .cf-input:hover > & {
     border-color: $g7-graphite;
   }
 }

--- a/src/Components/ColorPicker/ColorPreview.scss
+++ b/src/Components/ColorPicker/ColorPreview.scss
@@ -1,0 +1,25 @@
+@import '../../Styles/variables';
+
+/*
+  Color Preview Widget
+  ------------------------------------------------------------------------------
+*/
+
+.cf-color-preview {
+  pointer-events: none;
+  z-index: 2;
+  position: absolute;
+  top: 50%;
+  left: $cf-marg-c;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: $cf-border solid $g5-pepper;
+  transition: background-color $cf-transition-default,
+    border-color $cf-transition-default;
+
+  .cf-input:hover + & {
+    border-color: $g7-graphite;
+  }
+}

--- a/src/Components/ColorPicker/ColorPreview.tsx
+++ b/src/Components/ColorPicker/ColorPreview.tsx
@@ -9,6 +9,7 @@ import {StandardFunctionProps} from '../../Types'
 import './ColorPreview.scss'
 
 interface ColorPreviewProps extends StandardFunctionProps {
+  /** Any CSS color value is good */
   color: string
 }
 

--- a/src/Components/ColorPicker/ColorPreview.tsx
+++ b/src/Components/ColorPicker/ColorPreview.tsx
@@ -9,7 +9,6 @@ import {StandardFunctionProps} from '../../Types'
 import './ColorPreview.scss'
 
 interface ColorPreviewProps extends StandardFunctionProps {
-  /** Hex color in #000000 format */
   color: string
 }
 

--- a/src/Components/ColorPicker/ColorPreview.tsx
+++ b/src/Components/ColorPicker/ColorPreview.tsx
@@ -1,0 +1,27 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import classnames from 'classnames'
+
+// Types
+import {StandardFunctionProps} from '../../Types'
+
+// Styles
+import './ColorPreview.scss'
+
+interface ColorPreviewProps extends StandardFunctionProps {
+  /** Hex color in #000000 format */
+  color: string
+}
+
+export const ColorPreview: FunctionComponent<ColorPreviewProps> = ({
+  color,
+  className,
+}) => {
+  const colorPreviewClass = classnames('cf-color-preview', {
+    [`${className}`]: className,
+  })
+
+  return <div className={colorPreviewClass} style={{backgroundColor: color}} />
+}
+
+ColorPreview.displayName = 'ColorPickerPreview'

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -32,6 +32,8 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   inputIcon?: IconFont
   /** Optional theme of menu */
   menuTheme?: DropdownMenuTheme
+  /** Optional maximum pixel height menu */
+  menuMaxHeight?: number
   /** TODO: input type and dropdown type */
   /** enum
 "text" | "color" */
@@ -46,6 +48,10 @@ export const CreatableTypeAheadDropdown = forwardRef<
 >(
   (
     {
+      id,
+      style = {width: '100%'},
+      testID = 'creatable-type-ahead-dropdown',
+      className,
       selectedOption,
       options,
       onSelect,
@@ -54,6 +60,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
       inputIcon,
       placeholder = 'Select...',
       menuTheme = DropdownMenuTheme.Onyx,
+      menuMaxHeight,
     },
     ref
   ) => {
@@ -108,7 +115,11 @@ export const CreatableTypeAheadDropdown = forwardRef<
     )
 
     const menu = (onCollapse: () => void) => (
-      <Dropdown.Menu onCollapse={onCollapse} theme={menuTheme}>
+      <Dropdown.Menu
+        onCollapse={onCollapse}
+        theme={menuTheme}
+        maxHeight={menuMaxHeight}
+      >
         {options.map(option => (
           <Dropdown.Item
             key={option}
@@ -123,7 +134,17 @@ export const CreatableTypeAheadDropdown = forwardRef<
       </Dropdown.Menu>
     )
 
-    return <Dropdown.Dropdown ref={ref} button={button} menu={menu} />
+    return (
+      <Dropdown.Dropdown
+        id={id}
+        ref={ref}
+        style={style}
+        testID={testID}
+        className={className}
+        button={button}
+        menu={menu}
+      />
+    )
   }
 )
 CreatableTypeAheadDropdown.displayName = 'CreatableTypeAheadDropdown'

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -23,7 +23,7 @@ import {
 import {MenuStatus} from '../Dropdown'
 
 export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
-  /** Text to render in button as currently selected option */
+  /** Text to render in input as currently selected or typed option */
   selectedOption: string
   /** List of options to render in menu */
   options: string[]
@@ -35,17 +35,18 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   inputStatus?: ComponentStatus
   /** Optional size of input */
   inputSize?: ComponentSize
-  /** Optional icon to render in input */
+  /** Optional icon to be displayed to the left of text in input  */
   inputIcon?: IconFont
+  /** Optional color preview to be displayed to the left of text.
+   * The color is determined by the selected or typed option in #000000 format.
+   * If both icon and this props are set, icon will take priority */
+  inputColorPreviewOn?: boolean
   /** Optional theme of menu */
   menuTheme?: DropdownMenuTheme
   /** Optional maximum pixel height menu */
   menuMaxHeight?: number
   /** Optional customized dropdown item */
   customizedDropdownItem?: (displayText: string) => JSX.Element
-  /** TODO: input type and dropdown type */
-  /** enum "text" | "color" */
-  type?: string
 }
 
 export type CreatableTypeAheadDropdownReadmeRef = DropdownRef
@@ -66,6 +67,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
       inputStatus = ComponentStatus.Default,
       inputSize = ComponentSize.Small,
       inputIcon,
+      inputColorPreviewOn = false,
       placeholder = 'Select...',
       menuTheme = DropdownMenuTheme.Onyx,
       menuMaxHeight,
@@ -150,6 +152,13 @@ export const CreatableTypeAheadDropdown = forwardRef<
         status={inputStatus}
         size={inputSize}
         icon={inputIcon}
+        colorPreview={
+          inputColorPreviewOn
+            ? typedValue === ''
+              ? 'transparent'
+              : typedValue
+            : ''
+        }
       />
     )
 

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -34,9 +34,10 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   menuTheme?: DropdownMenuTheme
   /** Optional maximum pixel height menu */
   menuMaxHeight?: number
+  /** Optional customized dropdown item */
+  customizedDropdownItem?: (displayText: string) => JSX.Element
   /** TODO: input type and dropdown type */
-  /** enum
-"text" | "color" */
+  /** enum "text" | "color" */
   type?: string
 }
 
@@ -61,6 +62,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
       placeholder = 'Select...',
       menuTheme = DropdownMenuTheme.Onyx,
       menuMaxHeight,
+      customizedDropdownItem,
     },
     ref
   ) => {
@@ -128,7 +130,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
             selected={option === selectedOption}
             onClick={handleClick}
           >
-            {option}
+            {!!customizedDropdownItem ? customizedDropdownItem(option) : option}
           </Dropdown.Item>
         ))}
       </Dropdown.Menu>

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -23,7 +23,7 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   /** TODO: input type and dropdown type */
   /** enum
 "text" | "color" */
-  type: string
+  type?: string
 }
 
 export type CreatableTypeAheadDropdownReadmeRef = DropdownRef

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -23,17 +23,13 @@ import {
 import {MenuStatus} from '../Dropdown'
 
 export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
-  /** Text to render in input as currently selected or typed option */
+  /** Text to render in input field as currently selected or typed option */
   selectedOption: string
-  /** List of options to render in menu */
+  /** List of options to render in dropdown menu */
   options: string[]
-  /** Fires when an option is clicked, used to update state */
   onSelect: (option: string) => void
-  /** Optional placeholder text when no option is selected */
   placeholder?: string
-  /** Optional status of input */
   inputStatus?: ComponentStatus
-  /** Optional size of input */
   inputSize?: ComponentSize
   /** Optional icon to be displayed to the left of text in input  */
   inputIcon?: IconFont
@@ -41,11 +37,9 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
    * The color is determined by the selected or typed option in #000000 format.
    * If both icon and this props are set, icon will take priority */
   inputColorPreviewOn?: boolean
-  /** Optional theme of menu */
   menuTheme?: DropdownMenuTheme
-  /** Optional maximum pixel height menu */
   menuMaxHeight?: number
-  /** Optional customized dropdown item */
+  /** Customize the layout of dropdown items */
   customizedDropdownItem?: (displayText: string) => JSX.Element
 }
 

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -22,14 +22,14 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   options: string[]
   /** Fires when an option is clicked, used to update state */
   onSelect: (option: string) => void
+  /** Optional placeholder text when no option is selected */
+  placeholder?: string
   /** Optional status of input */
   inputStatus?: ComponentStatus
   /** Optional size of input */
   inputSize?: ComponentSize
   /** Optional icon to render in input */
   inputIcon?: IconFont
-  /** Placeholder text when no value is present */
-  placeholder?: string
   /** Optional theme of menu */
   menuTheme?: DropdownMenuTheme
   /** TODO: input type and dropdown type */

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {forwardRef} from 'react'
+import React, {ChangeEvent, forwardRef, MouseEvent, useState} from 'react'
 
 // Components
 import {Dropdown, DropdownRef} from '../'
@@ -7,7 +7,7 @@ import {DropdownHeader} from '../DropdownHeader'
 import {Input} from '../../Inputs/Input'
 
 // Types
-import {StandardFunctionProps} from '../../../Types'
+import {DropdownMenuTheme, StandardFunctionProps} from '../../../Types'
 
 export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   /** Text to render in button as currently selected option */
@@ -16,6 +16,10 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   options: string[]
   /** Fires when an option is clicked, used to update state */
   onSelect: (option: string) => void
+  /** Placeholder text when no value is present */
+  placeholder?: string
+  /** Optional theme of menu */
+  menuTheme?: DropdownMenuTheme
   /** TODO: input type and dropdown type */
   /** enum
 "text" | "color" */
@@ -27,26 +31,62 @@ export type CreatableTypeAheadDropdownReadmeRef = DropdownRef
 export const CreatableTypeAheadDropdown = forwardRef<
   CreatableTypeAheadDropdownReadmeRef,
   CreatableTypeAheadDropdownProps
->(({options, children}, ref) => {
-  const inputComponent = <Input />
+>(
+  (
+    {
+      selectedOption,
+      options,
+      onSelect,
+      placeholder = 'Select...',
+      menuTheme = DropdownMenuTheme.Onyx,
+    },
+    ref
+  ) => {
+    const [typedValue, setTypedValue] = useState<string>('')
 
-  return (
-    <Dropdown
-      button={(active, onClick) => (
-        <DropdownHeader active={active} onClick={onClick} testID="test TODO">
-          {inputComponent}
-        </DropdownHeader>
-      )}
-      menu={onCollapse => (
-        <Dropdown.Menu onCollapse={onCollapse}>
-          {options.map(option => (
-            <Dropdown.Item key={option}>
-              {!!children ? children : option}
-            </Dropdown.Item>
-          ))}
-        </Dropdown.Menu>
-      )}
-    />
-  )
-})
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event?.target?.value
+      setTypedValue(value)
+    }
+
+    const handleClear = () => {
+      setTypedValue('')
+    }
+
+    const handleFocus = (event?: ChangeEvent<HTMLInputElement>) => {
+      if (event) {
+        event.target.select()
+      }
+    }
+
+    const inputComponent = (
+      <Input
+        placeholder={placeholder}
+        onChange={handleChange}
+        value={typedValue}
+        onClear={handleClear}
+        onFocus={handleFocus}
+      />
+    )
+
+    const button = (
+      active: boolean,
+      onClick: (e: MouseEvent<HTMLElement>) => void
+    ) => (
+      <DropdownHeader active={active} onClick={onClick} testID="test TODO">
+        {inputComponent}
+      </DropdownHeader>
+    )
+
+    const menu = (onCollapse: () => void) => (
+      <Dropdown.Menu onCollapse={onCollapse} theme={menuTheme}>
+        {options.map(option => (
+          <Dropdown.Item key={option}>{option}</Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    )
+
+    return <Dropdown button={button} menu={menu} />
+  }
+)
 CreatableTypeAheadDropdown.displayName = 'CreatableTypeAheadDropdown'

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -1,0 +1,19 @@
+// Libraries
+import React, {forwardRef} from 'react'
+
+// Components
+import {Dropdown, DropdownRef} from '../'
+
+export type CreatableTypeAheadDropdownReadmeRef = DropdownRef
+
+export const CreatableTypeAheadDropdown = forwardRef(() => {
+  return (
+    <Dropdown
+      menu={onCollapse => <Dropdown.Menu onCollapse={onCollapse} />}
+      button={(active, onClick) => (
+        <Dropdown.Button active={active} onClick={onClick} />
+      )}
+    />
+  )
+})
+CreatableTypeAheadDropdown.displayName = 'CreatableTypeAheadDropdown'

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -3,15 +3,48 @@ import React, {forwardRef} from 'react'
 
 // Components
 import {Dropdown, DropdownRef} from '../'
+import {DropdownHeader} from '../DropdownHeader'
+import {Input} from '../../Inputs/Input'
+
+// Types
+import {StandardFunctionProps} from '../../../Types'
+
+export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
+  /** Text to render in button as currently selected option */
+  selectedOption: string
+  /** List of options to render in menu */
+  options: string[]
+  /** Fires when an option is clicked, used to update state */
+  onSelect: (option: string) => void
+  /** TODO: input type and dropdown type */
+  /** enum
+"text" | "color" */
+  type: string
+}
 
 export type CreatableTypeAheadDropdownReadmeRef = DropdownRef
 
-export const CreatableTypeAheadDropdown = forwardRef(() => {
+export const CreatableTypeAheadDropdown = forwardRef<
+  CreatableTypeAheadDropdownReadmeRef,
+  CreatableTypeAheadDropdownProps
+>(({options, children}, ref) => {
+  const inputComponent = <Input />
+
   return (
     <Dropdown
-      menu={onCollapse => <Dropdown.Menu onCollapse={onCollapse} />}
       button={(active, onClick) => (
-        <Dropdown.Button active={active} onClick={onClick} />
+        <DropdownHeader active={active} onClick={onClick} testID="test TODO">
+          {inputComponent}
+        </DropdownHeader>
+      )}
+      menu={onCollapse => (
+        <Dropdown.Menu onCollapse={onCollapse}>
+          {options.map(option => (
+            <Dropdown.Item key={option}>
+              {!!children ? children : option}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
       )}
     />
   )

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -159,6 +159,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
               : typedValue
             : ''
         }
+        testID={`${testID}--input`}
       />
     )
 
@@ -169,7 +170,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
       <DropdownHeader
         active={active}
         onClick={onClick}
-        testID="test TODO"
+        testID={`${testID}--dropdown-header`}
         size={inputSize}
       >
         {inputComponent}
@@ -186,6 +187,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
         onCollapse={onCollapse}
         theme={menuTheme}
         maxHeight={menuMaxHeight}
+        testID={`${testID}--menu`}
       >
         {shownOptions.map(option => (
           <Dropdown.Item
@@ -194,6 +196,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
             title={option}
             selected={option === typedValue}
             onClick={handleSelect}
+            testID={`${testID}--item-${option}`}
           >
             {!!customizedDropdownItem ? customizedDropdownItem(option) : option}
           </Dropdown.Item>

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -7,7 +7,13 @@ import {DropdownHeader} from '../DropdownHeader'
 import {Input} from '../../Inputs/Input'
 
 // Types
-import {DropdownMenuTheme, StandardFunctionProps} from '../../../Types'
+import {
+  ComponentSize,
+  ComponentStatus,
+  DropdownMenuTheme,
+  IconFont,
+  StandardFunctionProps,
+} from '../../../Types'
 
 export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   /** Text to render in button as currently selected option */
@@ -16,6 +22,12 @@ export interface CreatableTypeAheadDropdownProps extends StandardFunctionProps {
   options: string[]
   /** Fires when an option is clicked, used to update state */
   onSelect: (option: string) => void
+  /** Optional status of input */
+  inputStatus?: ComponentStatus
+  /** Optional size of input */
+  inputSize?: ComponentSize
+  /** Optional icon to render in input */
+  inputIcon?: IconFont
   /** Placeholder text when no value is present */
   placeholder?: string
   /** Optional theme of menu */
@@ -37,6 +49,9 @@ export const CreatableTypeAheadDropdown = forwardRef<
       selectedOption,
       options,
       onSelect,
+      inputStatus = ComponentStatus.Default,
+      inputSize = ComponentSize.Small,
+      inputIcon,
       placeholder = 'Select...',
       menuTheme = DropdownMenuTheme.Onyx,
     },
@@ -72,6 +87,9 @@ export const CreatableTypeAheadDropdown = forwardRef<
         value={typedValue}
         onClear={handleClear}
         onFocus={handleFocus}
+        status={inputStatus}
+        size={inputSize}
+        icon={inputIcon}
       />
     )
 
@@ -79,7 +97,12 @@ export const CreatableTypeAheadDropdown = forwardRef<
       active: boolean,
       onClick: (e: MouseEvent<HTMLElement>) => void
     ) => (
-      <DropdownHeader active={active} onClick={onClick} testID="test TODO">
+      <DropdownHeader
+        active={active}
+        onClick={onClick}
+        testID="test TODO"
+        size={inputSize}
+      >
         {inputComponent}
       </DropdownHeader>
     )

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -42,7 +42,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
     },
     ref
   ) => {
-    const [typedValue, setTypedValue] = useState<string>('')
+    const [typedValue, setTypedValue] = useState<string>(selectedOption)
 
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
       const value = event?.target?.value
@@ -51,12 +51,18 @@ export const CreatableTypeAheadDropdown = forwardRef<
 
     const handleClear = () => {
       setTypedValue('')
+      onSelect('')
     }
 
     const handleFocus = (event?: ChangeEvent<HTMLInputElement>) => {
       if (event) {
         event.target.select()
       }
+    }
+
+    const handleClick = (option: string) => {
+      onSelect(option)
+      setTypedValue(option)
     }
 
     const inputComponent = (
@@ -81,12 +87,20 @@ export const CreatableTypeAheadDropdown = forwardRef<
     const menu = (onCollapse: () => void) => (
       <Dropdown.Menu onCollapse={onCollapse} theme={menuTheme}>
         {options.map(option => (
-          <Dropdown.Item key={option}>{option}</Dropdown.Item>
+          <Dropdown.Item
+            key={option}
+            value={option}
+            title={option}
+            selected={option === selectedOption}
+            onClick={handleClick}
+          >
+            {option}
+          </Dropdown.Item>
         ))}
       </Dropdown.Menu>
     )
 
-    return <Dropdown button={button} menu={menu} />
+    return <Dropdown.Dropdown ref={ref} button={button} menu={menu} />
   }
 )
 CreatableTypeAheadDropdown.displayName = 'CreatableTypeAheadDropdown'

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -84,21 +84,27 @@ export const CreatableTypeAheadDropdown = forwardRef<
 
     /**
      *  Filter the options array based on the styped string
-     *  If the typed string is empty, then there is nothing to filter; so return everything
      */
     const doFilter = (typedString: string) => {
+      // If the typed string is empty, then there is nothing to filter;
+      // so return everything and keep the menu open
       if (!typedString) {
         setShownOptions(options)
-      } else {
-        const result = options?.filter(option => {
-          return option
-            .toLocaleLowerCase()
-            .includes(typedString.toLocaleLowerCase())
-        })
-        console.log(result)
-        setShownOptions(result)
+        setMenuOpen(MenuStatus.Open)
+        return
       }
-      setMenuOpen(MenuStatus.Open)
+
+      const result = options?.filter(option => {
+        return option
+          .toLocaleLowerCase()
+          .includes(typedString.toLocaleLowerCase())
+      })
+      setShownOptions(result)
+      if (result.length > 0) {
+        setMenuOpen(MenuStatus.Open)
+      } else {
+        setMenuOpen(MenuStatus.Closed)
+      }
     }
 
     /**
@@ -118,17 +124,12 @@ export const CreatableTypeAheadDropdown = forwardRef<
       onSelect('')
       setShownOptions(options)
       setMenuOpen(MenuStatus.Open)
-      handleFocus()
     }
 
     const handleFocus = (event?: ChangeEvent<HTMLInputElement>) => {
       if (event) {
         event.target.select()
       }
-    }
-
-    const handleClick = (option: string) => {
-      onSelect(option)
     }
 
     const inputComponent = (
@@ -170,7 +171,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
             value={option}
             title={option}
             selected={option === typedValue}
-            onClick={handleClick}
+            onClick={onSelect}
           >
             {!!customizedDropdownItem ? customizedDropdownItem(option) : option}
           </Dropdown.Item>

--- a/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/CreatableTypeAheadDropdown.tsx
@@ -78,9 +78,8 @@ export const CreatableTypeAheadDropdown = forwardRef<
     const [menuOpen, setMenuOpen] = useState<MenuStatus>(MenuStatus.Closed)
 
     useEffect(() => {
-      setTypedValue(selectedOption)
       setShownOptions(options)
-    }, [selectedOption, options])
+    }, [options])
 
     /**
      *  Filter the options array based on the styped string
@@ -128,7 +127,15 @@ export const CreatableTypeAheadDropdown = forwardRef<
 
     const handleFocus = (event?: ChangeEvent<HTMLInputElement>) => {
       if (event) {
+        // Select the string in the input field
         event.target.select()
+      }
+    }
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        onSelect(typedValue)
+        setMenuOpen(MenuStatus.Closed)
       }
     }
 
@@ -139,6 +146,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
         value={typedValue}
         onClear={handleClear}
         onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
         status={inputStatus}
         size={inputSize}
         icon={inputIcon}
@@ -159,6 +167,11 @@ export const CreatableTypeAheadDropdown = forwardRef<
       </DropdownHeader>
     )
 
+    const handleSelect = (option: string) => {
+      setTypedValue(option)
+      onSelect(option)
+    }
+
     const menu = (onCollapse: () => void) => (
       <Dropdown.Menu
         onCollapse={onCollapse}
@@ -171,7 +184,7 @@ export const CreatableTypeAheadDropdown = forwardRef<
             value={option}
             title={option}
             selected={option === typedValue}
-            onClick={onSelect}
+            onClick={handleSelect}
           >
             {!!customizedDropdownItem ? customizedDropdownItem(option) : option}
           </Dropdown.Item>

--- a/src/Components/Dropdowns/Documentation/CreatableTypeAheadDropdown.md
+++ b/src/Components/Dropdowns/Documentation/CreatableTypeAheadDropdown.md
@@ -1,0 +1,62 @@
+# Creatable Type Ahead Dropdown
+
+This is composed variation of a Dropdown with typeahead that enables users to create new options along with choosing existing options.
+
+### Usage
+
+```tsx
+import {CreatableTypeAheadDropdown} from '@influxdata/clockface'
+```
+
+This composed dropdown has two key props: `selectedOption` and `options` which deal with only strings for quicker and simpler usage. The component is relatively dumb in that it won't throw errors if the string passed into `selectedOption` isn't found in `options`, or if `options` contains duplicate items. `selectedOption` may or may not be in `options`. This flexibility allows for a couple different UX approaches:
+
+- No option selected by default, dropdown shows all options
+- An option is selected by default,
+  - If `selectedOption` is in `options`, dropdown shows the selected option along with other options
+  - If `selectedOption` is not in `options`, dropdown shows all options
+
+The typeahead text input is clearable with an 'x' button in the right that shows up when there is content. Pressing on the 'x' will clear the text input AND set the selection of this control to null.
+
+### Example
+
+<!-- STORY -->
+
+##### Managing state
+
+Here's an example of how to manage Creatable Type Ahead Dropdown state:
+
+```tsx
+const options = [
+  'A',
+  'B',
+  'C',
+]
+
+this.state = {
+  selectedOption: 'A',
+}
+
+private handleSelect = (selectedOption: string): void => {
+  this.setState({selectedOption})
+}
+```
+
+And here's rendering the component:
+
+```tsx
+const {selectedOption} = this.state
+
+<CreatableTypeAheadDropdown
+  selectedOption={selectedOption}
+  options={options}
+  onSelect={this.handleSelect}
+/>
+```
+
+---
+
+<!-- STORY HIDE START -->
+
+<!-- STORY HIDE END -->
+
+<!-- PROPS -->

--- a/src/Components/Dropdowns/Documentation/CreatableTypeAheadDropdown.md
+++ b/src/Components/Dropdowns/Documentation/CreatableTypeAheadDropdown.md
@@ -13,9 +13,9 @@ This composed dropdown has two key props: `selectedOption` and `options` which d
 - No option selected by default, dropdown shows all options
 - An option is selected by default,
   - If `selectedOption` is in `options`, dropdown shows the selected option along with other options
-  - If `selectedOption` is not in `options`, dropdown shows all options
+  - If `selectedOption` is not in `options`, dropdown shows nothing, i.e. no dropdown
 
-The typeahead text input is clearable with an 'x' button in the right that shows up when there is content. Pressing on the 'x' will clear the text input AND set the selection of this control to null.
+The typeahead text input is clearable with an 'x' button in the right that shows up when there is content. Pressing on the 'x' will clear the text input AND set the selection of this control to empty string.
 
 ### Example
 

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -683,6 +683,8 @@ dropdownComposedStories.add(
     return (
       <div className="story--example">
         <CreatableTypeAheadDropdown
+          ref={creatableTypeAheadDropdownReadmeRef}
+          style={object('style', defaultDropdownStyle)}
           options={array('options', defaultDropdownOptions)}
           selectedOption={selected}
           onSelect={changeSelected}
@@ -706,6 +708,12 @@ dropdownComposedStories.add(
               )
             ]
           }
+          menuTheme={
+            DropdownMenuTheme[
+              select('menuTheme', mapEnumKeys(DropdownMenuTheme), 'Onyx')
+            ]
+          }
+          menuMaxHeight={number('menuMaxHeight', 250)}
         />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -672,6 +672,8 @@ dropdownComposedStories.add(
       'Tomato',
       'Spinach',
     ]
+    const [selected, changeSelected] = useState('Celery')
+
     const creatableTypeAheadDropdownReadmeRef: RefObject<CreatableTypeAheadDropdownReadmeRef> = createRef()
     const logRef = (): void => {
       /* eslint-disable */
@@ -681,10 +683,9 @@ dropdownComposedStories.add(
     return (
       <div className="story--example">
         <CreatableTypeAheadDropdown
-          options={defaultOptions}
-          selectedOption="Celery"
-          onSelect={opt => console.log(opt)}
-          type="color"
+          options={array('options', defaultOptions)}
+          selectedOption={selected}
+          onSelect={changeSelected}
         />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -32,6 +32,7 @@ import {
   MultiSelectDropdown,
   MultiSelectDropdownRef,
 } from '../Composed/MultiSelectDropdown'
+import {ColorPreview} from '../../ColorPicker/ColorPicker'
 
 import {TypeAheadDropDown, SelectableItem} from '../Composed/TypeAheadDropDown'
 
@@ -63,6 +64,7 @@ import TypeAheadDropdownReadme from './TypeAheadDropdown.md'
 import CreatableTypeAheadDropdownReadme from './CreatableTypeAheadDropdown.md'
 import MultiSelectDropdownReadme from './MultiSelectDropdown.md'
 import {useState} from '@storybook/addons'
+import {FlexBox} from '../../FlexBox'
 
 const dropdownFamilyStories = storiesOf(
   'Components/Dropdowns/Family',
@@ -714,6 +716,12 @@ dropdownComposedStories.add(
             ]
           }
           menuMaxHeight={number('menuMaxHeight', 250)}
+          customizedDropdownItem={displayText => (
+            <FlexBox>
+              <ColorPreview color={displayText} />
+              <div style={{paddingLeft: '26px'}}>{displayText}</div>
+            </FlexBox>
+          )}
         />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -664,6 +664,14 @@ dropdownComposedStories.add(
 dropdownComposedStories.add(
   'CreatableTypeAheadDropdown',
   () => {
+    const defaultOptions = [
+      'Celery',
+      'Carrot',
+      'Potato',
+      'Onion',
+      'Tomato',
+      'Spinach',
+    ]
     const creatableTypeAheadDropdownReadmeRef: RefObject<CreatableTypeAheadDropdownReadmeRef> = createRef()
     const logRef = (): void => {
       /* eslint-disable */
@@ -672,7 +680,12 @@ dropdownComposedStories.add(
     }
     return (
       <div className="story--example">
-        <CreatableTypeAheadDropdown />
+        <CreatableTypeAheadDropdown
+          options={defaultOptions}
+          selectedOption="Celery"
+          onSelect={opt => console.log(opt)}
+          type="color"
+        />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>
         </div>

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -686,6 +686,7 @@ dropdownComposedStories.add(
           options={array('options', defaultDropdownOptions)}
           selectedOption={selected}
           onSelect={changeSelected}
+          placeholder={text('placeholder', 'Placeholder Text')}
           inputStatus={
             ComponentStatus[
               select('inputStatus', mapEnumKeys(ComponentStatus), 'Default')

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -32,7 +32,7 @@ import {
   MultiSelectDropdown,
   MultiSelectDropdownRef,
 } from '../Composed/MultiSelectDropdown'
-import {ColorPreview} from '../../ColorPicker/ColorPicker'
+import {ColorPreview} from '../../ColorPicker/ColorPreview'
 
 import {TypeAheadDropDown, SelectableItem} from '../Composed/TypeAheadDropDown'
 
@@ -674,7 +674,17 @@ dropdownComposedStories.add(
       'Tomato',
       'Spinach',
     ]
-    const [selected, changeSelected] = useState('Celery')
+    const [selected, changeSelected] = useState(defaultDropdownOptions[1])
+    const defaultColorOptions = [
+      '#DC4E58',
+      '#FFB94A',
+      '#2FA74D',
+      '#0098F0',
+      '#8E1FC3',
+    ]
+    const [selectedColor, changeSelectedColor] = useState(
+      defaultColorOptions[1]
+    )
 
     const creatableTypeAheadDropdownReadmeRef: RefObject<CreatableTypeAheadDropdownReadmeRef> = createRef()
     const logRef = (): void => {
@@ -710,6 +720,41 @@ dropdownComposedStories.add(
               )
             ]
           }
+          menuTheme={
+            DropdownMenuTheme[
+              select('menuTheme', mapEnumKeys(DropdownMenuTheme), 'Onyx')
+            ]
+          }
+          menuMaxHeight={number('menuMaxHeight', 250)}
+        />
+        <span>With customized dropdown item: </span>
+        <CreatableTypeAheadDropdown
+          ref={creatableTypeAheadDropdownReadmeRef}
+          style={object('style', defaultDropdownStyle)}
+          options={defaultColorOptions}
+          selectedOption={selectedColor}
+          onSelect={changeSelectedColor}
+          placeholder={text('placeholder', 'Placeholder Text')}
+          inputStatus={
+            ComponentStatus[
+              select('inputStatus', mapEnumKeys(ComponentStatus), 'Default')
+            ]
+          }
+          inputSize={
+            ComponentSize[
+              select('inputSize', mapEnumKeys(ComponentSize), 'Small')
+            ]
+          }
+          inputIcon={
+            IconFont[
+              select(
+                'inputIcon',
+                {None: 'none', ...mapEnumKeys(IconFont)},
+                'None'
+              )
+            ]
+          }
+          inputColorPreviewOn={true}
           menuTheme={
             DropdownMenuTheme[
               select('menuTheme', mapEnumKeys(DropdownMenuTheme), 'Onyx')

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -35,6 +35,11 @@ import {
 
 import {TypeAheadDropDown, SelectableItem} from '../Composed/TypeAheadDropDown'
 
+import {
+  CreatableTypeAheadDropdown,
+  CreatableTypeAheadDropdownReadmeRef,
+} from '../Composed/CreatableTypeAheadDropdown'
+
 // Types
 import {
   ComponentColor,
@@ -55,6 +60,7 @@ import DropdownLinkItemReadme from './DropdownLinkItem.md'
 import DropdownMenuReadme from './DropdownMenu.md'
 import SelectDropdownReadme from './SelectDropdown.md'
 import TypeAheadDropdownReadme from './TypeAheadDropdown.md'
+import CreatableTypeAheadDropdownReadme from './CreatableTypeAheadDropdown.md'
 import MultiSelectDropdownReadme from './MultiSelectDropdown.md'
 import {useState} from '@storybook/addons'
 
@@ -651,6 +657,31 @@ dropdownComposedStories.add(
   {
     readme: {
       content: marked(TypeAheadDropdownReadme),
+    },
+  }
+)
+
+dropdownComposedStories.add(
+  'CreatableTypeAheadDropdown',
+  () => {
+    const creatableTypeAheadDropdownReadmeRef: RefObject<CreatableTypeAheadDropdownReadmeRef> = createRef()
+    const logRef = (): void => {
+      /* eslint-disable */
+      console.log(creatableTypeAheadDropdownReadmeRef.current)
+      /* eslint-enable */
+    }
+    return (
+      <div className="story--example">
+        <CreatableTypeAheadDropdown />
+        <div className="story--test-buttons">
+          <button onClick={logRef}>Log Ref</button>
+        </div>
+      </div>
+    )
+  },
+  {
+    readme: {
+      content: marked(CreatableTypeAheadDropdownReadme),
     },
   }
 )

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -664,7 +664,7 @@ dropdownComposedStories.add(
 dropdownComposedStories.add(
   'CreatableTypeAheadDropdown',
   () => {
-    const defaultOptions = [
+    const defaultDropdownOptions = [
       'Celery',
       'Carrot',
       'Potato',
@@ -683,9 +683,28 @@ dropdownComposedStories.add(
     return (
       <div className="story--example">
         <CreatableTypeAheadDropdown
-          options={array('options', defaultOptions)}
+          options={array('options', defaultDropdownOptions)}
           selectedOption={selected}
           onSelect={changeSelected}
+          inputStatus={
+            ComponentStatus[
+              select('inputStatus', mapEnumKeys(ComponentStatus), 'Default')
+            ]
+          }
+          inputSize={
+            ComponentSize[
+              select('inputSize', mapEnumKeys(ComponentSize), 'Small')
+            ]
+          }
+          inputIcon={
+            IconFont[
+              select(
+                'inputIcon',
+                {None: 'none', ...mapEnumKeys(IconFont)},
+                'None'
+              )
+            ]
+          }
         />
         <div className="story--test-buttons">
           <button onClick={logRef}>Log Ref</button>

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -190,11 +190,15 @@ export const Input = forwardRef<InputRef, InputProps>(
     const correctlyTypedMax: string | number | undefined =
       max === max ? max : ''
 
-    const iconElement = icon && <Icon glyph={icon} className="cf-input-icon" />
-
-    const colorElement = colorPreview && (
-      <ColorPreview color={colorPreview} className="cf-input-icon" />
-    )
+    /** If both icon and colorPreview are set in props, icon has higher priority */
+    let iconElement = null
+    if (icon) {
+      iconElement = <Icon glyph={icon} className="cf-input-icon" />
+    } else if (colorPreview) {
+      iconElement = (
+        <ColorPreview color={colorPreview} className="cf-input-icon" />
+      )
+    }
 
     const clearClasses = classnames('cf-input-clear-btn', {
       large: size === ComponentSize.Large,
@@ -257,8 +261,7 @@ export const Input = forwardRef<InputRef, InputProps>(
         />
         {clearElement}
         {type === InputType.Checkbox && <div className={inputCheckboxClass} />}
-        {/** If both icon and colorPreview are set in props, icon has higher priority */
-        !!icon ? iconElement : colorElement}
+        {iconElement}
         {children}
       </div>
     )

--- a/src/Components/Inputs/Input.tsx
+++ b/src/Components/Inputs/Input.tsx
@@ -27,6 +27,7 @@ import {
   InputType,
   StandardFunctionProps,
 } from '../../Types'
+import {ColorPreview} from '../ColorPicker/ColorPreview'
 
 export interface InputProps extends StandardFunctionProps {
   /** Minimum value for number & range types */
@@ -92,6 +93,10 @@ export interface InputProps extends StandardFunctionProps {
   containerRef?: RefObject<InputContainerRef>
   /** Render input using monospace font */
   monospace?: boolean
+  /** Color preview to be displayed to the left of text.
+   * Value should be in #000000 format.
+   * If both icon and colorPreview props are set, icon will take priority */
+  colorPreview?: string
 }
 
 export type InputRef = HTMLInputElement
@@ -135,6 +140,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       containerRef,
       autocomplete = AutoComplete.Off,
       disabledTitleText = 'This input is disabled',
+      colorPreview,
     },
     ref
   ) => {
@@ -145,7 +151,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       [`cf-input-${size}`]: size,
       'cf-input__focused': isFocused,
       'cf-input__has-checkbox': type === InputType.Checkbox,
-      'cf-input__has-icon': icon,
+      'cf-input__has-icon': icon || colorPreview,
       'cf-input__has-clear-btn': onClear && value,
       'cf-input__valid': correctStatus === ComponentStatus.Valid,
       'cf-input__error': correctStatus === ComponentStatus.Error,
@@ -185,6 +191,10 @@ export const Input = forwardRef<InputRef, InputProps>(
       max === max ? max : ''
 
     const iconElement = icon && <Icon glyph={icon} className="cf-input-icon" />
+
+    const colorElement = colorPreview && (
+      <ColorPreview color={colorPreview} className="cf-input-icon" />
+    )
 
     const clearClasses = classnames('cf-input-clear-btn', {
       large: size === ComponentSize.Large,
@@ -247,7 +257,8 @@ export const Input = forwardRef<InputRef, InputProps>(
         />
         {clearElement}
         {type === InputType.Checkbox && <div className={inputCheckboxClass} />}
-        {iconElement}
+        {/** If both icon and colorPreview are set in props, icon has higher priority */
+        !!icon ? iconElement : colorElement}
         {children}
       </div>
     )


### PR DESCRIPTION
Closes influxdata/ui#3680

This PR created a new component called "Creatable Type Ahead Dropdown," a more flexible version of "Type Ahead Dropdown." 

Here are the features provided with this new component:
- Type ahead search in dropdown menu
- Accept typed values that are not in the dropdown menu
- Customizable dropdown items
- Optional color preview

### Changes

- Add a new component `CreatableTypeAheadDropdown`
- Add this new component into storybook with examples
- Add `colorPreview` prop to `Input` component
- Move `ColorPreview` component and its style into a single file

### Screenshots

https://user-images.githubusercontent.com/14298407/152875227-c79a1825-d8e4-4286-9764-c68b63da5899.mov



### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
