### PR TITLE
chore: use resolution to resolve ansi-regex 4.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   "resolutions": {
     "immer": "^9.0.6",
     "jest/**/ansi-regex": "^3.0.1",
+    "eslint/**/ansi-regex": "^4.1.1",
     "@wessberg/**/browserslist": "^4.16.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,10 +3391,15 @@ ansi-regex@^3.0.0, ansi-regex@^3.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
   integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-regex@^4.1.0, ansi-regex@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
https://github.com/influxdata/clockface/pull/777 had updates for ansi-regex, but I missed the one for 4.1.0 -> 4.1.1 (sorry for the extra PR). `yarn test` passes.

- [ ] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
