### PR TITLE
chore: add resolutions for loader-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,9 @@
   "resolutions": {
     "immer": "^9.0.6",
     "minimatch": "^3.0.5",
-    "@wessberg/**/browserslist": "^4.16.5"
+    "@wessberg/**/browserslist": "^4.16.5",
+    "@storybook/**/react-dev-utils/**/loader-utils": "^2.0.3",
+    "@storybook/**/file-loader/**/loader-utils": "^2.0.3"
   },
   "dependencies": {
     "@types/react-window": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,17 @@
     "minimatch": "^3.0.5",
     "@wessberg/**/browserslist": "^4.16.5",
     "@storybook/**/react-dev-utils/**/loader-utils": "^2.0.3",
-    "@storybook/**/file-loader/**/loader-utils": "^2.0.3"
+    "@storybook/**/file-loader/**/loader-utils": "^2.0.3",
+    "@storybook/**/babel-loader/**/loader-utils": "^1.4.1",
+    "@storybook/**/terser-webpack-plugin/**/loader-utils": "^1.4.1",
+    "@storybook/**/webpack/**/loader-utils": "^1.4.1",
+    "file-loader/**/loader-utils": "^1.4.1",
+    "html-loader/**/loader-utils": "^1.4.1",
+    "raw-loader/**/loader-utils": "^1.4.1",
+    "style-loader/**/loader-utils": "^1.4.1",
+    "sass-loader/**/loader-utils": "^1.4.1",
+    "ts-loader/**/loader-utils": "^1.4.1",
+    "webpack-loader/**/loader-utils": "^1.4.1"
   },
   "dependencies": {
     "@types/react-window": "^1.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8769,10 +8769,10 @@ loader-utils@2.0.0, loader-utils@^2.0.0, loader-utils@^2.0.3:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0, loader-utils@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.1.tgz#278ad7006660bccc4d2c0c1578e17c5c78d5c0e0"
+  integrity sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8760,10 +8760,10 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+loader-utils@2.0.0, loader-utils@^2.0.0, loader-utils@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
+  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -8777,15 +8777,6 @@ loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
-
-loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
* chore: use resolution for various @storybook's loader-utils to 2.0.3
* chore: resolve devDeps and remaining @storybook to loader-utils 1.4.1

These resolutions should be able to be removed once `clockface` moves to webpack5, which allows other devDependencies to be upgraded. For now, resolve `loader-utils` to 2.0.3 and 1.4.1 to address dependabot.