### PR TITLE
fix: remove box shadow from dropdown buttons when in error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 3.3.1 (2022-02-15)
 
-- [pending](https://github.com/influxdata/clockface/pulls): Remove conflicting box shadow from dropdown buttons when in error status.
+- [730](https://github.com/influxdata/clockface/pull/730): Remove conflicting box shadow from dropdown buttons when in error status.
 
 ### 3.3.0 (2022-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.3.1 (2022-02-15)
+
+- [pending](https://github.com/influxdata/clockface/pulls): Remove conflicting box shadow from dropdown buttons when in error status.
+
 ### 3.3.0 (2022-02-08)
 
 - [727](https://github.com/influxdata/clockface/pull/727): Allow dropdown buttons to have error status indicated with a styled border

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/DropdownButton.scss
+++ b/src/Components/Dropdowns/DropdownButton.scss
@@ -46,6 +46,7 @@
   &.cf-dropdown__error:hover,
   &.cf-dropdown__error:focus {
     border: $cf-border solid $cf-input-border--error;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3404


Previously, dropdown buttons were updated to allow for error status, which adds a visual border around the button. However, the box shadow was not removed when the button is focused. We want to remove all box shadows for dropdown buttons that are in error status.

### Changes

Removes the conflicting box shadow around dropdown buttons when in error status.

### Screenshots

BEFORE:
<img width="378" alt="Screen Shot 2022-02-14 at 4 01 38 PM" src="https://user-images.githubusercontent.com/10736577/154147863-4c518c07-a4c4-42cd-b5b7-14eb1cd6efa4.png">

AFTER:
<img width="383" alt="Screen Shot 2022-02-14 at 4 02 25 PM" src="https://user-images.githubusercontent.com/10736577/154147887-d04583d8-592f-4708-b383-6a0dd58e34ea.png">


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
