### PR TITLE
feat: Added new Brand Colors + Updated Funnel Page default Colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.9.0 (2022-03-31)
+
+- [754](https://github.com/influxdata/clockface/pull/754): Updated Funnel Page with new Brand Colors
+
 ### 3.8.0 (2022-03-31)
 
 - [752](https://github.com/influxdata/clockface/pull/752): Added Icon for Bulk Action Deselection 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
+++ b/src/Components/FunnelPage/Documentation/FunnelPage.stories.tsx
@@ -82,18 +82,22 @@ funnelPageStories.add(
                   select(
                     'backgroundColor',
                     mapEnumKeys(InfluxColors),
-                    'DeepPurple'
+                    'CetaceanBlue'
                   )
                 ]
               }
               accentColorA={
                 InfluxColors[
-                  select('accentColorA', mapEnumKeys(InfluxColors), 'Sapphire')
+                  select('accentColorA', mapEnumKeys(InfluxColors), 'PurpleX')
                 ]
               }
               accentColorB={
                 InfluxColors[
-                  select('accentColorB', mapEnumKeys(InfluxColors), 'Amethyst')
+                  select(
+                    'accentColorB',
+                    mapEnumKeys(InfluxColors),
+                    'DogwoodRose'
+                  )
                 ]
               }
             >

--- a/src/Components/FunnelPage/Family/FunnelPage.tsx
+++ b/src/Components/FunnelPage/Family/FunnelPage.tsx
@@ -42,10 +42,10 @@ export const FunnelPageRoot = forwardRef<FunnelPageRef, FunnelPageProps>(
       children,
       pageStyle,
       className,
-      accentColorA = InfluxColors.Sapphire,
-      accentColorB = InfluxColors.Amethyst,
+      accentColorA = InfluxColors.PurpleX,
+      accentColorB = InfluxColors.DogwoodRose,
       enableGraphic = false,
-      backgroundColor = InfluxColors.DeepPurple,
+      backgroundColor = InfluxColors.CetaceanBlue,
     },
     ref
   ) => {

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -269,6 +269,9 @@ export enum InfluxColors {
   Magenta = '#BF2FE5',
   Galaxy = '#9394FF',
   Pulsar = '#513CC6',
+  CetaceanBlue = '#020A47',
+  DogwoodRose = '#D30971',
+  PurpleX = '#9B2AFF',
 }
 
 export enum IconFont {


### PR DESCRIPTION
Closes #

### Changes

Added the three new brand colors and updated the funnel page to use these colors by default.

PurpleX,
CetaceanBlue,
DogwoodRose

### Screenshots

<img width="1269" alt="Screen Shot 2022-04-07 at 2 27 48 PM" src="https://user-images.githubusercontent.com/15152523/162273752-b8d84536-0a3d-461a-b7cb-fd20e5a821e4.png">

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
