### PR TITLE
fix: Removed Text Color and Opacity from Disabled Input (Accessibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 6.3.2 (2022-08-24)
+
+- [830](https://github.com/influxdata/clockface/pull/830): Removed text color change and opacity when inputs are disabled. Accessbility on text readability change.
+
 ### 6.3.1 (2022-08-24)
 
 - [829](https://github.com/influxdata/clockface/pull/829): Removed CSS filters from Selectable Card

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/clockface",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "license": "MIT",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -330,7 +330,5 @@ alternate css for the other sizes */
 .cf-input-field[disabled]:hover {
   border-color: $cf-input-border--disabled;
   background-color: $cf-input-background--disabled;
-  color: $cf-input-text--disabled;
   cursor: not-allowed;
-  opacity: $cf-disabled-opacity;
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/810

### Changes

Removed the text color and opacity when an input is disabled.
Before this change, the text was hard to read from an accessibility standpoint

### Screenshots
Old:
<img width="277" alt="Screen Shot 2022-08-30 at 12 58 19 PM" src="https://user-images.githubusercontent.com/15152523/187496202-5694a7e5-5241-43a8-8b93-4fc4ad19dd68.png">

New:
<img width="282" alt="Screen Shot 2022-08-30 at 12 58 25 PM" src="https://user-images.githubusercontent.com/15152523/187496205-c1cd7e75-af96-4f16-b4f9-f3e8fae3a7a2.png">



### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
