### PR TITLE
fix: Removed CSS Filters from Selectable Cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 6.3.1 (2022-08-24)
+
+- [829](https://github.com/influxdata/clockface/pull/829): Removed CSS filters from Selectable Card
+
 ### 6.3.0 (2022-08-24)
 
 - [828](https://github.com/influxdata/clockface/pull/828): Added a Sync Icon to the Icon set

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/SelectableCard/SelectableCard.scss
+++ b/src/Components/SelectableCard/SelectableCard.scss
@@ -134,8 +134,6 @@ $selectable-card--label: $cf-grey-75;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  filter: grayscale(0) opacity(100%);
-  transition: filter $cf-transition-default;
 }
 
 /*
@@ -149,10 +147,6 @@ $selectable-card--label: $cf-grey-75;
 .cf-selectable-card__disabled.cf-selectable-card__selected {
   cursor: not-allowed;
   opacity: $cf-disabled-opacity;
-
-  .cf-selectable-card--children {
-    filter: grayscale(0.5) opacity(30%);
-  }
 }
 
 /*


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/711

### Changes

The titles explains it mostly. The css filters were causing performance issues on the selectable cards. They have been removed now.

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [x] Updated documentation to reflect changes
- [x] Added entry to top of Changelog with link to PR (not issue)
- [x] Tests pass
- [x] Peer reviewed and approved
