### PR TITLE
feat(Dropdowns): Clockface 4 dropdown updates

### DIFF
--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -222,7 +222,12 @@
 
 .cf-button-primary,
 .cf-button-success {
-  @include buttonColorModifier($cf-turquoise, $cf-turquoise, $cf-grey-1, $cf-grey-1);
+  @include buttonColorModifier(
+    $cf-turquoise,
+    $cf-turquoise,
+    $cf-grey-1,
+    $cf-grey-1
+  );
 }
 
 .cf-button-tertiary {
@@ -237,10 +242,15 @@
 
 .cf-button-warning,
 .cf-button-danger {
-  @include buttonColorModifier($cf-carnation, $cf-carnation, $cf-grey-1, $cf-grey-1);
+  @include buttonColorModifier(
+    $cf-carnation,
+    $cf-carnation,
+    $cf-grey-1,
+    $cf-grey-1
+  );
 
-  &:focus{
-    @include focus-shadow($cf-carnation)
+  &:focus {
+    @include focus-shadow($cf-carnation);
   }
 }
 

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -43,6 +43,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
   border-radius: $cf-radius;
   box-shadow: 0 2px 5px 0.6px rgba($g0-obsidian, 0.2);
   padding: $cf-space-2xs;
+  border: rgba(255, 255, 255, 0.05) solid $cf-border;
 }
 
 .cf-dropdown-menu--contents {
@@ -52,6 +53,8 @@ $dropdown-item--padding-v: $cf-space-2xs;
   flex-direction: column;
   align-items: stretch;
   cursor: pointer;
+  margin-right: 2px;
+  margin-left: 1px;
 }
 
 /*
@@ -69,10 +72,18 @@ $dropdown-item--padding-v: $cf-space-2xs;
 .cf-dropdown-divider {
   @include dropdownItemStyles();
   font-weight: $cf-font-weight--medium;
+  text-transform: uppercase;
+  color: #88889b;
+  padding-bottom: 4px;
+  border-bottom: $cf-grey-4 1px solid;
+  margin-bottom: 4px;
 
   &.line {
     padding: 0;
     height: $cf-border;
+    background: $cf-grey-4;
+    margin: 8px 0;
+    width: 100%;
   }
 
   &:hover {
@@ -85,6 +96,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
   color: $g20-white;
   position: relative;
   border-radius: $cf-radius;
+  margin-top: $cf-space-3xs;
 
   &.cf-dropdown-link-item {
     padding: 0;
@@ -292,7 +304,9 @@ $dropdown-item--padding-v: $cf-space-2xs;
   }
 
   .cf-dropdown-item.active:not(.cf-dropdown-item__disabled) {
-    background-color: $active;
+    background-color: $cf-martinique;
+    border: 1px $cf-lavender solid;
+    border-radius: $cf-border;
   }
 }
 
@@ -309,7 +323,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 }
 
 .cf-dropdown__onyx {
-  @include dropdownMenuColor($c-pool);
+  @include dropdownMenuColor($cf-lavender);
 }
 
 .cf-dropdown__none {

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -299,7 +299,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
 
   .cf-dropdown-item:not(.cf-dropdown-item__disabled):hover,
   .cf-dropdown-item:not(.cf-dropdown-item__disabled):focus {
-    background-color: rgba($cf-grey-95, 0.1);
+    background-color: rgba($cf-grey-95, 0.09);
     outline: none;
   }
 

--- a/src/Components/Dropdowns/Dropdown.scss
+++ b/src/Components/Dropdowns/Dropdown.scss
@@ -82,7 +82,7 @@ $dropdown-item--padding-v: $cf-space-2xs;
     padding: 0;
     height: $cf-border;
     background: $cf-grey-4;
-    margin: 8px 0;
+    margin: 8px 0 4px;
     width: 100%;
   }
 

--- a/src/Components/Dropdowns/DropdownMenu.tsx
+++ b/src/Components/Dropdowns/DropdownMenu.tsx
@@ -61,8 +61,6 @@ export const DropdownMenu = forwardRef<DropdownMenuRef, DropdownMenuProps>(
       [`cf-dropdown__${theme}`]: theme,
     })
 
-    // const {thumbStartColor, thumbStopColor} = getScrollbarColorsFromTheme(theme)
-
     const scrollTop = calculateSelectedPosition(scrollToSelected, children)
 
     const scrollbarsStyle = {

--- a/src/Components/Inputs/Input.scss
+++ b/src/Components/Inputs/Input.scss
@@ -133,6 +133,7 @@ alternate css for the other sizes */
       &:before,
       &:after {
         width: $cf-form-sm-font;
+        background: $cf-input-text--default;
       }
     }
   }

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -331,7 +331,7 @@ $cf-input-text--hover: $cf-white;
 $cf-input-text--disabled: $cf-empty-state-text;
 
 $cf-input-border--default: $cf-grey-4;
-$cf-input-border--focused: rgba($c-pool, 0.75);
+$cf-input-border--focused: rgba($cf-turquoise, 0.75);
 $cf-input-border--hover: $g5-pepper;
 $cf-input-border--disabled: $g4-onyx;
 

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -330,7 +330,7 @@ $cf-input-text--focused: $cf-white;
 $cf-input-text--hover: $cf-white;
 $cf-input-text--disabled: $cf-empty-state-text;
 
-$cf-input-border--default: $g5-pepper;
+$cf-input-border--default: $cf-grey-4;
 $cf-input-border--focused: rgba($c-pool, 0.75);
 $cf-input-border--hover: $g5-pepper;
 $cf-input-border--disabled: $g4-onyx;


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/838

Couple screenshots:

`SelectDropdown`:

<img width="384" alt="Screen Shot 2022-10-17 at 9 22 16 PM" src="https://user-images.githubusercontent.com/18511823/196334900-b2eab897-269c-4506-a3ab-457a03779caf.png">

`TypeAheadDropdown`:

<img width="191" alt="Screen Shot 2022-10-17 at 9 27 58 PM" src="https://user-images.githubusercontent.com/18511823/196335514-0b7e6f63-4692-408d-bb76-0a75e51495be.png">

`CreateableTypeAheadDropdown`: 

<img width="351" alt="Screen Shot 2022-10-17 at 9 28 43 PM" src="https://user-images.githubusercontent.com/18511823/196335590-9ab87026-1cd8-42c6-84a2-aba84325bf8d.png">

`MultiSelect`:

<img width="357" alt="Screen Shot 2022-10-17 at 9 29 16 PM" src="https://user-images.githubusercontent.com/18511823/196335676-f8436c8a-21a0-4b7e-8079-acbbd8ea77c9.png">

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
