### PR TITLE
chore: add .npmrc to gitignore to support publishing without leaking tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 storybook-static
 docs
 package-lock.json
+.npmrc


### PR DESCRIPTION
**npm** requires new steps to publish when requiring 2FA (two-factor authentication). One of the steps involves inserting a token into your local **.npmrc** file, which should remain local so that we do not leak tokens.

- add **.npmrc** to **.gitignore**