### PR TITLE
add an optional prop to TreeNavSubMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 4.2.0 (2022-05-19)
+### 4.2.0 (2022-05-20)
 
 - [768](https://github.com/influxdata/clockface/pull/768): Added optional property to TreeNavSubMenu
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.2.0 (2022-05-19)
+
+- [768](https://github.com/influxdata/clockface/pull/768): Added optional property to TreeNavSubMenu
+
 ### 4.0.2 (2022-04-21)
 
 - [767](https://github.com/influxdata/clockface/pull/767): Fixed Form Element text size (14px too small for Proxima Nova)
@@ -34,7 +38,7 @@
 
 ### 3.8.0 (2022-03-31)
 
-- [752](https://github.com/influxdata/clockface/pull/752): Added Icon for Bulk Action Deselection 
+- [752](https://github.com/influxdata/clockface/pull/752): Added Icon for Bulk Action Deselection
 
 ### 3.7.0 (2022-03-31)
 
@@ -51,6 +55,7 @@
 ### 3.5.1 (2022-03-11)
 
 - [744](https://github.com/influxdata/clockface/pull/744): FormValidationElement bug fix
+
 ### 3.5.0 (2022-03-10)
 
 - [740](https://github.com/influxdata/clockface/pull/740): Added input functionality to the PaginationNav

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.2.0 (2022-05-19)
 
 - [768](https://github.com/influxdata/clockface/pull/768): Added optional property to TreeNavSubMenu
+
 ### 4.1.0 (2022-05-19)
 
 - [769](https://github.com/influxdata/clockface/pull/769): Selectable resource card for Bulk Actions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "4.0.2",
+  "version": "4.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/TreeNav/TreeNavSubMenu.tsx
+++ b/src/Components/TreeNav/TreeNavSubMenu.tsx
@@ -21,47 +21,52 @@ export type TreeNavSubMenuRef = HTMLDivElement
 export const TreeNavSubMenu = forwardRef<
   TreeNavSubMenuRef,
   TreeNavSubMenuProps
->(({id, style, testID = 'tree-nav--sub-menu', className, children, helpBar}, ref) => {
-  const navMenuHeaderClass = classnames('cf-tree-nav--sub-menu', {
-    [`${className}`]: className,
-  })
-  let popoverPosition = PopoverPosition.ToTheRightTop
-  if (helpBar) {
-    popoverPosition = PopoverPosition.ToTheRight
-  }
-  const triggerRef = useRef<HTMLButtonElement>(null)
+>(
+  (
+    {id, style, testID = 'tree-nav--sub-menu', className, children, helpBar},
+    ref
+  ) => {
+    const navMenuHeaderClass = classnames('cf-tree-nav--sub-menu', {
+      [`${className}`]: className,
+    })
+    let popoverPosition = PopoverPosition.ToTheRightTop
+    if (helpBar) {
+      popoverPosition = PopoverPosition.ToTheRight
+    }
+    const triggerRef = useRef<HTMLButtonElement>(null)
 
-  return (
-    <>
-      <button
-        type="button"
-        className="cf-tree-nav--sub-menu-trigger"
-        ref={triggerRef}
-        aria-label="Show sub menu"
-      />
-      {triggerRef && (
-        <Popover
-          enableDefaultStyles={true}
-          contents={onHide => <div onClick={onHide}>{children}</div>}
-          hideEvent={PopoverInteraction.Hover}
-          showEvent={PopoverInteraction.Hover}
-          triggerRef={triggerRef}
-          position={popoverPosition}
-          className="cf-popover__nav"
-          distanceFromTrigger={4}
+    return (
+      <>
+        <button
+          type="button"
+          className="cf-tree-nav--sub-menu-trigger"
+          ref={triggerRef}
+          aria-label="Show sub menu"
         />
-      )}
-      <div
-        id={id}
-        ref={ref}
-        style={style}
-        className={navMenuHeaderClass}
-        data-testid={testID}
-      >
-        {children}
-      </div>
-    </>
-  )
-})
+        {triggerRef && (
+          <Popover
+            enableDefaultStyles={true}
+            contents={onHide => <div onClick={onHide}>{children}</div>}
+            hideEvent={PopoverInteraction.Hover}
+            showEvent={PopoverInteraction.Hover}
+            triggerRef={triggerRef}
+            position={popoverPosition}
+            className="cf-popover__nav"
+            distanceFromTrigger={4}
+          />
+        )}
+        <div
+          id={id}
+          ref={ref}
+          style={style}
+          className={navMenuHeaderClass}
+          data-testid={testID}
+        >
+          {children}
+        </div>
+      </>
+    )
+  }
+)
 
 TreeNavSubMenu.displayName = 'TreeNavSubMenu'

--- a/src/Components/TreeNav/TreeNavSubMenu.tsx
+++ b/src/Components/TreeNav/TreeNavSubMenu.tsx
@@ -10,18 +10,25 @@ import {
 } from '../../Types'
 import {Popover} from '../Popover'
 
-export type TreeNavSubMenuProps = StandardFunctionProps
+export interface HelpBarProp {
+  helpBar?: boolean
+}
+
+export type TreeNavSubMenuProps = StandardFunctionProps & HelpBarProp
 
 export type TreeNavSubMenuRef = HTMLDivElement
 
 export const TreeNavSubMenu = forwardRef<
   TreeNavSubMenuRef,
   TreeNavSubMenuProps
->(({id, style, testID = 'tree-nav--sub-menu', className, children}, ref) => {
+>(({id, style, testID = 'tree-nav--sub-menu', className, children, helpBar}, ref) => {
   const navMenuHeaderClass = classnames('cf-tree-nav--sub-menu', {
     [`${className}`]: className,
   })
-
+  let popoverPosition = PopoverPosition.ToTheRightTop
+  if (helpBar) {
+    popoverPosition = PopoverPosition.ToTheRight
+  }
   const triggerRef = useRef<HTMLButtonElement>(null)
 
   return (
@@ -39,7 +46,7 @@ export const TreeNavSubMenu = forwardRef<
           hideEvent={PopoverInteraction.Hover}
           showEvent={PopoverInteraction.Hover}
           triggerRef={triggerRef}
-          position={PopoverPosition.ToTheRightTop}
+          position={popoverPosition}
           className="cf-popover__nav"
           distanceFromTrigger={4}
         />

--- a/src/Components/TreeNav/TreeNavSubMenu.tsx
+++ b/src/Components/TreeNav/TreeNavSubMenu.tsx
@@ -10,11 +10,11 @@ import {
 } from '../../Types'
 import {Popover} from '../Popover'
 
-export interface HelpBarProp {
-  helpBar?: boolean
+export interface OptionalProp {
+  position?: PopoverPosition
 }
 
-export type TreeNavSubMenuProps = StandardFunctionProps & HelpBarProp
+export type TreeNavSubMenuProps = StandardFunctionProps & OptionalProp
 
 export type TreeNavSubMenuRef = HTMLDivElement
 
@@ -23,16 +23,20 @@ export const TreeNavSubMenu = forwardRef<
   TreeNavSubMenuProps
 >(
   (
-    {id, style, testID = 'tree-nav--sub-menu', className, children, helpBar},
+    {
+      id,
+      style,
+      testID = 'tree-nav--sub-menu',
+      className,
+      children,
+      position = PopoverPosition.ToTheRightTop,
+    },
     ref
   ) => {
     const navMenuHeaderClass = classnames('cf-tree-nav--sub-menu', {
       [`${className}`]: className,
     })
-    let popoverPosition = PopoverPosition.ToTheRightTop
-    if (helpBar) {
-      popoverPosition = PopoverPosition.ToTheRight
-    }
+
     const triggerRef = useRef<HTMLButtonElement>(null)
 
     return (
@@ -50,7 +54,7 @@ export const TreeNavSubMenu = forwardRef<
             hideEvent={PopoverInteraction.Hover}
             showEvent={PopoverInteraction.Hover}
             triggerRef={triggerRef}
-            position={popoverPosition}
+            position={position}
             className="cf-popover__nav"
             distanceFromTrigger={4}
           />


### PR DESCRIPTION
Closes #

### Changes

PR adds an optional prop to `TreeNavSubMenu` component with a default value set to `PopoverPosition.ToTheRightTop`. This will give `TreeNavSubMenu` the ability to change the position of the popover modal. 

### Screenshots

https://user-images.githubusercontent.com/66275100/169159301-d2993d23-e531-47e3-8554-b0cba6a70339.mov


### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
