### PR TITLE
fix: FormValidationElement compares values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.5.1 (2022-03-11)
+
+- [744](https://github.com/influxdata/clockface/pull/744): FormValidationElement bug fix
+
 ### 3.5.0 (2022-03-10)
 
 - [738](https://github.com/influxdata/clockface/pull/740): Added input functionality to the PaginationNav

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Form/FormValidationElement.tsx
+++ b/src/Components/Form/FormValidationElement.tsx
@@ -63,12 +63,15 @@ export const FormValidationElement = forwardRef<
     ref
   ) => {
     const shouldPerformValidation = useRef<boolean>(prevalidate)
+    const originalValue = useRef(value)
 
     let errorMessage = null
     let status = ComponentStatus.Default
 
     useEffect(() => {
-      shouldPerformValidation.current = true
+      if (originalValue.current !== value) {
+        shouldPerformValidation.current = true
+      }
     }, [value])
 
     if (shouldPerformValidation.current) {


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/743

### Changes

FormValidationElement now compares new values to the original value before enabling validation. See the attached issue for more context.

### Screenshots

https://user-images.githubusercontent.com/6411855/157991870-64d42687-7d13-46ba-a69e-ff01b12e8009.mov

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
