### PR TITLE
fix: Multi-org dropdown shouldn't show typeahead if only one account/org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 4.7.3 (2022-07-01)
+
+- [794](https://github.com/influxdata/clockface/pull/794): Multi-Org dropdown displays selected item first, and will not offer option to change accounts/orgs if no other accounts or orgs exist
 
 ### 4.7.2 (2022-06-30)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -346,7 +346,10 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
                       id={value.id.toString()}
                       value={value}
                       onClick={() => doSelection(value, true)}
-                      selected={value.id === selectedItem?.id}
+                      /* Values need to be compared as string because account items have number ids*/
+                      selected={
+                        value.id.toString() === selectedItem?.id.toString()
+                      }
                       className={classN}
                       trailingIconOnSelected={true}
                     >

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -39,7 +39,7 @@ export interface SubMenuItem {
 
 export interface MenuDropdownProps extends StandardFunctionProps {
   /** A default pre-selected Option */
-  selectedOption: SubMenuItem
+  selectedOption?: SubMenuItem
   /** List of href options to render in the main menu */
   options: MenuItem[]
   /** List of options to render in the sub type-ahead menu */
@@ -132,13 +132,12 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       // if it had a value, and then they type, the queryResults changes
       // so need to reset
 
-      // Always show an instance of currently selected option at beginning of list.
       setQueryResults(result)
       setSelectIndex(-1)
     } else {
       setQueryResults(subMenuOptions)
     }
-  }, [subMenuOptions, typedValue, selectedOption])
+  }, [subMenuOptions, typedValue])
 
   const dropdownButton = (
     active: boolean,

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -131,7 +131,6 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       // always reset the selectIndex when doing filtering;  because
       // if it had a value, and then they type, the queryResults changes
       // so need to reset
-
       setQueryResults(result)
       setSelectIndex(-1)
     } else {

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -133,7 +133,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       // so need to reset
 
       // Always show an instance of currently selected option at beginning of list.
-      setQueryResults(result)
+      setQueryResults([selectedOption, ...result])
       setSelectIndex(-1)
     } else {
       setQueryResults([selectedOption, ...subMenuOptions])

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -133,7 +133,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       // so need to reset
 
       // Always show an instance of currently selected option at beginning of list.
-      setQueryResults([selectedOption, ...result])
+      setQueryResults(result)
       setSelectIndex(-1)
     } else {
       setQueryResults([selectedOption, ...subMenuOptions])

--- a/src/Components/Dropdowns/Composed/MenuDropdown.tsx
+++ b/src/Components/Dropdowns/Composed/MenuDropdown.tsx
@@ -38,10 +38,10 @@ export interface SubMenuItem {
 }
 
 export interface MenuDropdownProps extends StandardFunctionProps {
-  /** List of href options to render in the main menu */
-  options: MenuItem[]
   /** A default pre-selected Option */
   selectedOption: SubMenuItem
+  /** List of href options to render in the main menu */
+  options: MenuItem[]
   /** List of options to render in the sub type-ahead menu */
   subMenuOptions: SubMenuItem[]
   /** used for generating custom test ids */
@@ -89,7 +89,7 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
   testIdSuffix = 'menu',
   options,
   subMenuOptions,
-  selectedOption = subMenuOptions[0],
+  selectedOption = null,
   defaultText = 'No Account Selected',
   menuHeaderIcon = IconFont.Switch_New,
   menuHeaderText = 'Switch Account',
@@ -133,10 +133,10 @@ export const MenuDropdown: FC<MenuDropdownProps> = ({
       // so need to reset
 
       // Always show an instance of currently selected option at beginning of list.
-      setQueryResults([selectedOption, ...result])
+      setQueryResults(result)
       setSelectIndex(-1)
     } else {
-      setQueryResults([selectedOption, ...subMenuOptions])
+      setQueryResults(subMenuOptions)
     }
   }, [subMenuOptions, typedValue, selectedOption])
 


### PR DESCRIPTION
Per [UI 4047](https://github.com/influxdata/ui/issues/4047) and [UI 4051](https://github.com/influxdata/ui/issues/4051), the multi-org dropdown:

1. Should not display the 'switch account' or 'switch org' menu if there's only one account or org.
2. Should check for the currently 'selected' account or org's `id` after converting to a string: Org arrays have `string` ids, but account arrays have `number` ids.

*EDIT*: Removed prior change involving sorting selected item to first part of the array. That is easier to handle in a sort in the UI.
 
### Checklist
Check all that apply

- [x] Updated documentation to reflect changes [N/A]
- [X] Added entry to top of Changelog with link to PR (not issue)
- [X] Tests pass
- [x] Peer reviewed and approved
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) [N/A - InfluxData employee)
