### PR TITLE
feat: Enables Loading Spinner for Dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.8.0 (2022-07-14)
+
+- [801](https://github.com/influxdata/clockface/pull/801): Update Dropdown Loading state to have a spinner
+
 ### 4.7.4 (2022-07-01)
 
 - [794](https://github.com/influxdata/clockface/pull/794): Multi-Org dropdown displays selected item first, and will not offer option to change accounts/orgs if no other accounts or orgs exist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -285,6 +285,7 @@
 .cf-button--loading:active:hover,
 .cf-button--loading[disabled],
 .cf-button--loading[disabled]:hover {
+  color: transparent;
   position: relative;
 }
 

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -285,7 +285,6 @@
 .cf-button--loading:active:hover,
 .cf-button--loading[disabled],
 .cf-button--loading[disabled]:hover {
-  color: transparent;
   position: relative;
 }
 

--- a/src/Components/Dropdowns/DropdownButton.scss
+++ b/src/Components/Dropdowns/DropdownButton.scss
@@ -50,6 +50,10 @@
   }
 }
 
+.cf-dropdown__loading {
+  color: #fff !important;
+}
+
 /** small size is the default */
 .header-container--button {
   width: $cf-form-sm-width;

--- a/src/Components/Dropdowns/DropdownButton.tsx
+++ b/src/Components/Dropdowns/DropdownButton.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames'
 // Components
 import {Icon} from '../Icon'
 import {ButtonBase, ButtonBaseRef} from '../Button/Base/ButtonBase'
+import {TechnoSpinner} from '../Spinners/TechnoSpinner'
 
 // Types
 import {
@@ -86,7 +87,11 @@ export const DropdownButton = forwardRef<
       >
         {!!icon && <Icon glyph={icon} className="cf-dropdown--icon" />}
         <span className="cf-dropdown--selected">{children}</span>
-        <Icon glyph={IconFont.CaretDown_New} className="cf-dropdown--caret" />
+        {status === ComponentStatus.Loading ? (
+          <TechnoSpinner diameterPixels={20} />
+        ) : (
+          <Icon glyph={IconFont.CaretDown_New} className="cf-dropdown--caret" />
+        )}
       </ButtonBase>
     )
   }

--- a/src/Components/Dropdowns/DropdownButton.tsx
+++ b/src/Components/Dropdowns/DropdownButton.tsx
@@ -66,6 +66,7 @@ export const DropdownButton = forwardRef<
     const dropdownButtonClass = classnames('cf-dropdown--button', {
       [`${className}`]: className,
       'cf-dropdown__error': status === ComponentStatus.Error,
+      'cf-dropdown__loading': status === ComponentStatus.Loading,
     })
 
     return (


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/800

### Changes

Updated the dropdown component to enable a spinner for the Loading state.

Button loading state has changed to no longer have a transparency.

### Screenshots

<img width="376" alt="Screen Shot 2022-07-14 at 1 46 24 PM" src="https://user-images.githubusercontent.com/15152523/179048891-4d7b01d0-f8c2-4415-8734-6b9f66eb7645.png">


### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
