### PR TITLE
fix: Updated Form Element Font Size

### DIFF
--- a/src/Components/Form/Form.scss
+++ b/src/Components/Form/Form.scss
@@ -30,7 +30,7 @@
 .cf-form--element-error {
   text-align: left;
   display: inline-block;
-  font-size: $cf-text-base-0;
+  font-size: $cf-text-base-1;
   font-weight: $cf-font-weight--regular;
   @extend %no-user-select;
 }


### PR DESCRIPTION
Closes #

### Changes

Updated the Form Element font size to better reflect the Proxima nova's slightly smaller size vs. the old font.

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
