### PR TITLE
fix: Styling menudropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.7.1 (2022-06-30)
+
+- [790](https://github.com/influxdata/clockface/pull/790): styling fix for MenuDropdown component
+
 ### 4.7.0 (2022-06-30)
 
 - [789](https://github.com/influxdata/clockface/pull/789): react-window for long lists in MenuDropdown component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -310,6 +310,11 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       />
     )
 
+    let menuWidth = '300px'
+    if (menuStyle?.width) {
+      menuWidth = menuStyle.width.toString()
+    }
+
     return (
       <Dropdown.Menu testID={menuTestID} theme={menuTheme} style={menuStyle}>
         <div>
@@ -326,7 +331,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
             height={150}
             itemCount={queryResults.length}
             itemSize={50}
-            width={'300px'}
+            width={menuWidth}
             itemData={queryResults}
           >
             {({data, index, style}) => {

--- a/src/Components/Dropdowns/Composed/MenuDropdownStyles.scss
+++ b/src/Components/Dropdowns/Composed/MenuDropdownStyles.scss
@@ -1,6 +1,7 @@
 .menu-dropdown-typeahead-item {
   width: 100%;
   padding-left: 14px;
+  padding-right: 20px;
 }
 
 .menu-dropdown-typeahead-input {


### PR DESCRIPTION
Closes #

Simple styling change so it shows the Checkmark when the dropdown is selected.

// Describe what you changed

### Screenshots

<img width="400" alt="Screen Shot 2022-06-30 at 12 51 49 PM" src="https://user-images.githubusercontent.com/18511823/176765076-6a59cf51-bdd1-4a0e-b558-e64c1e4e3c80.png">

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
