### PR TITLE
feat: add custom check ability per step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+### 4.7.2 (2022-06-30)
+
+- [788](https://github.com/influxdata/clockface/pull/788): Ability to show Checkmark on Subway Nav before clicking
+
 ### 4.7.1 (2022-06-30)
 
 - [790](https://github.com/influxdata/clockface/pull/790): styling fix for MenuDropdown component

--- a/src/Components/SubwayNav/SubwayNav.tsx
+++ b/src/Components/SubwayNav/SubwayNav.tsx
@@ -10,6 +10,7 @@ import './SubwayNav.scss'
 export interface SubwayNavModel {
   glyph: IconFont
   name: string
+  isCompleted?: boolean
 }
 
 interface OwnProps {
@@ -55,7 +56,9 @@ export class SubwayNav extends PureComponent<OwnProps> {
                 this.handleClick(index + 1)
               }}
               stepIsActive={index === this.props.currentStep - 1}
-              stepIsComplete={index < this.props.currentStep - 1}
+              stepIsComplete={
+                value?.isCompleted ?? index < this.props.currentStep - 1
+              }
               text={value.name}
               showCheckmark={this.props.showCheckmark !== false}
             />

--- a/src/Components/SubwayNav/SubwayNav.tsx
+++ b/src/Components/SubwayNav/SubwayNav.tsx
@@ -59,6 +59,7 @@ export class SubwayNav extends PureComponent<OwnProps> {
               stepIsComplete={
                 value?.isComplete ?? index < this.props.currentStep - 1
               }
+              stepIsReached={index <= this.props.currentStep - 1}
               text={value.name}
               showCheckmark={this.props.showCheckmark !== false}
             />

--- a/src/Components/SubwayNav/SubwayNav.tsx
+++ b/src/Components/SubwayNav/SubwayNav.tsx
@@ -10,7 +10,7 @@ import './SubwayNav.scss'
 export interface SubwayNavModel {
   glyph: IconFont
   name: string
-  isCompleted?: boolean
+  isComplete?: boolean
 }
 
 interface OwnProps {
@@ -57,7 +57,7 @@ export class SubwayNav extends PureComponent<OwnProps> {
               }}
               stepIsActive={index === this.props.currentStep - 1}
               stepIsComplete={
-                value?.isCompleted ?? index < this.props.currentStep - 1
+                value?.isComplete ?? index < this.props.currentStep - 1
               }
               text={value.name}
               showCheckmark={this.props.showCheckmark !== false}

--- a/src/Components/SubwayNav/SubwayNavStep.tsx
+++ b/src/Components/SubwayNav/SubwayNavStep.tsx
@@ -31,6 +31,7 @@ export const SubwayNavStep = (props: OwnProps) => {
     fontSize: '20px',
   }
   const completedStepStyle = {color: InfluxColors.Grey95, fontSize: '25px'}
+  const isActiveStepStyle = {...completedStepStyle, fontSize: '20px'}
 
   return (
     <span
@@ -49,7 +50,7 @@ export const SubwayNavStep = (props: OwnProps) => {
           style={{
             color: iconAndTextColor,
             background:
-              stepIsReached && stepIsComplete && showCheckmark
+              (stepIsReached && stepIsComplete && showCheckmark) || stepIsActive
                 ? InfluxColors.Pool
                 : '',
           }}
@@ -57,7 +58,10 @@ export const SubwayNavStep = (props: OwnProps) => {
           {stepIsComplete && showCheckmark ? (
             <Icon glyph={IconFont.Checkmark_New} style={completedStepStyle} />
           ) : (
-            <Icon glyph={glyph} style={glyphFontStyle} />
+            <Icon
+              glyph={glyph}
+              style={stepIsActive ? isActiveStepStyle : glyphFontStyle}
+            />
           )}
         </span>
         <span

--- a/src/Components/SubwayNav/SubwayNavStep.tsx
+++ b/src/Components/SubwayNav/SubwayNavStep.tsx
@@ -11,6 +11,7 @@ type OwnProps = {
   stepIsComplete: boolean
   text: string
   showCheckmark: boolean
+  stepIsReached: boolean
 }
 
 export const SubwayNavStep = (props: OwnProps) => {
@@ -21,9 +22,10 @@ export const SubwayNavStep = (props: OwnProps) => {
     stepIsComplete,
     text,
     showCheckmark,
+    stepIsReached,
   } = props
   const iconAndTextColor =
-    stepIsActive || stepIsComplete ? InfluxColors.Pool : InfluxColors.Grey95
+    stepIsActive || stepIsReached ? InfluxColors.Pool : InfluxColors.Grey95
 
   const glyphFontStyle = {
     fontSize: '20px',
@@ -33,13 +35,13 @@ export const SubwayNavStep = (props: OwnProps) => {
   return (
     <span
       className={classnames('subway-navigation-step-flex-wrapper', {
-        stepIsComplete: stepIsComplete,
+        stepIsComplete: stepIsReached,
       })}
       onClick={onClick}
     >
       <div
         className={classnames('subway-navigation-step', {
-          showBorderColor: stepIsActive || stepIsComplete,
+          showBorderColor: stepIsReached,
         })}
       >
         <span
@@ -47,7 +49,9 @@ export const SubwayNavStep = (props: OwnProps) => {
           style={{
             color: iconAndTextColor,
             background:
-              stepIsComplete && showCheckmark ? InfluxColors.Pool : '',
+              stepIsReached && stepIsComplete && showCheckmark
+                ? InfluxColors.Pool
+                : '',
           }}
         >
           {stepIsComplete && showCheckmark ? (


### PR DESCRIPTION
### Changes

We currently don't have the ability to have checkbox based on a custom criteria. Instead of adding a criteria function, I am adding an optional `isCompleted` boolean per step. If the boolean exists for a step then that boolean will take precedence. If it doesn't exist in the navigation step, then the regular logic will be applied.

NOTE: Please note that the last step is now checked in the AFTER gif. Earlier, this wasn't possible. Reason this is checked is because I set `isComplete` for that step to true.

### Screenshots
## BEFORE
![BEFORE](https://user-images.githubusercontent.com/1637395/176563591-62c0c2d6-1ff7-45d6-ba02-6a2d53f9a07e.gif)

## AFTER
![AFTER](https://user-images.githubusercontent.com/1637395/176563619-d4318498-b3d9-4878-b419-e314b153ea46.gif)

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
