### PR TITLE
fix: MenuDropdown fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### 4.6.0 (2022-05-31)
+### 4.6.1 (2022-06-25)
+
+- [786](https://github.com/influxdata/clockface/pull/786): MenuDropdown component design fixes
+
+### 4.6.0 (2022-06-24)
 
 - [784](https://github.com/influxdata/clockface/pull/784): Accordion Caret Updates
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -111,13 +111,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   const [selectIndex, setSelectIndex] = useState(-1)
   const [queryResults, setQueryResults] = useState(subMenuOptions)
   const [menuOpen, setMenuOpen] = useState<MenuStatus>(MenuStatus.Closed)
-  const [selectedItem, setSelectedItem] = useState<SubMenuItem | null>(
-    selectedOption
-  )
-
-  useEffect(() => {
-    setSelectedItem(selectedOption)
-  }, [selectedOption])
 
   const initialTypedValue = ''
   const [typedValue, setTypedValue] = useState<string>(initialTypedValue)
@@ -155,7 +148,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       icon={buttonIcon}
       className={'cf-dropdown-menu--button'}
     >
-      {selectedItem?.name || defaultText}
+      {selectedOption?.name || defaultText}
     </Dropdown.Button>
   )
 
@@ -168,7 +161,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   }
 
   const setTypedValueToSelectedName = (backupName?: string) => {
-    let selectedName = backupName ?? selectedItem?.name
+    let selectedName = backupName ?? selectedOption?.name
     if (!selectedName) {
       selectedName = ''
     }
@@ -221,7 +214,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   }
 
   const doSelection = (item: SubMenuItem | null, closeMenuNow?: boolean) => {
-    setSelectedItem(item)
     const actualName = getDisplayName(item)
     setTypedValue(actualName)
     backupValue.current = actualName
@@ -231,7 +223,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       setIsTypeAhead(false)
       setMenuOpen(MenuStatus.Closed)
     }
-    setSelectedItem(item)
     if (onSelectOption) {
       onSelectOption(item)
     }
@@ -362,7 +353,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                     value={value}
                     onClick={() => doSelection(value, true)}
                     style={itemStyle}
-                    selected={value.id === selectedItem?.id}
+                    selected={value.id === selectedOption?.id}
                     className={classN}
                     trailingIconOnSelected={true}
                   >

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -111,6 +111,13 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   const [selectIndex, setSelectIndex] = useState(-1)
   const [queryResults, setQueryResults] = useState(subMenuOptions)
   const [menuOpen, setMenuOpen] = useState<MenuStatus>(MenuStatus.Closed)
+  const [selectedItem, setSelectedItem] = useState<SubMenuItem | null>(
+    selectedOption
+  )
+
+  useEffect(() => {
+    setSelectedItem(selectedOption)
+  }, [selectedOption])
 
   const initialTypedValue = ''
   const [typedValue, setTypedValue] = useState<string>(initialTypedValue)
@@ -148,7 +155,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       icon={buttonIcon}
       className={'cf-dropdown-menu--button'}
     >
-      {selectedOption?.name || defaultText}
+      {selectedItem?.name || defaultText}
     </Dropdown.Button>
   )
 
@@ -161,7 +168,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   }
 
   const setTypedValueToSelectedName = (backupName?: string) => {
-    let selectedName = backupName ?? selectedOption?.name
+    let selectedName = backupName ?? selectedItem?.name
     if (!selectedName) {
       selectedName = ''
     }
@@ -214,6 +221,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   }
 
   const doSelection = (item: SubMenuItem | null, closeMenuNow?: boolean) => {
+    setSelectedItem(item)
     const actualName = getDisplayName(item)
     setTypedValue(actualName)
     backupValue.current = actualName
@@ -223,6 +231,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       setIsTypeAhead(false)
       setMenuOpen(MenuStatus.Closed)
     }
+    setSelectedItem(item)
     if (onSelectOption) {
       onSelectOption(item)
     }
@@ -353,7 +362,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                     value={value}
                     onClick={() => doSelection(value, true)}
                     style={itemStyle}
-                    selected={value.id === selectedOption?.id}
+                    selected={value.id === selectedItem?.id}
                     className={classN}
                     trailingIconOnSelected={true}
                   >

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -64,7 +64,6 @@ export interface MenuDropdownProps extends StandardFunctionProps {
   menuTestID?: string
   /** the name/label to show in the dropdown where there is an item with an id but without a name; defaults to the empty string */
   menuStyle?: React.CSSProperties
-
   // Callback function for when option is selected
   onSelectOption?: (item: SubMenuItem | null) => void
 }

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -15,6 +15,8 @@ import {Dropdown} from '../.'
 import {Icon} from '../../Icon/Base/Icon'
 import {Input} from '../../Inputs/Input'
 
+import './MenuDropdownStyles.scss'
+
 // Types
 import {
   ComponentSize,
@@ -296,14 +298,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   )
 
   const typeAheadMenu = () => {
-    const itemStyle = {width: '100%', paddingLeft: '14px'}
-    const inputStyle = {
-      marginTop: '4px',
-      marginBottom: '8px',
-      marginLeft: '0',
-      marginRight: '0',
-      zIndex: '0',
-    }
     const iconFont = IconFont.CaretLeft_New
     const textEl = <span>{menuHeaderText}</span>
     const iconEl = (
@@ -324,7 +318,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
         testID={`dropdown-input-typeAhead--${testIdSuffix}`}
         onClear={clear}
         onFocus={selectAllTextInInput}
-        style={inputStyle}
+        className="menu-dropdown-typeahead-input"
       />
     )
 
@@ -351,7 +345,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
           ) : (
             queryResults?.map((value, index) => {
               // add the 'active' class to highlight when arrowing; like a hover
-              const classN = classnames({
+              const classN = classnames('menu-dropdown-typeahead-item', {
                 active: index === selectIndex,
               })
 
@@ -361,7 +355,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                     id={value.id}
                     value={value}
                     onClick={() => doSelection(value, true)}
-                    style={itemStyle}
                     selected={value.id === selectedItem?.id}
                     className={classN}
                     trailingIconOnSelected={true}

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -64,7 +64,11 @@ export interface MenuDropdownProps extends StandardFunctionProps {
   menuTestID?: string
   /** the name/label to show in the dropdown where there is an item with an id but without a name; defaults to the empty string */
   menuStyle?: React.CSSProperties
+
+  // Callback function for when option is selected
+  onSelectOption?: (item: SubMenuItem | null) => void
 }
+
 const isBlank = (pString: string | undefined): boolean =>
   // Checks for falsiness or a non-white space character
   !pString || !/[^\s]+/.test(pString)
@@ -99,6 +103,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   buttonSize = ComponentSize.Small,
   buttonIcon,
   menuTestID = 'type-ahead-dropdown--menu',
+  onSelectOption,
 }) => {
   // Menu Dropdown State
   const [isTypeAhead, setIsTypeAhead] = useState(false)
@@ -228,6 +233,9 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       setMenuOpen(MenuStatus.Closed)
     }
     setSelectedItem(item)
+    if (onSelectOption) {
+      onSelectOption(item)
+    }
   }
 
   const clear = () => {

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -280,7 +280,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
             {menuHeaderCaretEl}
           </div>
         </div>
-        <hr className="cf-dropdown-menu__line-break"></hr>
+        <hr className="cf-dropdown-menu__line-break" />
         {options.map(value => {
           const iconFont = value.iconFont
           const iconEl = <Icon glyph={iconFont} className="cf-button-icon" />
@@ -370,7 +370,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                     {value.name}
                   </Dropdown.Item>
                   {index !== queryResults.length - 1 && (
-                    <hr className="cf-dropdown-menu__line-break"></hr>
+                    <hr className="cf-dropdown-menu__line-break" />
                   )}
                 </div>
               )

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -1,11 +1,11 @@
 // Libraries
 import React, {
   ChangeEvent,
-  MouseEvent,
   FC,
-  useState,
-  useRef,
+  MouseEvent,
   useEffect,
+  useRef,
+  useState,
 } from 'react'
 import classnames from 'classnames'
 import {MenuStatus} from '../Dropdown'
@@ -18,8 +18,8 @@ import {Input} from '../../Inputs/Input'
 // Types
 import {
   ComponentSize,
-  IconFont,
   DropdownMenuTheme,
+  IconFont,
   StandardFunctionProps,
 } from '../../../Types'
 
@@ -94,7 +94,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   largeListCeiling = 0,
   largeListSearch = false,
   searchText = 'Search Accounts',
-  menuTheme = DropdownMenuTheme.Onyx,
+  menuTheme = DropdownMenuTheme.None,
   className,
   buttonSize = ComponentSize.Small,
   buttonIcon,
@@ -289,13 +289,12 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   )
 
   const typeAheadMenu = () => {
-    const itemWidth = {width: 'calc(100% - 8px)'}
+    const itemStyle = {width: '100%', paddingLeft: '14px'}
     const inputStyle = {
-      width: 'calc(100% - 8px)',
       marginTop: '4px',
       marginBottom: '8px',
-      marginLeft: 'auto',
-      marginRight: 'auto',
+      marginLeft: '0',
+      marginRight: '0',
       zIndex: '0',
     }
     const iconFont = IconFont.CaretLeft_New
@@ -355,13 +354,16 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                     id={value.id}
                     value={value}
                     onClick={() => doSelection(value, true)}
-                    style={itemWidth}
+                    style={itemStyle}
                     selected={value.id === selectedItem?.id}
                     className={classN}
+                    trailingIconOnSelected={true}
                   >
                     {value.name}
                   </Dropdown.Item>
-                  <hr className="cf-dropdown-menu__line-break"></hr>
+                  {index !== queryResults.length - 1 && (
+                    <hr className="cf-dropdown-menu__line-break"></hr>
+                  )}
                 </div>
               )
             })

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -87,7 +87,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   testIdSuffix = 'menu',
   options,
   subMenuOptions,
-  selectedOption = {id: '1', name: 'wt'},
+  selectedOption = null,
   defaultText = 'No Account Selected',
   menuHeaderIcon = IconFont.Switch_New,
   menuHeaderText = 'Switch Account',
@@ -231,7 +231,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   }
 
   const clear = () => {
-    doSelection(null)
     doFilter('')
   }
 
@@ -300,7 +299,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       zIndex: '0',
     }
     const iconFont = IconFont.CaretLeft_New
-    const textEl = <span>Switch Account</span>
+    const textEl = <span>{menuHeaderText}</span>
     const iconEl = (
       <Icon
         glyph={iconFont}
@@ -389,10 +388,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       testID={testID || `typeAhead-dropdown--${testIdSuffix}`}
       onClickAway={onClickAwayHere}
       disableAutoFocus
-      button={(active, onClick) => {
-        console.log('button render')
-        return button(active, onClick)
-      }}
+      button={button}
       menu={isTypeAhead ? typeAheadMenu : menu}
     />
   )

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -87,7 +87,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   testIdSuffix = 'menu',
   options,
   subMenuOptions,
-  selectedOption = null,
+  selectedOption = {id: '1', name: 'wt'},
   defaultText = 'No Account Selected',
   menuHeaderIcon = IconFont.Switch_New,
   menuHeaderText = 'Switch Account',
@@ -110,6 +110,10 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   const [selectedItem, setSelectedItem] = useState<SubMenuItem | null>(
     selectedOption
   )
+
+  useEffect(() => {
+    setSelectedItem(selectedOption)
+  }, [selectedOption])
 
   const initialTypedValue = ''
   const [typedValue, setTypedValue] = useState<string>(initialTypedValue)
@@ -385,7 +389,10 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       testID={testID || `typeAhead-dropdown--${testIdSuffix}`}
       onClickAway={onClickAwayHere}
       disableAutoFocus
-      button={button}
+      button={(active, onClick) => {
+        console.log('button render')
+        return button(active, onClick)
+      }}
       menu={isTypeAhead ? typeAheadMenu : menu}
     />
   )

--- a/src/Components/Dropdowns/Composed/MenuDropdownStyles.scss
+++ b/src/Components/Dropdowns/Composed/MenuDropdownStyles.scss
@@ -1,0 +1,12 @@
+.menu-dropdown-typeahead-item {
+  width: 100%;
+  padding-left: 14px;
+}
+
+.menu-dropdown-typeahead-input {
+  margin-top: 4px;
+  margin-bottom: 8px;
+  margin-left: 0;
+  margin-right: 0;
+  z-index: 0;
+}

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -310,3 +310,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 .cf-dropdown__onyx {
   @include dropdownMenuColor($c-pool);
 }
+
+.cf-dropdown__none {
+  @include dropdownMenuColor('none');
+}

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -249,6 +249,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 
 .cf-dropdown-menu__line-break {
   margin: 8px;
+  background-color: rgba(241, 241, 243, 0.1);
 }
 
 .cf-dropdown-menu--button {

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -248,7 +248,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 */
 
 .cf-dropdown-menu__line-break {
-  margin: 8px; 
+  margin: 8px;
 }
 
 .cf-dropdown-menu--button {
@@ -257,6 +257,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 
 .cf-dropdown-menu--caret-icon {
   font-size: 16.5px;
+  margin-right: 0.35em;
 }
 
 .cf-dropdown-menu-header {

--- a/src/Components/Dropdowns/DropdownHrefItem.tsx
+++ b/src/Components/Dropdowns/DropdownHrefItem.tsx
@@ -63,23 +63,24 @@ export const DropdownHrefItem = forwardRef<
     }
 
     return (
-      <button
-        type="button"
-        id={id}
-        ref={ref}
-        style={styles}
-        title={title}
-        className={dropdownItemClass}
-        data-testid={testID}
+      <a
+        href={href}
+        className="cf-dropdown-item--children cf-dropdown-href-text"
       >
-        <DropdownItemSelectionIndicator type={type} />
-        <a
-          href={href}
-          className="cf-dropdown-item--children cf-dropdown-href-text"
+        <button
+          type="button"
+          id={id}
+          ref={ref}
+          style={styles}
+          title={title}
+          className={dropdownItemClass}
+          data-testid={testID}
         >
+          <DropdownItemSelectionIndicator type={type} />
+
           {children}
-        </a>
-      </button>
+        </button>
+      </a>
     )
   }
 )

--- a/src/Components/Dropdowns/DropdownItem.tsx
+++ b/src/Components/Dropdowns/DropdownItem.tsx
@@ -84,7 +84,11 @@ export const DropdownItem = forwardRef<DropdownItemRef, DropdownItemProps>(
           {trailingIconOnSelected && selected && (
             <Icon
               glyph={IconFont.Checkmark_New}
-              style={{float: 'right', color: InfluxColors.Pool}}
+              style={{
+                float: 'right',
+                color: InfluxColors.Pool,
+                fontSize: '20px',
+              }}
             />
           )}
         </div>

--- a/src/Components/Dropdowns/DropdownItem.tsx
+++ b/src/Components/Dropdowns/DropdownItem.tsx
@@ -1,13 +1,18 @@
 // Libraries
-import React, { forwardRef, MouseEvent } from "react";
-import classnames from "classnames";
+import React, {forwardRef, MouseEvent} from 'react'
+import classnames from 'classnames'
 
 // Types
-import { DropdownItemType, IconFont, InfluxColors, StandardFunctionProps } from "../../Types";
+import {
+  DropdownItemType,
+  IconFont,
+  InfluxColors,
+  StandardFunctionProps,
+} from '../../Types'
 
 // Components
-import { DropdownItemSelectionIndicator } from "./DropdownItemSelectionIndicator";
-import { Icon } from "../Icon";
+import {DropdownItemSelectionIndicator} from './DropdownItemSelectionIndicator'
+import {Icon} from '../Icon'
 
 export interface DropdownItemProps extends StandardFunctionProps {
   /** Value to be returned via the onClick function */

--- a/src/Components/Dropdowns/DropdownItem.tsx
+++ b/src/Components/Dropdowns/DropdownItem.tsx
@@ -1,12 +1,13 @@
 // Libraries
-import React, {forwardRef, MouseEvent} from 'react'
-import classnames from 'classnames'
+import React, { forwardRef, MouseEvent } from "react";
+import classnames from "classnames";
 
 // Types
-import {DropdownItemType, StandardFunctionProps} from '../../Types'
+import { DropdownItemType, IconFont, InfluxColors, StandardFunctionProps } from "../../Types";
 
 // Components
-import {DropdownItemSelectionIndicator} from './DropdownItemSelectionIndicator'
+import { DropdownItemSelectionIndicator } from "./DropdownItemSelectionIndicator";
+import { Icon } from "../Icon";
 
 export interface DropdownItemProps extends StandardFunctionProps {
   /** Value to be returned via the onClick function */
@@ -23,6 +24,8 @@ export interface DropdownItemProps extends StandardFunctionProps {
   title?: string
   /** Prevents any interaction with this element, including the onClick function */
   disabled?: boolean
+
+  trailingIconOnSelected?: boolean
 }
 
 export type DropdownItemRef = HTMLButtonElement
@@ -42,6 +45,7 @@ export const DropdownItem = forwardRef<DropdownItemRef, DropdownItemProps>(
       children,
       disabled,
       className,
+      trailingIconOnSelected = false,
     },
     ref
   ) => {
@@ -75,7 +79,15 @@ export const DropdownItem = forwardRef<DropdownItemRef, DropdownItemProps>(
         data-testid={testID}
       >
         <DropdownItemSelectionIndicator type={type} />
-        <div className="cf-dropdown-item--children">{children}</div>
+        <div className="cf-dropdown-item--children">
+          {children}
+          {trailingIconOnSelected && selected && (
+            <Icon
+              glyph={IconFont.Checkmark_New}
+              style={{float: 'right', color: InfluxColors.Pool}}
+            />
+          )}
+        </div>
       </button>
     )
   }

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -147,6 +147,7 @@ export enum DropdownMenuTheme {
   Malachite = 'malachite',
   Sapphire = 'sapphire',
   Onyx = 'onyx',
+  None = 'none'
 }
 
 export interface DropdownMenuScrollbarColors {

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -147,7 +147,7 @@ export enum DropdownMenuTheme {
   Malachite = 'malachite',
   Sapphire = 'sapphire',
   Onyx = 'onyx',
-  None = 'none'
+  None = 'none',
 }
 
 export interface DropdownMenuScrollbarColors {


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/787

### Changes

1. Added an `onSelectOption` handler which sends the information back to the UI when an option is selected.
2. Adds the checkmark instead of the blue background for the selected option.
3. When dropdown typeahead was cleared it cleared the state of the whole component, this is undesirable. 
4. Some styling changes to make it match the figma design.

### Screenshots

https://user-images.githubusercontent.com/18511823/175786985-be13c653-cdf3-4fb3-af10-afe046cefa7b.mov

// Add screenshots here if relevant

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
