### PR TITLE
fix: ResourceCardName make <a> tag instead of <span>

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -153,13 +153,13 @@ export const ResourceCardEditableName = forwardRef<
           loading={loading}
           spinnerComponent={<TechnoSpinner diameterPixels={20} />}
         >
-          <span
+          <a
             className={resourceCardEditableNameLinkClass}
             onClick={handleClick}
             data-testid={testID}
           >
             {name || noNameString}
-          </span>
+          </a>
         </SpinnerContainer>
         <div
           className="cf-resource-editable-name--toggle"

--- a/src/Components/ResourceList/Card/ResourceCardName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardName.scss
@@ -21,6 +21,10 @@
   font-family: $cf-text-font;
   color: $g17-whisper;
   user-select: none;
+
+  &:hover {
+    color: $g17-whisper;
+  }
 }
 
 .cf-resource-name--text__link {


### PR DESCRIPTION
Part of: https://github.com/influxdata/clockface/issues/723

### Changes
Changes the `span` to an `a` tag to make the CMD-Click behavior consistent across environments.

### Screenshots


https://user-images.githubusercontent.com/18511823/155027682-361874f6-d93c-4774-ae20-3cdfcfa74214.mov



### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
