### PR TITLE
feat(ResourceCard): add href property for proper browser context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### 3.11.0 (2022-04-13)
+### 3.12.0 (2022-04-19)
+
+- [760](https://github.com/influxdata/clockface/pull/760): Add optional href property to ResourceCardEditableName
+
+### 3.11.0 (2022-04-18)
 
 - [759](https://github.com/influxdata/clockface/pull/759): Added new props to Subway Nav
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.scss
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.scss
@@ -12,6 +12,7 @@
 }
 
 .cf-resource-editable-name > a {
+  color: $g17-whisper;
   display: inline-block;
 }
 

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -44,6 +44,8 @@ export interface ResourceCardEditableNameProps extends StandardFunctionProps {
   inputTestID?: string
   /** Pass through to assign a ref to the Input present in edit mode */
   inputRef?: RefObject<InputRef>
+  /** For the anchor tag in the resource card - needed for browsers to show the proper context menu */
+  href?: string
 }
 
 export type ResourceCardEditableNameRef = HTMLDivElement
@@ -55,6 +57,7 @@ export const ResourceCardEditableName = forwardRef<
   (
     {
       id,
+      href,
       name,
       style,
       testID = 'resource-editable-name',
@@ -92,6 +95,10 @@ export const ResourceCardEditableName = forwardRef<
     )
 
     const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+      // this behavior is overriden by the on
+      if (href) {
+        e.preventDefault()
+      }
       if (onClick) {
         onClick(e)
       }
@@ -157,6 +164,7 @@ export const ResourceCardEditableName = forwardRef<
             className={resourceCardEditableNameLinkClass}
             onClick={handleClick}
             data-testid={testID}
+            href={href}
           >
             {name || noNameString}
           </a>

--- a/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
+++ b/src/Components/ResourceList/Card/ResourceCardEditableName.tsx
@@ -95,7 +95,7 @@ export const ResourceCardEditableName = forwardRef<
     )
 
     const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-      // this behavior is overriden by the on
+      // this behavior is overriden by the onClick handler
       if (href) {
         e.preventDefault()
       }


### PR DESCRIPTION
Connects #723

### Changes

Adds an `href` property to `ResourceCardEditableName`. The `href` property is what the browser uses to infer that the element is a link and should have the proper context menu that includes `Open Link in New Tab` and `Open Link in New Window`.

The property will need to be passed into `ResourceCard.EditableName` on the ui side for this to work completely.

### Screenshots

**Dashboards**
![Screen Shot 2022-04-19 at 12 14 13 PM](https://user-images.githubusercontent.com/146112/164049246-b4a18783-2c76-4107-9e51-b12b0978e519.png)

**Tasks**
![Screen Shot 2022-04-19 at 12 13 56 PM](https://user-images.githubusercontent.com/146112/164049235-3e565bc6-6db0-4283-815f-dc24f8e43006.png)


### Checklist
Check all that apply

- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved

