### PR TITLE
fix(TypeAheadDropdown): input select on focus now works in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 6.1.1 (2022-08-17)
+
+- [823](https://github.com/influxdata/clockface/pull/823): Typeahead Dropdown select text on focus works on all browsers
+
 ### 6.1.0 (2022-08-09)
 
 - [820](https://github.com/influxdata/clockface/pull/820): Typeahead Dropdown scroll to selected item

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Dropdowns/Composed/TypeAheadDropDown.tsx
+++ b/src/Components/Dropdowns/Composed/TypeAheadDropDown.tsx
@@ -242,7 +242,8 @@ export const TypeAheadDropDown: FC<OwnProps> = ({
 
   const selectAllTextInInput = (event?: ChangeEvent<HTMLInputElement>) => {
     if (event) {
-      event.target.select()
+      const target = event.target
+      setTimeout(() => target.select(), 0)
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/824

This is a known issue with Safari. 

https://stackoverflow.com/questions/54229359/why-does-select-not-work-on-safari-with-reactjs


After change: 

https://user-images.githubusercontent.com/18511823/185027574-df232908-4b4c-4466-bdb6-5626249ae3a1.mov


### Changes

// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
