### PR TITLE
feat: add error status to dropdown button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 3.3.0 (2022-02-08)
 
-- [pending](https://github.com/influxdata/clockface/pulls): Allow dropdown buttons to have error status indicated with a styled border
+- [727](https://github.com/influxdata/clockface/pull/727): Allow dropdown buttons to have error status indicated with a styled border
 
 ### 3.2.1 (2022-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.3.0 (2022-02-08)
+
+- [pending](https://github.com/influxdata/clockface/pulls): Allow dropdown buttons to have error status indicated with a styled border
+
 ### 3.2.1 (2022-02-08)
 
 - [728](https://github.com/influxdata/clockface/pull/728): Export `CreatableTypeAheadDropdown` and `ColorPreview`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
+++ b/src/Components/Dropdowns/Documentation/Dropdowns.stories.tsx
@@ -100,7 +100,15 @@ dropdownFamilyStories.add(
           ref={dropdownRef}
           style={object('style', defaultDropdownStyle)}
           button={(active, onClick) => (
-            <Dropdown.Button active={active} onClick={onClick}>
+            <Dropdown.Button
+              active={active}
+              onClick={onClick}
+              status={
+                ComponentStatus[
+                  select('status', mapEnumKeys(ComponentStatus), 'Default')
+                ]
+              }
+            >
               {text('Button Text', 'I am a Dropdown!')}
             </Dropdown.Button>
           )}

--- a/src/Components/Dropdowns/DropdownButton.scss
+++ b/src/Components/Dropdowns/DropdownButton.scss
@@ -41,6 +41,13 @@
   }
 }
 
+.cf-dropdown__error,
+.cf-dropdown__error:hover,
+.cf-dropdown__error:focus {
+  border-color: $cf-input-border--error;
+  box-shadow: 0 0 6px 0 $cf-input-border--error-focused;
+}
+
 /** small size is the default */
 .header-container--button {
   width: $cf-form-sm-width;

--- a/src/Components/Dropdowns/DropdownButton.scss
+++ b/src/Components/Dropdowns/DropdownButton.scss
@@ -41,11 +41,12 @@
   }
 }
 
-.cf-dropdown__error,
-.cf-dropdown__error:hover,
-.cf-dropdown__error:focus {
-  border-color: $cf-input-border--error;
-  box-shadow: 0 0 6px 0 $cf-input-border--error-focused;
+.cf-dropdown--button {
+  &.cf-dropdown__error,
+  &.cf-dropdown__error:hover,
+  &.cf-dropdown__error:focus {
+    border: $cf-border solid $cf-input-border--error;
+  }
 }
 
 /** small size is the default */

--- a/src/Components/Dropdowns/DropdownButton.tsx
+++ b/src/Components/Dropdowns/DropdownButton.tsx
@@ -64,16 +64,8 @@ export const DropdownButton = forwardRef<
   ) => {
     const dropdownButtonClass = classnames('cf-dropdown--button', {
       [`${className}`]: className,
+      'cf-dropdown__error': status === ComponentStatus.Error,
     })
-
-    const dropdownButtonStatus = (): ComponentStatus => {
-      const isDisabled = [
-        ComponentStatus.Disabled,
-        ComponentStatus.Error,
-      ].includes(status)
-
-      return isDisabled ? ComponentStatus.Disabled : ComponentStatus.Default
-    }
 
     return (
       <ButtonBase
@@ -86,7 +78,7 @@ export const DropdownButton = forwardRef<
         shape={ButtonShape.StretchToFit}
         testID={testID}
         active={active}
-        status={dropdownButtonStatus()}
+        status={status}
         onClick={onClick}
         className={dropdownButtonClass}
         titleText={title}


### PR DESCRIPTION
Supports https://github.com/influxdata/ui/issues/3404  - a new set of dropdowns will be put into Band View's options to allow the user to select only valid column names. The 3 different columns that have selectable names must choose different names. Indicate to the user that a dropdown has an invalid selection.

This is a minimalist feature. It simply allows the `Dropdown.Button` to add a box-shadow when the component status is error. Completely opt-in and backwards compatible.

### Changes

- adds component status to Dropdown buttons
- adds box shadow to indicate error status for Dropdown buttons

### Screenshots

<img width="348" alt="Screen Shot 2022-02-08 at 5 21 50 PM" src="https://user-images.githubusercontent.com/10736577/153103791-238c71e4-0e64-435d-b769-749eb3bc80c8.png">

**_UPDATED_** to use a solid border without shadow:
<img width="290" alt="Screen Shot 2022-02-10 at 2 25 21 PM" src="https://user-images.githubusercontent.com/10736577/153507035-925b80c8-be09-4e84-8c1f-b83e00f851ec.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
