### PR TITLE
chore: remove the sass warning on using division in storybook

### DIFF
--- a/.storybook/Story.scss
+++ b/.storybook/Story.scss
@@ -433,7 +433,7 @@ body.sb-show-main {
   hr {
     margin: $cf-marg-d 0;
     height: $cf-border;
-    border-radius: $cf-border / 2;
+    border-radius: $cf-border * 0.5;
     background-color: $g2-kevlar;
   }
 


### PR DESCRIPTION
Fixes a minor annoyance i noticed when running storybook. There's a warning on using division in sass.

BEFORE:
<img width="1528" alt="Screen Shot 2022-11-04 at 9 59 15 AM" src="https://user-images.githubusercontent.com/10736577/200033521-bb5e243f-da00-4315-b8d2-55f95fcd4da5.png">


AFTER:
<img width="1532" alt="Screen Shot 2022-11-04 at 10 01 02 AM" src="https://user-images.githubusercontent.com/10736577/200033565-cb200631-2e89-4977-9b21-9a24da928a0a.png">
